### PR TITLE
feat(mcp): wire all module IModuleRegistrar registrars into MCP DI

### DIFF
--- a/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
+++ b/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinanceSentry.Core\FinanceSentry.Core.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Infrastructure\FinanceSentry.Infrastructure.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Alerts\FinanceSentry.Modules.Alerts.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Auth\FinanceSentry.Modules.Auth.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.BankSync\FinanceSentry.Modules.BankSync.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.BrokerageSync\FinanceSentry.Modules.BrokerageSync.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Budgets\FinanceSentry.Modules.Budgets.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.CryptoSync\FinanceSentry.Modules.CryptoSync.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Subscriptions\FinanceSentry.Modules.Subscriptions.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Wealth\FinanceSentry.Modules.Wealth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/FinanceSentry.Mcp/Program.cs
+++ b/backend/src/FinanceSentry.Mcp/Program.cs
@@ -1,0 +1,48 @@
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Alerts;
+using FinanceSentry.Modules.Auth;
+using FinanceSentry.Modules.BankSync;
+using FinanceSentry.Modules.BrokerageSync;
+using FinanceSentry.Modules.Budgets;
+using FinanceSentry.Modules.CryptoSync;
+using FinanceSentry.Modules.Subscriptions;
+using FinanceSentry.Modules.Wealth;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Map POSTGRES_CONNECTION_STRING → ConnectionStrings:Default consumed by all module DbContexts.
+var pgConnStr = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
+if (pgConnStr is not null)
+    builder.Configuration["ConnectionStrings:Default"] = pgConnStr;
+
+// Pin one exported type per module so the runtime loads each assembly before the scan.
+// The internal ModuleRegistrar classes are not directly reachable; reflection finds them.
+Type[] moduleAnchors =
+[
+    typeof(AlertsModule),
+    typeof(AuthModule),
+    typeof(BankSyncModule),
+    typeof(BrokerageSyncModule),
+    typeof(BudgetsModule),
+    typeof(CryptoSyncModule),
+    typeof(SubscriptionsModule),
+    typeof(WealthModule),
+];
+
+var moduleAssemblies = moduleAnchors.Select(t => t.Assembly).Distinct().ToArray();
+
+var registrars = moduleAssemblies
+    .SelectMany(a => a.GetTypes())
+    .Where(t => typeof(IModuleRegistrar).IsAssignableFrom(t) && t is { IsInterface: false, IsAbstract: false })
+    .Select(t => (IModuleRegistrar)Activator.CreateInstance(t)!)
+    .ToList();
+
+builder.Services.AddCqrs(moduleAssemblies);
+
+foreach (var registrar in registrars)
+    registrar.Register(builder.Services, builder.Configuration);
+
+var app = builder.Build();
+
+app.Run();


### PR DESCRIPTION
## Changes
Creates the FinanceSentry.Mcp project (Microsoft.NET.Sdk.Web) and wires
its DI container using the same reflection-based IModuleRegistrar loop as
the API.  POSTGRES_CONNECTION_STRING env var is mapped to
ConnectionStrings:Default so every module's EF Core DbContext resolves
the same way it does in the API host.  All eight module assemblies are
pinned via typeof() anchors before the scan, ensuring they are loaded
into AppDomain before reflection runs.

Verified: dotnet build backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
→ 0 warnings, 0 errors.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<details><summary>📋 Ticket (what was asked + why)</summary>

Wire FinanceSentry.Mcp DI container to call each backend module's IModuleRegistrar so IMediator and all query handlers are resolvable, including EF Core DbContext pointing at the connection string from environment.

Concrete steps:
1. Read backend/src/FinanceSentry.API/Program.cs to understand the exact IModuleRegistrar loop pattern already in use.
2. Discover all IModuleRegistrar implementations under backend/src/FinanceSentry.Modules.*/ — do NOT copy-paste service registrations; delegate to each registrar.
3. In backend/src/FinanceSentry.Mcp/Program.cs, add a call to each IModuleRegistrar (loop or explicit calls mirroring the API pattern), wire MediatR, and add the EF Core DbContext pointing at POSTGRES_CONNECTION_STRING environment variable.
4. The project must build cleanly: dotnet build backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj.

Constraints:
- Touch ONLY backend/src/FinanceSentry.Mcp/Program.cs for the DI wiring (plus any new extension file under FinanceSentry.Mcp if you introduce a helper).
- Do NOT modify any module's own .csproj, IModuleRegistrar, or infrastructure outside FinanceSentry.Mcp.
- Do NOT modify Directory.Build.props or any .sln file.

Evidence: backend/src/FinanceSentry.Mcp/Program.cs must contain an IModuleRegistrar loop or equivalent multi-registrar call and appear in the git diff.

</details>

## Verification
Gate `dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj` passed (exit 0).

## Files changed
```
.../src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj | 16 ++++++++
 backend/src/FinanceSentry.Mcp/Program.cs           | 48 ++++++++++++++++++++++
 2 files changed, 64 insertions(+)
```

---
🤖 Delivered by devclaw (task `cd2c7a03-e612-4849-a49d-1b5dca4dced8`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.