### PR TITLE
fix(dashboard): current-month inflow/outflow with USD-normalized totals

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
@@ -1,16 +1,22 @@
 namespace FinanceSentry.Modules.BankSync.Application.Services;
 
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
 /// <summary>
 /// Monthly cash-flow statistics for a user (inflow / outflow / net per currency).
+/// Amounts are provided both in the source currency and normalized to USD so
+/// consumers can render a single cross-currency total per month.
 /// </summary>
 public record MonthlyFlow(
     string Month,       // "2026-03"
     string Currency,
     decimal Inflow,
     decimal Outflow,
-    decimal Net);
+    decimal Net,
+    decimal InflowUsd,
+    decimal OutflowUsd,
+    decimal NetUsd);
 
 /// <summary>
 /// Computes monthly money-flow statistics using an in-memory join of transactions and accounts.
@@ -62,7 +68,17 @@ public class MoneyFlowStatisticsService(
             {
                 var inflow = g.Where(x => x.Transaction.TransactionType == "credit").Sum(x => x.Transaction.Amount);
                 var outflow = g.Where(x => x.Transaction.TransactionType == "debit").Sum(x => x.Transaction.Amount);
-                return new MonthlyFlow(g.Key.Month, g.Key.Currency, inflow, outflow, inflow - outflow);
+                var inflowUsd = CurrencyConverter.ToUsd(inflow, g.Key.Currency);
+                var outflowUsd = CurrencyConverter.ToUsd(outflow, g.Key.Currency);
+                return new MonthlyFlow(
+                    g.Key.Month,
+                    g.Key.Currency,
+                    inflow,
+                    outflow,
+                    inflow - outflow,
+                    inflowUsd,
+                    outflowUsd,
+                    inflowUsd - outflowUsd);
             })
             .OrderByDescending(mf => mf.Month)
             .ToList();

--- a/frontend/src/app/modules/bank-sync/models/dashboard/dashboard.model.ts
+++ b/frontend/src/app/modules/bank-sync/models/dashboard/dashboard.model.ts
@@ -20,6 +20,9 @@ export interface MonthlyFlow {
   inflow: number;
   outflow: number;
   net: number;
+  inflowUsd: number;
+  outflowUsd: number;
+  netUsd: number;
 }
 
 export interface CategoryStat {

--- a/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
@@ -22,6 +22,27 @@ const COMPACT_FORMATTER = new Intl.NumberFormat('en-US', {
 
 const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', {month: 'short', year: '2-digit'});
 
+const MONTH_KEY_PAD = 2;
+
+function currentMonthKey(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(MONTH_KEY_PAD, '0')}`;
+}
+
+function sumCurrentMonthUsd(
+  rows: {month: string; inflowUsd: number; outflowUsd: number}[]
+): Nullable<{inflow: number; outflow: number}> {
+  const key = currentMonthKey();
+  const forMonth = rows.filter(r => r.month === key);
+  if (forMonth.length === 0) {
+    return null;
+  }
+  return {
+    inflow: forMonth.reduce((s, r) => s + r.inflowUsd, 0),
+    outflow: forMonth.reduce((s, r) => s + r.outflowUsd, 0),
+  };
+}
+
 export function dashboardComputed(store: StateSignals) {
   const currency = inject(CurrencyPipe);
 
@@ -34,23 +55,25 @@ export function dashboardComputed(store: StateSignals) {
     ),
 
     latestInflowFormatted: computed(() => {
-      const flows = store.data()?.monthlyFlow ?? [];
-      const latest = flows[flows.length - 1];
-      return latest ? COMPACT_FORMATTER.format(latest.inflow) : '—';
+      const current = sumCurrentMonthUsd(store.data()?.monthlyFlow ?? []);
+      return current ? COMPACT_FORMATTER.format(current.inflow) : '—';
     }),
 
     latestOutflowFormatted: computed(() => {
-      const flows = store.data()?.monthlyFlow ?? [];
-      const latest = flows[flows.length - 1];
-      return latest ? COMPACT_FORMATTER.format(latest.outflow) : '—';
+      const current = sumCurrentMonthUsd(store.data()?.monthlyFlow ?? []);
+      return current ? COMPACT_FORMATTER.format(current.outflow) : '—';
     }),
 
-    netFlowChartData: computed((): ChartPoint[] =>
-      (store.data()?.monthlyFlow ?? []).map(m => ({
-        label: m.month,
-        value: m.net,
-      }))
-    ),
+    netFlowChartData: computed((): ChartPoint[] => {
+      const rows = store.data()?.monthlyFlow ?? [];
+      const byMonth = new Map<string, number>();
+      for (const m of rows) {
+        byMonth.set(m.month, (byMonth.get(m.month) ?? 0) + m.netUsd);
+      }
+      return [...byMonth.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([month, value]) => ({label: month, value}));
+    }),
 
     categoryChartData: computed((): DonutSegment[] =>
       (store.data()?.topCategories ?? []).map(c => ({


### PR DESCRIPTION
## Summary
Fixes the dashboard's \"This month inflow/outflow\" numbers, which were both wrong-month and single-currency.

**Sort direction bug** — \`MoneyFlowStatisticsService\` returns months descending (June at index 0). The dashboard was reading \`flows[flows.length - 1]\`, which is the *oldest* month in the 6-month window. Result: \"This month\" outflow was 3 months stale.

**Currency-mix bug** — For a multi-currency user, June has separate rows per currency (EUR row + UAH row). The old code only read one arbitrary row; other currencies were dropped from the total.

**Fix**:
- Backend: \`MonthlyFlow\` gains \`InflowUsd\`, \`OutflowUsd\`, \`NetUsd\` via \`CurrencyConverter.ToUsd\`.
- Frontend: dashboard picks the current \`YYYY-MM\` key explicitly (regardless of sort direction) and sums the \`*Usd\` fields across all currency rows for that month. Net-flow chart groups by month and sums \`netUsd\`.

Contract stays backwards-compatible — raw per-currency fields (\`inflow\`/\`outflow\`/\`net\`) are still returned.

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test --filter MoneyFlow\` — 4/4 pass
- [x] Frontend ESLint clean on touched files
- [ ] Manual dashboard check: current-month inflow/outflow reflect actual current-month transactions in USD

🤖 Generated with [Claude Code](https://claude.com/claude-code)