### PR TITLE
feat(bank-sync): categorize TrueLayer transactions via transaction_classification

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/CategoryMapping/TrueLayerCategoryMapper.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/CategoryMapping/TrueLayerCategoryMapper.cs
@@ -1,0 +1,41 @@
+namespace FinanceSentry.Modules.BankSync.Application.Services.CategoryMapping;
+
+public class TrueLayerCategoryMapper
+{
+    private static readonly IReadOnlyDictionary<string, string> Lookup =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Bills and Utilities"] = "utilities",
+            ["Utilities"] = "utilities",
+            ["Entertainment"] = "entertainment",
+            ["Food & Dining"] = "food_and_drink",
+            ["Food and Drink"] = "food_and_drink",
+            ["Restaurants"] = "food_and_drink",
+            ["Groceries"] = "food_and_drink",
+            ["General Merchandise"] = "shopping",
+            ["Shopping"] = "shopping",
+            ["Personal Care"] = "shopping",
+            ["Healthcare"] = "health",
+            ["Medical"] = "health",
+            ["Transport"] = "transport",
+            ["Transportation"] = "transport",
+            ["Travel"] = "travel",
+            ["Home Improvement"] = "housing",
+            ["Rent and Utilities"] = "housing",
+            ["Housing"] = "housing",
+        };
+
+    public string Map(IReadOnlyList<string>? classification)
+    {
+        if (classification is null || classification.Count == 0)
+            return "other";
+
+        foreach (var raw in classification)
+        {
+            if (raw is null) continue;
+            if (Lookup.TryGetValue(raw.Trim(), out var key))
+                return key;
+        }
+        return "other";
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
@@ -91,6 +91,7 @@ public static class BankSyncModule
         services.AddHttpClient(TrueLayerHttpClient.AuthClientName, c => c.BaseAddress = trueLayerAuthBase);
         services.AddHttpClient(TrueLayerHttpClient.ApiClientName, c => c.BaseAddress = trueLayerApiBase);
         services.AddSingleton<ITrueLayerClient, TrueLayerHttpClient>();
+        services.AddSingleton<TrueLayerCategoryMapper>();
         services.AddScoped<TrueLayerAdapter>();
         services.AddScoped<IBankProvider>(sp => sp.GetRequiredService<TrueLayerAdapter>());
 

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerAdapter.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer;
 
 using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Application.Services.CategoryMapping;
 using FinanceSentry.Modules.BankSync.Domain.Interfaces;
 
 /// <summary>
@@ -9,9 +10,11 @@ using FinanceSentry.Modules.BankSync.Domain.Interfaces;
 /// exchanging the per-connection refresh_token for a fresh access_token before
 /// invoking this adapter.
 /// </summary>
-public class TrueLayerAdapter(ITrueLayerClient client) : IBankProvider
+public class TrueLayerAdapter(ITrueLayerClient client, TrueLayerCategoryMapper categoryMapper) : IBankProvider
 {
     private const int InitialSyncWindowDays = 90;
+
+    private readonly TrueLayerCategoryMapper _categoryMapper = categoryMapper;
 
     public string ProviderName => "truelayer";
 
@@ -60,7 +63,7 @@ public class TrueLayerAdapter(ITrueLayerClient client) : IBankProvider
 
         var candidates = booked
             .Concat(pending)
-            .Select(t => MapTransaction(t, accountId, userId))
+            .Select(t => MapTransaction(t, accountId, userId, _categoryMapper))
             .ToList();
 
         return (candidates, DateTime.UtcNow);
@@ -69,7 +72,7 @@ public class TrueLayerAdapter(ITrueLayerClient client) : IBankProvider
     public Task DisconnectAsync(string credential, CancellationToken ct = default)
         => Task.CompletedTask;
 
-    private static TransactionCandidate MapTransaction(TrueLayerTransaction t, Guid accountId, Guid userId)
+    private static TransactionCandidate MapTransaction(TrueLayerTransaction t, Guid accountId, Guid userId, TrueLayerCategoryMapper categoryMapper)
     {
         var amount = Math.Abs(t.Amount);
         var txType = t.Amount < 0 || t.TransactionType == "debit" ? "debit" : "credit";
@@ -84,7 +87,7 @@ public class TrueLayerAdapter(ITrueLayerClient client) : IBankProvider
             IsPending: t.IsPending,
             TransactionType: txType,
             MerchantName: t.MerchantName,
-            MerchantCategory: null,
+            MerchantCategory: categoryMapper.Map(t.Classification),
             PlaidTransactionId: null);
     }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerHttpClient.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerHttpClient.cs
@@ -165,7 +165,8 @@ public sealed class TrueLayerHttpClient(
             Description: description.Trim(),
             MerchantName: t.MerchantName,
             TransactionType: txType,
-            IsPending: isPending);
+            IsPending: isPending,
+            Classification: t.TransactionClassification ?? []);
     }
 
     private static DateTime ParseTimestamp(string? raw)
@@ -336,5 +337,6 @@ public sealed class TrueLayerHttpClient(
         [JsonPropertyName("description")] public string? Description { get; set; }
         [JsonPropertyName("merchant_name")] public string? MerchantName { get; set; }
         [JsonPropertyName("transaction_type")] public string? TransactionType { get; set; }
+        [JsonPropertyName("transaction_classification")] public List<string>? TransactionClassification { get; set; }
     }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerTypes.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerTypes.cs
@@ -33,4 +33,5 @@ public record TrueLayerTransaction(
     string Description,
     string? MerchantName,
     string TransactionType,
-    bool IsPending);
+    bool IsPending,
+    IReadOnlyList<string> Classification);

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TrueLayerAdapterTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TrueLayerAdapterTests.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Tests.Unit.BankSync.Infrastructure;
 
+using FinanceSentry.Modules.BankSync.Application.Services.CategoryMapping;
 using FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer;
 using FluentAssertions;
 using Moq;
@@ -13,7 +14,7 @@ public class TrueLayerAdapterTests
     private const string ExternalAccountId = "tl-acct-1234abcd";
 
     private readonly Mock<ITrueLayerClient> _clientMock = new(MockBehavior.Strict);
-    private TrueLayerAdapter CreateSut() => new(_clientMock.Object);
+    private TrueLayerAdapter CreateSut() => new(_clientMock.Object, new TrueLayerCategoryMapper());
 
     [Fact]
     public void ProviderName_IsTrueLayer()
@@ -111,7 +112,8 @@ public class TrueLayerAdapterTests
             Description: "Tesco Galway",
             MerchantName: "Tesco",
             TransactionType: "debit",
-            IsPending: false);
+            IsPending: false,
+            Classification: ["Groceries"]);
 
         var pending = new TrueLayerTransaction(
             TransactionId: "tx-2",
@@ -121,7 +123,8 @@ public class TrueLayerAdapterTests
             Description: "Salary",
             MerchantName: null,
             TransactionType: "credit",
-            IsPending: true);
+            IsPending: true,
+            Classification: []);
 
         _clientMock
             .Setup(c => c.GetTransactionsAsync(AccessToken, ExternalAccountId, It.IsAny<DateOnly?>(), It.IsAny<DateOnly?>(), default))
@@ -143,6 +146,7 @@ public class TrueLayerAdapterTests
         debit.TransactionType.Should().Be("debit");
         debit.IsPending.Should().BeFalse();
         debit.PostedDate.Should().NotBeNull();
+        debit.MerchantCategory.Should().Be("food_and_drink");
 
         var credit = candidates.Single(c => c.Description == "Salary");
         credit.Amount.Should().Be(1000m);


### PR DESCRIPTION
## Summary
- Parses TrueLayer's \`transaction_classification\` field (previously ignored) into \`TrueLayerTransaction.Classification\`.
- New \`TrueLayerCategoryMapper\` translates TrueLayer's top-level categories (Groceries, Bills and Utilities, Transport, Travel, …) into our taxonomy (\`food_and_drink\`, \`utilities\`, \`transport\`, \`travel\`, \`shopping\`, \`entertainment\`, \`health\`, \`housing\`, \`other\`).
- \`TrueLayerAdapter\` now populates \`MerchantCategory\` on every synced transaction instead of leaving it null.

Addresses backlog item #6 for TrueLayer. Monobank already had its MCC → taxonomy mapper (untouched here). Existing TrueLayer transactions stay uncategorized until the next sync repopulates them.

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test --filter Wealth|TrueLayer\` — all pass, including new \`MerchantCategory.Should().Be(\"food_and_drink\")\` assertion on a Groceries classification
- [ ] Force-refresh a TrueLayer connection in the running dev stack and confirm transactions land with non-null MerchantCategory

🤖 Generated with [Claude Code](https://claude.com/claude-code)