### PR TITLE
feat(wealth): daily net-worth snapshots instead of monthly

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
@@ -7,7 +7,7 @@ public interface INetWorthSnapshotService
         NetWorthSnapshotData data,
         CancellationToken ct = default);
 
-    Task<bool> HasSnapshotForCurrentMonthAsync(
+    Task<bool> HasSnapshotForTodayAsync(
         Guid userId,
         CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/EventHandlers/FirstSyncSnapshotTrigger.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/EventHandlers/FirstSyncSnapshotTrigger.cs
@@ -16,7 +16,7 @@ public class FirstSyncSnapshotTrigger(
         if (@event.Status != "success")
             return;
 
-        if (await _snapshotService.HasSnapshotForCurrentMonthAsync(@event.UserId, cancellationToken))
+        if (await _snapshotService.HasSnapshotForTodayAsync(@event.UserId, cancellationToken))
             return;
 
         _jobScheduler.ScheduleForUser(@event.UserId);

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
@@ -29,10 +29,9 @@ public class NetWorthSnapshotService(INetWorthSnapshotRepository repository) : I
         await _repository.PersistAsync(snapshot, ct);
     }
 
-    public async Task<bool> HasSnapshotForCurrentMonthAsync(Guid userId, CancellationToken ct = default)
+    public async Task<bool> HasSnapshotForTodayAsync(Guid userId, CancellationToken ct = default)
     {
-        var now = DateTime.UtcNow;
-        var monthEnd = new DateOnly(now.Year, now.Month, DateTime.DaysInMonth(now.Year, now.Month));
-        return await _repository.ExistsAsync(userId, monthEnd, ct);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        return await _repository.ExistsAsync(userId, today, ct);
     }
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
@@ -36,8 +36,7 @@ public class NetWorthSnapshotJob(
         var brokerageHoldings = await _brokerageReader.GetHoldingsAsync(userId, ct);
         var brokerageTotal = brokerageHoldings.Sum(h => h.UsdValue);
 
-        var now = DateTime.UtcNow;
-        var snapshotDate = new DateOnly(now.Year, now.Month, DateTime.DaysInMonth(now.Year, now.Month));
+        var snapshotDate = DateOnly.FromDateTime(DateTime.UtcNow);
 
         await _snapshotService.PersistSnapshotAsync(userId, new NetWorthSnapshotData(
             snapshotDate, bankingTotal, brokerageTotal, cryptoTotal), ct);

--- a/backend/src/FinanceSentry.Modules.Wealth/WealthModule.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/WealthModule.cs
@@ -28,7 +28,7 @@ public static class WealthModule
             mgr.AddOrUpdate<NetWorthSnapshotJob>(
                 "net-worth-snapshot",
                 job => job.ExecuteAsync(CancellationToken.None),
-                "0 1 L * *");
+                Cron.Daily(1));
         }
     }
 


### PR DESCRIPTION
## Summary
The net-worth history chart looked empty because snapshots were monthly-only:
- Cron: \`0 1 L * *\` = 01:00 last-day-of-month → 1 snapshot per calendar month
- \`snapshotDate\` was always end-of-month, so \`ExistsAsync\` idempotency also gated at month granularity

With ~1 month of usage the test user had exactly 1 snapshot (2026-06-30), so the chart rendered a single lonely point.

**Change**: switch to daily. \`NetWorthSnapshotJob\` snapshots today's date; cron becomes \`Cron.Daily(1)\` (01:00 UTC every day); \`HasSnapshotForCurrentMonthAsync\` → \`HasSnapshotForTodayAsync\` and its one caller (\`FirstSyncSnapshotTrigger\`) updated. Existing month-end rows stay as valid points; new daily rows accumulate.

Storage impact: ~365 rows/year/user instead of 12. Trivial for a personal-use app.

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test --filter Snapshot|NetWorth|FirstSync\` — 11/11 pass
- [ ] After deploy: verify a new snapshot lands each day, chart populates with a real trend

🤖 Generated with [Claude Code](https://claude.com/claude-code)