### PR TITLE
feat(wealth): count institutions instead of card/holding rows

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/IBankingAccountsReader.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IBankingAccountsReader.cs
@@ -15,4 +15,6 @@ public record BankingAccountSummary(
     decimal? CurrentBalance,
     decimal? BalanceUsd,
     string SyncStatus,
-    DateTime? LastSyncTimestamp);
+    DateTime? LastSyncTimestamp,
+    Guid? MonobankCredentialId = null,
+    Guid? TrueLayerConnectionId = null);

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingAccountsReader.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingAccountsReader.cs
@@ -23,7 +23,9 @@ public class BankingAccountsReader(IBankAccountRepository accounts) : IBankingAc
             a.CurrentBalance,
             a.CurrentBalance.HasValue ? CurrencyConverter.ToUsd(a.CurrentBalance.Value, a.Currency) : null,
             a.SyncStatus == "active" ? "synced" : a.SyncStatus,
-            a.UpdatedAt))
+            a.UpdatedAt,
+            a.MonobankCredentialId,
+            a.TrueLayerConnectionId))
         .ToList();
     }
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetWealthSummaryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetWealthSummaryQuery.cs
@@ -21,6 +21,7 @@ public record AccountBalanceDto(
 public record CategorySummaryDto(
     string Category,
     decimal TotalInBaseCurrency,
+    int InstitutionCount,
     IReadOnlyList<AccountBalanceDto> Accounts);
 
 public record WealthSummaryResponse(

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
@@ -40,13 +40,16 @@ public class WealthAggregationService(
             .GroupBy(a => ProviderCategoryMapper.GetCategory(a.Provider))
             .Select(g =>
             {
-                var accountDtos = g.Select(a => new AccountBalanceDto(
+                var summaries = g.ToList();
+                var accountDtos = summaries.Select(a => new AccountBalanceDto(
                     a.AccountId, a.BankName, a.AccountType, a.AccountNumberLast4,
                     a.Provider, ProviderCategoryMapper.GetCategory(a.Provider),
                     a.Currency, a.CurrentBalance, a.BalanceUsd,
                     a.SyncStatus, a.LastSyncTimestamp)).ToList();
 
-                return new CategorySummaryDto(g.Key, accountDtos.Sum(d => d.BalanceInBaseCurrency ?? 0m), accountDtos);
+                var institutionCount = CountBankingInstitutions(summaries);
+
+                return new CategorySummaryDto(g.Key, accountDtos.Sum(d => d.BalanceInBaseCurrency ?? 0m), institutionCount, accountDtos);
             })
             .ToList();
 
@@ -60,7 +63,8 @@ public class WealthAggregationService(
                     "USD", h.FreeQuantity + h.LockedQuantity, h.UsdValue, "synced", h.SyncedAt))
                     .ToList<AccountBalanceDto>();
 
-                grouped.Add(new CategorySummaryDto("crypto", holdings.Sum(h => h.UsdValue), dtos));
+                var institutionCount = holdings.Select(h => h.Provider).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+                grouped.Add(new CategorySummaryDto("crypto", holdings.Sum(h => h.UsdValue), institutionCount, dtos));
             }
         }
 
@@ -76,13 +80,24 @@ public class WealthAggregationService(
                     DateTime.UtcNow - h.SyncedAt > StaleThreshold ? "stale" : "synced", h.SyncedAt))
                     .ToList<AccountBalanceDto>();
 
-                grouped.Add(new CategorySummaryDto("brokerage", holdings.Sum(h => h.UsdValue), dtos));
+                var institutionCount = holdings.Select(h => h.Provider).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+                grouped.Add(new CategorySummaryDto("brokerage", holdings.Sum(h => h.UsdValue), institutionCount, dtos));
             }
         }
 
         return new WealthSummaryResponse(
             grouped.Sum(c => c.TotalInBaseCurrency), "USD", grouped,
             new AppliedFiltersDto(category, provider));
+    }
+
+    private static int CountBankingInstitutions(IReadOnlyList<BankingAccountSummary> accounts)
+    {
+        return accounts
+            .Select(a => (
+                Provider: a.Provider.ToLowerInvariant(),
+                InstitutionKey: (a.MonobankCredentialId ?? a.TrueLayerConnectionId ?? a.AccountId).ToString()))
+            .Distinct()
+            .Count();
     }
 
     public async Task<TransactionSummaryResponse> GetTransactionSummaryAsync(

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -59,8 +59,8 @@
             Banking Institutions
           </h2>
           <span class="text-cmn-xs text-text-secondary"
-            >{{ banking.accounts.length }} account{{
-              banking.accounts.length !== 1 ? 's' : ''
+            >{{ banking.institutionCount }} institution{{
+              banking.institutionCount !== 1 ? 's' : ''
             }}</span
           >
         </div>
@@ -139,7 +139,9 @@
             Brokerage &amp; Investment
           </h2>
           <span class="text-cmn-xs text-text-secondary"
-            >{{ brokerage.accounts.length }} account{{
+            >{{ brokerage.institutionCount }} broker{{
+              brokerage.institutionCount !== 1 ? 's' : ''
+            }} · {{ brokerage.accounts.length }} position{{
               brokerage.accounts.length !== 1 ? 's' : ''
             }}</span
           >
@@ -201,7 +203,11 @@
             Digital Assets
           </h2>
           <span class="text-cmn-xs text-text-secondary"
-            >{{ crypto.accounts.length }} account{{ crypto.accounts.length !== 1 ? 's' : '' }}</span
+            >{{ crypto.institutionCount }} exchange{{
+              crypto.institutionCount !== 1 ? 's' : ''
+            }} · {{ crypto.accounts.length }} asset{{
+              crypto.accounts.length !== 1 ? 's' : ''
+            }}</span
           >
         </div>
         <cmn-card>

--- a/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
@@ -27,7 +27,7 @@ export function accountsComputed(store: StateSignals) {
       () => store.summary()?.categories.find(c => c.category === 'brokerage') ?? null
     ),
     totalConnections: computed(
-      () => store.summary()?.categories.reduce((sum, cat) => sum + cat.accounts.length, 0) ?? 0
+      () => store.summary()?.categories.reduce((sum, cat) => sum + cat.institutionCount, 0) ?? 0
     ),
   };
 }

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -48,7 +48,11 @@
               <span class="text-xs font-medium uppercase tracking-wider text-neutral-500">
                 {{ cat.category | categoryLabel }}
               </span>
-              <span class="text-xs text-neutral-400">{{ cat.accounts.length }} accounts</span>
+              <span class="text-xs text-neutral-400"
+                >{{ cat.institutionCount }} institution{{
+                  cat.institutionCount !== 1 ? 's' : ''
+                }}</span
+              >
             </div>
             <p
               class="text-xl font-mono font-semibold text-neutral-900 dark:text-neutral-100 tabular-nums"

--- a/frontend/src/app/shared/models/wealth/wealth.model.ts
+++ b/frontend/src/app/shared/models/wealth/wealth.model.ts
@@ -16,6 +16,7 @@ export interface AccountBalanceItem extends AccountIdentity {
 export interface CategorySummary {
   category: AccountCategory;
   totalInBaseCurrency: number;
+  institutionCount: number;
   accounts: AccountBalanceItem[];
 }
 


### PR DESCRIPTION
## Summary
- Fixes the inflated \"8 banking / 5 brokerage / 7 crypto\" counts on the Accounts and Holdings pages — now reports \"3 / 1 / 1\" (Monobank+AIB+Revolut / IBKR / Binance).
- Backend: `CategorySummaryDto` gains `InstitutionCount`, computed via `Distinct(Provider, MonobankCredentialId ?? TrueLayerConnectionId ?? AccountId)` for banking and `Distinct(Provider)` for crypto/brokerage. `BankingAccountSummary` exposes the two credential/connection FKs the read model needs.
- Frontend: `CategorySummary.institutionCount` drives `totalConnections` and per-category headers (\"3 institutions\", \"1 broker · N positions\", \"1 exchange · N assets\"). Card-level `accounts[]` untouched, so per-position drill-down still works.
- **Zero DB migration** — read-model fix only.

Live-verified against the running dev stack:
- `totalNetWorth = $17,826.22`
- `banking: institutionCount=3, accounts=8`
- `crypto: institutionCount=1, accounts=7`
- `brokerage: institutionCount=1, accounts=5`
- `totalConnections = 5`

Resolves item #3 of the 2026-06-30 backlog. Items #1 (parent-child schema) and #2 (per-card 429 storm during Monobank sync) remain open — this PR intentionally does not touch schema so the visible UX bug ships without migration risk.

## Test plan
- [x] `dotnet build backend/` — 0 warnings, 0 errors
- [x] `dotnet test` — Unit 32/32 pass, Integration 11/11 pass
- [x] `npx eslint` on touched TS files — clean
- [x] Live API: `GET /api/v1/wealth/summary` returns correct `institutionCount` for banking/crypto/brokerage
- [ ] Manual browser check on the Accounts list header + Holdings summary cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)