### PR TITLE
feat(mcp): add FinanceSentry.Mcp project with list_transactions tool

### DIFF
--- a/backend/FinanceSentry.sln
+++ b/backend/FinanceSentry.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Modules.Subsc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Modules.Wealth", "src\FinanceSentry.Modules.Wealth\FinanceSentry.Modules.Wealth.csproj", "{C371F09B-C555-488A-9CE3-32B57C398337}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Mcp", "src\FinanceSentry.Mcp\FinanceSentry.Mcp.csproj", "{EC090CC0-54A4-485B-A71C-71242DDA5CD4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -199,6 +201,18 @@ Global
 		{C371F09B-C555-488A-9CE3-32B57C398337}.Release|x64.Build.0 = Release|Any CPU
 		{C371F09B-C555-488A-9CE3-32B57C398337}.Release|x86.ActiveCfg = Release|Any CPU
 		{C371F09B-C555-488A-9CE3-32B57C398337}.Release|x86.Build.0 = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|x64.Build.0 = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -217,5 +231,6 @@ Global
 		{42F2E89C-DF10-409A-AB24-B427738189C1} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
 		{B682FF21-1F52-4F7B-A2D5-38BC4393FB92} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
 		{C371F09B-C555-488A-9CE3-32B57C398337} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
+		{EC090CC0-54A4-485B-A71C-71242DDA5CD4} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/FinanceSentry.Mcp/Abstractions/IMcpTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Abstractions/IMcpTool.cs
@@ -1,0 +1,15 @@
+namespace FinanceSentry.Mcp.Abstractions;
+
+public interface IMcpTool
+{
+    string Name { get; }
+    string Description { get; }
+    bool IsReadOnly { get; }
+    bool IsStub { get; }
+    string? StubReason { get; }
+
+    Task<McpToolResult> InvokeAsync(
+        Guid userId,
+        IReadOnlyDictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/FinanceSentry.Mcp/Abstractions/McpToolResult.cs
+++ b/backend/src/FinanceSentry.Mcp/Abstractions/McpToolResult.cs
@@ -1,0 +1,17 @@
+namespace FinanceSentry.Mcp.Abstractions;
+
+public sealed class McpToolResult
+{
+    public bool IsSuccess { get; private init; }
+    public object? Payload { get; private init; }
+    public string? ErrorMessage { get; private init; }
+
+    public static McpToolResult Success(object payload) =>
+        new() { IsSuccess = true, Payload = payload };
+
+    public static McpToolResult Error(string message) =>
+        new() { IsSuccess = false, ErrorMessage = message };
+
+    public static McpToolResult NotYetAvailable(string reason) =>
+        new() { IsSuccess = false, ErrorMessage = $"not_yet_available: {reason}" };
+}

--- a/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
+++ b/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinanceSentry.Core\FinanceSentry.Core.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.BankSync\FinanceSentry.Modules.BankSync.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/FinanceSentry.Mcp/Program.cs
+++ b/backend/src/FinanceSentry.Mcp/Program.cs
@@ -1,0 +1,27 @@
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Mcp.Abstractions;
+using FinanceSentry.Mcp.Tools.BankCash;
+using FinanceSentry.Mcp.Tools.Transactions;
+using FinanceSentry.Modules.BankSync.Application.Queries;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
+using FinanceSentry.Modules.BankSync.Infrastructure.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddDbContext<BankSyncDbContext>(o =>
+    o.UseNpgsql(builder.Configuration.GetConnectionString("Default")!));
+
+builder.Services.AddScoped<IBankAccountRepository, BankAccountRepository>();
+builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
+
+builder.Services.AddCqrs(typeof(GetAccountsQueryHandler).Assembly);
+
+builder.Services.AddScoped<IMcpTool, ListBankAccountsTool>();
+builder.Services.AddScoped<IMcpTool, GetAccountBalancesTool>();
+builder.Services.AddScoped<IMcpTool, ListTransactionsTool>();
+
+var app = builder.Build();
+
+app.Run();

--- a/backend/src/FinanceSentry.Mcp/Tools/BankCash/GetAccountBalancesTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/BankCash/GetAccountBalancesTool.cs
@@ -1,0 +1,38 @@
+namespace FinanceSentry.Mcp.Tools.BankCash;
+
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Mcp.Abstractions;
+using FinanceSentry.Modules.BankSync.Application.Queries;
+
+public sealed class GetAccountBalancesTool(IQueryHandler<GetAccountsQuery, GetAccountsResult> accounts) : IMcpTool
+{
+    private readonly IQueryHandler<GetAccountsQuery, GetAccountsResult> _accounts = accounts;
+
+    public string Name => "get_account_balances";
+    public string Description => "Returns current balance and currency for each bank account for the authenticated user.";
+    public bool IsReadOnly => true;
+    public bool IsStub => false;
+    public string? StubReason => null;
+
+    public async Task<McpToolResult> InvokeAsync(
+        Guid userId,
+        IReadOnlyDictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _accounts.Handle(new GetAccountsQuery(userId), cancellationToken);
+            var payload = result.Accounts.Select(a => new
+            {
+                accountId = a.AccountId,
+                balance = a.CurrentBalance,
+                currency = a.Currency,
+            });
+            return McpToolResult.Success(payload);
+        }
+        catch (Exception ex)
+        {
+            return McpToolResult.Error(ex.Message);
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Mcp/Tools/BankCash/ListBankAccountsTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/BankCash/ListBankAccountsTool.cs
@@ -1,0 +1,41 @@
+namespace FinanceSentry.Mcp.Tools.BankCash;
+
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Mcp.Abstractions;
+using FinanceSentry.Modules.BankSync.Application.Queries;
+
+public sealed class ListBankAccountsTool(IQueryHandler<GetAccountsQuery, GetAccountsResult> accounts) : IMcpTool
+{
+    private readonly IQueryHandler<GetAccountsQuery, GetAccountsResult> _accounts = accounts;
+
+    public string Name => "list_bank_accounts";
+    public string Description => "Lists all bank accounts for the authenticated user, including name, type, currency, and sync status.";
+    public bool IsReadOnly => true;
+    public bool IsStub => false;
+    public string? StubReason => null;
+
+    public async Task<McpToolResult> InvokeAsync(
+        Guid userId,
+        IReadOnlyDictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var result = await _accounts.Handle(new GetAccountsQuery(userId), cancellationToken);
+            var payload = result.Accounts.Select(a => new
+            {
+                accountId = a.AccountId,
+                bankName = a.BankName,
+                accountType = a.AccountType,
+                currency = a.Currency,
+                syncStatus = a.SyncStatus,
+                provider = a.Provider,
+            });
+            return McpToolResult.Success(payload);
+        }
+        catch (Exception ex)
+        {
+            return McpToolResult.Error(ex.Message);
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Mcp/Tools/Transactions/ListTransactionsTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/Transactions/ListTransactionsTool.cs
@@ -1,0 +1,80 @@
+namespace FinanceSentry.Mcp.Tools.Transactions;
+
+using FinanceSentry.Core.Api;
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Mcp.Abstractions;
+using FinanceSentry.Modules.BankSync.Application.Queries;
+
+public sealed class ListTransactionsTool(IQueryHandler<GetAllTransactionsQuery, AllTransactionsResult> transactions) : IMcpTool
+{
+    private readonly IQueryHandler<GetAllTransactionsQuery, AllTransactionsResult> _transactions = transactions;
+
+    public string Name => "list_transactions";
+    public string Description => "Returns paginated bank transactions for the authenticated user with optional date range, account, and page size filters.";
+    public bool IsReadOnly => true;
+    public bool IsStub => false;
+    public string? StubReason => null;
+
+    public async Task<McpToolResult> InvokeAsync(
+        Guid userId,
+        IReadOnlyDictionary<string, string>? parameters = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            DateTime? dateFrom = null;
+            DateTime? dateTo = null;
+            Guid? accountId = null;
+            int pageSize = 50;
+
+            if (parameters is not null)
+            {
+                if (parameters.TryGetValue("dateFrom", out var dateFromStr) &&
+                    DateTime.TryParse(dateFromStr, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsedFrom))
+                    dateFrom = parsedFrom;
+
+                if (parameters.TryGetValue("dateTo", out var dateToStr) &&
+                    DateTime.TryParse(dateToStr, null, System.Globalization.DateTimeStyles.RoundtripKind, out var parsedTo))
+                    dateTo = parsedTo;
+
+                if (parameters.TryGetValue("accountId", out var accountIdStr) &&
+                    Guid.TryParse(accountIdStr, out var parsedAccountId))
+                    accountId = parsedAccountId;
+
+                if (parameters.TryGetValue("pageSize", out var pageSizeStr) &&
+                    int.TryParse(pageSizeStr, out var parsedPageSize) &&
+                    parsedPageSize > 0)
+                    pageSize = parsedPageSize;
+            }
+
+            var query = new GetAllTransactionsQuery(
+                userId,
+                new PagedRequest(0, pageSize),
+                dateFrom,
+                dateTo);
+
+            var result = await _transactions.Handle(query, cancellationToken);
+
+            var rows = result.Transactions.AsEnumerable();
+            if (accountId.HasValue)
+                rows = rows.Where(t => t.AccountId == accountId.Value);
+
+            // currency is not present in GlobalTransactionDto — omitted per spec
+            var payload = rows.Select(t => new
+            {
+                transactionId = t.TransactionId,
+                accountId = t.AccountId,
+                date = t.Date,
+                description = t.Description,
+                amount = t.Amount,
+                category = t.MerchantCategory,
+            });
+
+            return McpToolResult.Success(payload);
+        }
+        catch (Exception ex)
+        {
+            return McpToolResult.Error(ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Changes
Introduces FinanceSentry.Mcp as a standalone ASP.NET Core 9 project with:

- IMcpTool / McpToolResult: minimal abstraction layer supporting optional
  per-call parameter dictionaries (dateFrom, dateTo, accountId, pageSize)
- ListBankAccountsTool: projects accountId/bankName/accountType/currency/
  syncStatus/provider from GetAccountsQuery
- GetAccountBalancesTool: projects accountId/balance/currency from the
  same query
- ListTransactionsTool: dispatches GetAllTransactionsQuery with dateFrom,
  dateTo, and pageSize parsed from the parameters map; filters by accountId
  client-side (query has no accountId predicate); projects transactionId/
  accountId/date/description/amount/category — currency omitted because
  GlobalTransactionDto has no currency field (spec: omit missing fields)
- Program.cs: registers BankSyncDbContext, both repositories, AddCqrs on
  the BankSync assembly, and all three tools as IMcpTool

Verified: dotnet build → 0 warnings 0 errors; dotnet test → 223/223 passed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<details><summary>📋 Ticket (what was asked + why)</summary>

Implement list_transactions MCP tool in FinanceSentry.Mcp.

Create backend/src/FinanceSentry.Mcp/Tools/Transactions/ListTransactionsTool.cs.

Steps:
1. Check backend/src/FinanceSentry.Modules.BankSync/Application/Queries/ for a transaction list query handler (look for GetTransactions, ListTransactions, or similar). Note the query class name, parameters, and result DTO fields.
2. If a transaction list query handler exists:
   - Implement ListTransactionsTool : IMcpTool
   - Name = "list_transactions"
   - Description = "Returns paginated bank transactions for the authenticated user with optional date range, account, and page size filters."
   - IsReadOnly = true
   - IsStub = false
   - Accept optional parameters: dateFrom (string ISO8601), dateTo (string ISO8601), accountId (string), pageSize (int, default 50)
   - InvokeAsync dispatches the query via IMediator, maps results to objects with fields: transactionId, accountId, date, description, amount, currency, category.
   - Return McpToolResult.Success(payload) on success; McpToolResult.Error on failure.
3. If NO transaction list query handler exists:
   - Implement as a legit stub: IsStub = true, IsReadOnly = true
   - InvokeAsync returns McpToolResult.NotYetAvailable(reason: "no transaction list query handler in BankSync module")
4. Register ListTransactionsTool as IMcpTool in DI — follow the exact same pattern used by ListBankAccountsTool and GetAccountBalancesTool in Program.cs.
5. Verify: dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj (must pass, gate count must not decrease).

Constraints:
- Do NOT add new query handlers to any module.
- Do NOT modify any existing source files outside of FinanceSentry.Mcp.
- Only project the fields listed above — do not leak internal EF entities.
- If the DTO lacks any of the listed fields, omit the missing ones rather than projecting null/0.

</details>

## Verification
Gate `dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj` passed (exit 0).

## Files changed
```
backend/FinanceSentry.sln                          | 15 ++++
 .../src/FinanceSentry.Mcp/Abstractions/IMcpTool.cs | 15 ++++
 .../Abstractions/McpToolResult.cs                  | 17 +++++
 .../src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj | 13 ++++
 backend/src/FinanceSentry.Mcp/Program.cs           | 27 ++++++++
 .../Tools/BankCash/GetAccountBalancesTool.cs       | 38 ++++++++++
 .../Tools/BankCash/ListBankAccountsTool.cs         | 41 +++++++++++
 .../Tools/Transactions/ListTransactionsTool.cs     | 80 ++++++++++++++++++++++
 8 files changed, 246 insertions(+)
```

---
🤖 Delivered by devclaw (task `598a3644-0752-4a9c-be2d-19e488b064be`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.