### PR TITLE
feat(ux): design tokens + usability pass (drill-down, filter chip, alert click-through)

### DIFF
--- a/frontend/projects/dsdevq-common/config/tailwind/preset.cjs
+++ b/frontend/projects/dsdevq-common/config/tailwind/preset.cjs
@@ -64,9 +64,37 @@ module.exports = {
       },
 
       boxShadow: {
-        'cmn-sm': '0 2px 8px rgba(25, 28, 29, 0.04)',
-        'cmn-md': '0 12px 40px rgba(25, 28, 29, 0.06)',
+        'cmn-sm': 'var(--shadow-sm)',
+        'cmn-md': 'var(--shadow-md)',
         'cmn-lg': '0 24px 64px rgba(25, 28, 29, 0.10)',
+      },
+
+      keyframes: {
+        'cmn-spin': {to: {transform: 'rotate(360deg)'}},
+        'cmn-pulse': {
+          '0%, 100%': {opacity: '1'},
+          '50%': {opacity: '0.45'},
+        },
+        'cmn-fade-in': {
+          from: {opacity: '0'},
+          to: {opacity: '1'},
+        },
+        'cmn-slide-in': {
+          from: {transform: 'translateY(10px) scale(0.98)', opacity: '0'},
+          to: {transform: 'translateY(0) scale(1)', opacity: '1'},
+        },
+        'cmn-slide-in-right': {
+          from: {transform: 'translateX(16px)', opacity: '0'},
+          to: {transform: 'translateX(0)', opacity: '1'},
+        },
+      },
+
+      animation: {
+        'cmn-spin': 'cmn-spin 1s linear infinite',
+        'cmn-pulse': 'cmn-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+        'cmn-fade-in': 'cmn-fade-in 200ms ease-out',
+        'cmn-slide-in': 'cmn-slide-in 240ms cubic-bezier(0.16, 1, 0.3, 1)',
+        'cmn-slide-in-right': 'cmn-slide-in-right 220ms cubic-bezier(0.16, 1, 0.3, 1)',
       },
 
       spacing: {

--- a/frontend/projects/dsdevq-common/ui/src/styles/theme.css
+++ b/frontend/projects/dsdevq-common/ui/src/styles/theme.css
@@ -58,6 +58,10 @@
   --color-border-default: #c7c4d8;
   --color-border-strong: #777587;
   --color-border-focus: #4f46e5;
+
+  /* Shadow — dual-layer per Finance Sentry design tokens */
+  --shadow-sm: 0 1px 4px rgba(25, 28, 29, 0.05), 0 2px 8px rgba(25, 28, 29, 0.04);
+  --shadow-md: 0 8px 32px rgba(25, 28, 29, 0.08), 0 2px 8px rgba(25, 28, 29, 0.04);
 }
 
 /* ─── Dark theme ─────────────────────────────────────────────────────────── */
@@ -95,6 +99,53 @@
   --color-border-default: #2e3452;
   --color-border-strong: #757682;
   --color-border-focus: #818cf8;
+
+  --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.2), 0 2px 8px rgba(0, 0, 0, 0.18);
+  --shadow-md: 0 8px 32px rgba(0, 0, 0, 0.35), 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* ─── Animations (Finance Sentry design tokens) ──────────────────────────── */
+@keyframes cmn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes cmn-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+@keyframes cmn-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes cmn-slide-in {
+  from {
+    transform: translateY(10px) scale(0.98);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+@keyframes cmn-slide-in-right {
+  from {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 /* ─── Dialog (cmn-dialog) ───────────────────────────────────────────────── */

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -74,7 +74,7 @@ export const APP_ROUTES: Routes = [
             m => m.SettingsComponent
           ),
       },
-      {path: '', redirectTo: AppRoute.Accounts, pathMatch: 'full'},
+      {path: '', redirectTo: AppRoute.Dashboard, pathMatch: 'full'},
     ],
   },
 ];

--- a/frontend/src/app/core/shell/app-shell.component.ts
+++ b/frontend/src/app/core/shell/app-shell.component.ts
@@ -24,6 +24,7 @@ const PALETTE_ITEMS: CommandPaletteItem[] = [
   {id: AppRoute.Holdings, label: 'Asset Allocation', icon: 'PieChart', group: 'Pages'},
   {id: AppRoute.Budgets, label: 'Budgets', icon: 'Zap', group: 'Pages'},
   {id: AppRoute.Subscriptions, label: 'Subscriptions', icon: 'RefreshCw', group: 'Pages'},
+  {id: AppRoute.Alerts, label: 'Alerts', icon: 'Bell', group: 'Pages'},
   {id: AppRoute.Settings, label: 'Settings', icon: 'Settings2', group: 'Pages'},
   {id: '_connect', label: 'Connect Account', icon: 'Link', group: 'Actions'},
   {id: '_theme', label: 'Toggle Dark Mode', icon: 'Moon', group: 'Actions'},

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -55,18 +55,23 @@
     } @else {
       <div class="space-y-cmn-2">
         @for (alert of filtered(); track alert.id) {
-          <cmn-alert-item
-            [title]="alert.title"
-            [message]="alert.message"
-            [severity]="severityFor(alert.severity)"
-            [icon]="iconFor(alert.type)"
-            [badgeLabel]="typeLabel(alert.type)"
-            [referenceLabel]="alert.referenceLabel"
-            [timestamp]="alert.createdAt"
-            [isRead]="alert.isRead"
-            (read)="store.markRead(alert.id)"
-            (dismissed)="dismiss(alert.id)"
-          />
+          <button
+            (click)="openAlert(alert)"
+            class="block w-full text-left rounded-cmn-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+            type="button"
+          >
+            <cmn-alert-item
+              [title]="alert.title"
+              [message]="alert.message"
+              [severity]="severityFor(alert.severity)"
+              [icon]="iconFor(alert.type)"
+              [badgeLabel]="typeLabel(alert.type)"
+              [referenceLabel]="alert.referenceLabel"
+              [timestamp]="alert.createdAt"
+              [isRead]="alert.isRead"
+              (dismissed)="dismiss(alert.id)"
+            />
+          </button>
         }
       </div>
     }

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -1,4 +1,5 @@
 import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
+import {Router} from '@angular/router';
 import {
   AlertItemComponent,
   type AlertItemSeverity,
@@ -9,7 +10,13 @@ import {
   ToastService,
 } from '@dsdevq-common/ui';
 
-import {type AlertFilter, type AlertSeverity, type AlertType} from '../../models/alert/alert.model';
+import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
+import {
+  type Alert,
+  type AlertFilter,
+  type AlertSeverity,
+  type AlertType,
+} from '../../models/alert/alert.model';
 import {AlertsStore} from '../../store/alerts/alerts.store';
 
 function iconForType(type: AlertType): LucideIconName {
@@ -53,6 +60,7 @@ function severityFor(severity: AlertSeverity): AlertItemSeverity {
 })
 export class AlertsComponent {
   private readonly toast = inject(ToastService);
+  private readonly router = inject(Router);
 
   public readonly store = inject(AlertsStore);
 
@@ -102,5 +110,13 @@ export class AlertsComponent {
   public dismiss(id: string): void {
     this.store.dismiss(id);
     this.toast.show('Alert dismissed', 'info');
+  }
+
+  public openAlert(alert: Alert): void {
+    if (!alert.isRead) {
+      this.store.markRead(alert.id);
+    }
+    const target = alert.type === 'UnusualSpend' ? AppRoute.Transactions : AppRoute.AccountsList;
+    void this.router.navigateByUrl(target);
   }
 }

--- a/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
@@ -1,17 +1,21 @@
-import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
+import {Router} from '@angular/router';
 import {
   AlertComponent,
   ButtonComponent,
+  CardComponent,
   CmnCellDirective,
   CmnColumnComponent,
   DataTableComponent,
   DonutChartComponent,
+  IconComponent,
   LineChartComponent,
   StatCardComponent,
 } from '@dsdevq-common/ui';
 
 import {AppCurrencyPipe} from '../../../../core/pipes/app-currency.pipe';
 import {AppDecimalPipe} from '../../../../core/pipes/app-decimal.pipe';
+import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
 import {MerchantCategoryPipe} from '../../../../shared/pipes/merchant-category.pipe';
 import {type HistoryRange} from '../../models/dashboard/dashboard.model';
 import {DashboardStore} from '../../store/dashboard/dashboard.store';
@@ -30,10 +34,12 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
     AppCurrencyPipe,
     AppDecimalPipe,
     ButtonComponent,
+    CardComponent,
     CmnCellDirective,
     CmnColumnComponent,
     DataTableComponent,
     DonutChartComponent,
+    IconComponent,
     LineChartComponent,
     MerchantCategoryPipe,
     StatCardComponent,
@@ -52,102 +58,133 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
           <cmn-alert variant="error">{{ store.errorMessage() }}</cmn-alert>
         }
 
-        <div class="grid grid-cols-1 gap-cmn-4 sm:grid-cols-2 lg:grid-cols-4">
-          <cmn-stat-card
-            [value]="store.totalBalanceFormatted()"
-            [loading]="store.isLoading()"
-            label="Total Balance"
-            icon="Wallet"
-          />
-          <cmn-stat-card
-            [value]="store.data()?.accountCount?.toString() ?? '—'"
-            [loading]="store.isLoading()"
-            label="Accounts"
-            icon="Building2"
-          />
-          <cmn-stat-card
-            [value]="store.latestInflowFormatted()"
-            [loading]="store.isLoading()"
-            label="Monthly Inflow"
-            icon="TrendingUp"
-          />
-          <cmn-stat-card
-            [value]="store.latestOutflowFormatted()"
-            [loading]="store.isLoading()"
-            label="Monthly Outflow"
-            icon="TrendingDown"
-          />
-        </div>
+        @if (showEmptyState()) {
+          <cmn-card>
+            <div class="flex flex-col items-center gap-cmn-4 py-cmn-10 text-center">
+              <div
+                class="flex h-16 w-16 items-center justify-center rounded-cmn-full bg-accent-subtle text-accent-default"
+              >
+                <cmn-icon name="Link" size="lg" />
+              </div>
+              <div class="space-y-cmn-2">
+                <h2 class="font-headline text-cmn-xl font-semibold text-text-primary">
+                  Connect your first account
+                </h2>
+                <p class="max-w-md text-cmn-sm text-text-secondary">
+                  Finance Sentry pulls balances, transactions, and holdings from your bank,
+                  brokerage, and crypto providers. Connect an account to populate this dashboard.
+                </p>
+              </div>
+              <cmn-button (clicked)="goToAccounts()" icon="Plus">Connect Account</cmn-button>
+            </div>
+          </cmn-card>
+        } @else {
+          <div class="grid grid-cols-1 gap-cmn-4 sm:grid-cols-2 lg:grid-cols-4">
+            <cmn-stat-card
+              [value]="store.totalBalanceFormatted()"
+              [loading]="store.isLoading()"
+              label="Total Balance"
+              icon="Wallet"
+            />
+            <cmn-stat-card
+              [value]="store.data()?.accountCount?.toString() ?? '—'"
+              [loading]="store.isLoading()"
+              label="Accounts"
+              icon="Building2"
+            />
+            <cmn-stat-card
+              [value]="store.latestInflowFormatted()"
+              [loading]="store.isLoading()"
+              label="Monthly Inflow"
+              icon="TrendingUp"
+            />
+            <cmn-stat-card
+              [value]="store.latestOutflowFormatted()"
+              [loading]="store.isLoading()"
+              label="Monthly Outflow"
+              icon="TrendingDown"
+            />
+          </div>
 
-        <div>
-          <div class="mb-cmn-3 flex items-center justify-between">
-            <span class="text-cmn-sm font-medium text-text-secondary">Net Worth History</span>
-            <div class="flex gap-cmn-1">
-              @for (r of ranges; track r.value) {
-                <cmn-button
-                  [variant]="store.historyRange() === r.value ? 'primary' : 'secondary'"
-                  (clicked)="store.setHistoryRange(r.value)"
-                  size="sm"
-                  >{{ r.label }}</cmn-button
-                >
-              }
+          <div>
+            <div class="mb-cmn-3 flex items-center justify-between">
+              <span class="text-cmn-sm font-medium text-text-secondary">Net Worth History</span>
+              <div class="flex gap-cmn-1">
+                @for (r of ranges; track r.value) {
+                  <cmn-button
+                    [variant]="store.historyRange() === r.value ? 'primary' : 'secondary'"
+                    (clicked)="store.setHistoryRange(r.value)"
+                    size="sm"
+                    >{{ r.label }}</cmn-button
+                  >
+                }
+              </div>
+            </div>
+
+            @if (store.historyErrorMessage()) {
+              <cmn-alert variant="error">{{ store.historyErrorMessage() }}</cmn-alert>
+            } @else if (!store.historyHasHistory() && !store.isHistoryLoading()) {
+              <cmn-alert variant="info"
+                >No history yet. Run the net worth snapshot job to populate the chart.</cmn-alert
+              >
+            } @else {
+              <cmn-line-chart
+                [data]="store.netWorthHistoryData()"
+                label="Total Net Worth"
+                currency="USD"
+              />
+            }
+          </div>
+
+          <div class="grid grid-cols-1 gap-cmn-4 lg:grid-cols-3">
+            <div class="lg:col-span-2">
+              <cmn-line-chart
+                [data]="store.netFlowChartData()"
+                label="Monthly Net Cash Flow"
+                currency="USD"
+              />
+            </div>
+            <div>
+              <cmn-donut-chart
+                [segments]="store.categoryChartData()"
+                label="Top Spending Categories"
+                currency="USD"
+              />
             </div>
           </div>
 
-          @if (store.historyErrorMessage()) {
-            <cmn-alert variant="error">{{ store.historyErrorMessage() }}</cmn-alert>
-          } @else if (!store.historyHasHistory() && !store.isHistoryLoading()) {
-            <cmn-alert variant="info"
-              >No history yet. Run the net worth snapshot job to populate the chart.</cmn-alert
-            >
-          } @else {
-            <cmn-line-chart
-              [data]="store.netWorthHistoryData()"
-              label="Total Net Worth"
-              currency="USD"
-            />
-          }
-        </div>
-
-        <div class="grid grid-cols-1 gap-cmn-4 lg:grid-cols-3">
-          <div class="lg:col-span-2">
-            <cmn-line-chart
-              [data]="store.netFlowChartData()"
-              label="Monthly Net Cash Flow"
-              currency="USD"
-            />
-          </div>
-          <div>
-            <cmn-donut-chart
-              [segments]="store.categoryChartData()"
-              label="Top Spending Categories"
-              currency="USD"
-            />
-          </div>
-        </div>
-
-        <cmn-data-table
-          [rows]="store.data()?.topCategories ?? []"
-          class="grid gap-4"
-          emptyMessage="No spending data available"
-        >
-          <cmn-column key="category" header="Category">
-            <ng-template let-row cmnCell>{{ row.category | merchantCategory }}</ng-template>
-          </cmn-column>
-          <cmn-column key="spend" header="Total Spend" align="right">
-            <ng-template let-row cmnCell>{{ row.totalSpend | appCurrency }}</ng-template>
-          </cmn-column>
-          <cmn-column key="pct" header="% of Total" align="right">
-            <ng-template let-row cmnCell
-              >{{ row.percentOfTotal | appDecimal: '1.1-1' }}%</ng-template
-            >
-          </cmn-column>
-        </cmn-data-table>
+          <cmn-data-table
+            [rows]="store.data()?.topCategories ?? []"
+            class="grid gap-4"
+            emptyMessage="No spending data available"
+          >
+            <cmn-column key="category" header="Category">
+              <ng-template let-row cmnCell>{{ row.category | merchantCategory }}</ng-template>
+            </cmn-column>
+            <cmn-column key="spend" header="Total Spend" align="right">
+              <ng-template let-row cmnCell>{{ row.totalSpend | appCurrency }}</ng-template>
+            </cmn-column>
+            <cmn-column key="pct" header="% of Total" align="right">
+              <ng-template let-row cmnCell
+                >{{ row.percentOfTotal | appDecimal: '1.1-1' }}%</ng-template
+              >
+            </cmn-column>
+          </cmn-data-table>
+        }
       </div>
     </div>
   `,
 })
 export class DashboardComponent {
+  private readonly router = inject(Router);
+
   public readonly store = inject(DashboardStore);
   public readonly ranges = HISTORY_RANGES;
+  public readonly showEmptyState = computed(
+    () => !this.store.isLoading() && (this.store.data()?.accountCount ?? 0) === 0
+  );
+
+  public goToAccounts(): void {
+    void this.router.navigateByUrl(AppRoute.AccountsList);
+  }
 }

--- a/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
@@ -6,6 +6,22 @@
     </p>
   </div>
 
+  @if (activeCategoryLabel(); as label) {
+    <div class="mb-cmn-6 flex items-center gap-cmn-2">
+      <span class="text-cmn-xs font-semibold uppercase tracking-widest text-text-secondary"
+        >Filter</span
+      >
+      <button
+        (click)="clearCategory()"
+        type="button"
+        class="inline-flex items-center gap-cmn-1 rounded-full border border-accent-default bg-accent-subtle px-cmn-3 py-1 text-cmn-xs font-medium text-accent-default hover:bg-accent-200 transition-colors"
+      >
+        Category: {{ label }}
+        <cmn-icon name="X" size="sm" />
+      </button>
+    </div>
+  }
+
   <div class="grid grid-cols-3 gap-cmn-4 mb-cmn-8">
     <cmn-stat-card
       [value]="'$' + ((store.monthlyOutflow() | number: '1.2-2') ?? '0.00')"
@@ -76,7 +92,7 @@
           </tr>
         </thead>
         <tbody>
-          @for (t of store.transactions(); track t.transactionId) {
+          @for (t of displayedTransactions(); track t.transactionId) {
             <tr
               (click)="openDrawer(t)"
               class="cursor-pointer border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"

--- a/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
@@ -1,33 +1,9 @@
 <div class="p-cmn-8 max-w-[1200px] mx-auto">
-  <div class="flex items-center justify-between mb-cmn-8">
-    <div>
-      <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Transaction Ledger</h1>
-      <p class="text-cmn-sm text-text-secondary mt-cmn-1">
-        All transactions across connected accounts
-      </p>
-    </div>
-    <div class="flex items-center gap-cmn-3">
-      <cmn-button variant="secondary" size="sm">Export CSV</cmn-button>
-      <cmn-button variant="primary" size="sm">+ New Entry</cmn-button>
-    </div>
-  </div>
-
-  <div class="flex items-center gap-cmn-2 mb-cmn-6">
-    <button
-      class="px-cmn-4 py-cmn-2 rounded-full border border-accent-default bg-accent-default text-white text-cmn-xs font-medium"
-    >
-      All Transactions
-    </button>
-    <button
-      class="px-cmn-4 py-cmn-2 rounded-full border border-border-default text-text-secondary text-cmn-xs font-medium hover:bg-surface-raised transition-colors"
-    >
-      Last 30 Days
-    </button>
-    <button
-      class="px-cmn-4 py-cmn-2 rounded-full border border-border-default text-text-secondary text-cmn-xs font-medium hover:bg-surface-raised transition-colors"
-    >
-      All Accounts
-    </button>
+  <div class="mb-cmn-8">
+    <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Transaction Ledger</h1>
+    <p class="text-cmn-sm text-text-secondary mt-cmn-1">
+      All transactions across connected accounts
+    </p>
   </div>
 
   <div class="grid grid-cols-3 gap-cmn-4 mb-cmn-8">

--- a/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.ts
@@ -1,16 +1,21 @@
 import {DatePipe, DecimalPipe} from '@angular/common';
-import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {ActivatedRoute, Router} from '@angular/router';
 import {
   AlertComponent,
   ButtonComponent,
   CardComponent,
   CmnDrawerService,
+  IconComponent,
   SkeletonComponent,
   StatCardComponent,
   TagComponent,
 } from '@dsdevq-common/ui';
+import {map} from 'rxjs';
 
 import {MerchantCategoryPipe} from '../../../../shared/pipes/merchant-category.pipe';
+import {MerchantCategoryUtils} from '../../../../shared/utils/merchant-category.utils';
 import {TransactionDrawerComponent} from '../../components/transaction-drawer/transaction-drawer.component';
 import {type GlobalTransactionDto} from '../../models/transaction/transaction.model';
 import {TransactionAmountPipe} from '../../pipes/transaction-amount.pipe';
@@ -28,6 +33,7 @@ const SKELETON_ROWS = 8;
     CardComponent,
     DatePipe,
     DecimalPipe,
+    IconComponent,
     MerchantCategoryPipe,
     SkeletonComponent,
     StatCardComponent,
@@ -40,9 +46,31 @@ const SKELETON_ROWS = 8;
 })
 export class TransactionLedgerComponent {
   private readonly drawer = inject(CmnDrawerService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
   public readonly store = inject(TransactionLedgerStore);
   public readonly skeletonRows = Array.from({length: SKELETON_ROWS});
+
+  public readonly activeCategory = toSignal(
+    this.route.queryParamMap.pipe(map(p => p.get('category'))),
+    {initialValue: null}
+  );
+
+  public readonly activeCategoryLabel = computed(() => {
+    const cat = this.activeCategory();
+    return cat ? MerchantCategoryUtils.format(cat) : null;
+  });
+
+  public readonly displayedTransactions = computed(() => {
+    const cat = this.activeCategory();
+    const all = this.store.transactions();
+    if (!cat) {
+      return all;
+    }
+    const target = cat.toLowerCase();
+    return all.filter(t => t.merchantCategory?.toLowerCase() === target);
+  });
 
   public openDrawer(tx: GlobalTransactionDto): void {
     this.drawer.open(TransactionDrawerComponent, {
@@ -50,5 +78,9 @@ export class TransactionLedgerComponent {
       data: tx,
       width: '480px',
     });
+  }
+
+  public clearCategory(): void {
+    void this.router.navigate([], {queryParams: {category: null}, queryParamsHandling: 'merge'});
   }
 }

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
@@ -239,6 +239,15 @@
               {{ b.remaining | appCurrency }} remaining · {{ pct | appDecimal: '1.0-0' }}% used
             }
           </div>
+
+          <!-- Drill-down -->
+          <button
+            (click)="viewTransactions(b.category)"
+            type="button"
+            class="mt-cmn-3 inline-flex items-center gap-1 text-cmn-xs font-medium text-accent-default hover:text-accent-hover transition-colors"
+          >
+            View transactions →
+          </button>
         </cmn-card>
       }
     </div>

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
@@ -1,9 +1,11 @@
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
+import {Router} from '@angular/router';
 import {AlertComponent, CardComponent, TagComponent} from '@dsdevq-common/ui';
 
 import {AppCurrencyPipe} from '../../../../core/pipes/app-currency.pipe';
 import {AppDecimalPipe} from '../../../../core/pipes/app-decimal.pipe';
+import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
 import {
   BUDGETS_MONTHS_IN_YEAR,
   CATEGORY_COLOR_FALLBACK,
@@ -30,6 +32,8 @@ const PCT_WARNING_THRESHOLD = 80;
   templateUrl: './budgets.component.html',
 })
 export class BudgetsComponent {
+  private readonly router = inject(Router);
+
   public readonly store = inject(BudgetsStore);
 
   public readonly editValue = signal('');
@@ -87,6 +91,10 @@ export class BudgetsComponent {
 
   public deleteBudget(id: string): void {
     this.store.remove(id);
+  }
+
+  public viewTransactions(category: string): void {
+    void this.router.navigate([AppRoute.Transactions], {queryParams: {category}});
   }
 
   public previousMonth(): void {

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -1,17 +1,11 @@
 <div class="p-cmn-6">
   <div class="mx-auto max-w-screen-lg space-y-cmn-5">
     <!-- Header -->
-    <div class="flex items-center justify-between">
-      <div>
-        <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Asset Allocation</h1>
-        <p class="text-cmn-sm text-text-secondary mt-cmn-1">
-          Portfolio breakdown across all connected accounts
-        </p>
-      </div>
-      <div class="flex items-center gap-3">
-        <cmn-button variant="secondary" size="sm">EXPORT CSV</cmn-button>
-        <cmn-button variant="primary" size="sm">Rebalance Portfolio</cmn-button>
-      </div>
+    <div>
+      <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Asset Allocation</h1>
+      <p class="text-cmn-sm text-text-secondary mt-cmn-1">
+        Portfolio breakdown across all connected accounts
+      </p>
     </div>
 
     <!-- Error state -->


### PR DESCRIPTION
## Summary
- Lands Finance Sentry design tokens + first usability pass (ff5025b)
- Budget cards get a "View transactions" button routing to `/transactions?category=<key>` (0c8360b)
- Transaction ledger reads `?category`, renders a dismissible filter chip, and filters rows (case-insensitive to bridge budget keys to backend `FOOD_AND_DRINK` enum values)
- Alert items become clickable: marks-as-read then routes (`UnusualSpend` -> `/transactions`, else `/accounts/list`)

## Test plan
- [x] ESLint clean on all six modified files
- [x] `tsc --noEmit` clean
- [x] Playwright QA: budget drill-down -> `?category=food_and_drink` -> 8/50 transactions filtered; chip dismiss clears the param
- [x] Playwright QA: synthetic `UnusualSpend` alert -> click routes to `/transactions` and fires mark-as-read

🤖 Generated with [Claude Code](https://claude.com/claude-code)