### PR TITLE
feat(brokerage): per-user IBeam Docker orchestration (stage 2 of 4)

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -49,6 +49,9 @@
     <PackageVersion Include="Serilog.Enrichers.Context" Version="4.6.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="2.3.0" />
 
+    <!-- Docker.DotNet — per-user IBeam container orchestration -->
+    <PackageVersion Include="Docker.DotNet" Version="3.125.15" />
+
     <!-- Polly / HTTP / JSON -->
     <PackageVersion Include="Polly" Version="8.2.0" />
     <PackageVersion Include="Polly.Core" Version="8.4.1" />

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
@@ -3,13 +3,13 @@ using FinanceSentry.Infrastructure.Encryption;
 using FinanceSentry.Modules.BrokerageSync.Domain;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 
 namespace FinanceSentry.Modules.BrokerageSync.Application.Commands;
 
 /// <summary>
-/// Per-user IBKR connect request. The username and password are encrypted at
-/// rest and used to spawn a dedicated IBeam gateway container for the user in
-/// stage 2 of the per-user IBKR rollout.
+/// Per-user IBKR connect request. Username and password are encrypted at rest,
+/// then used to spawn the user's dedicated IBeam gateway container.
 /// </summary>
 public sealed record ConnectIBKRRequest(string Username, string Password);
 
@@ -19,7 +19,9 @@ public sealed record ConnectIBKRResult(int HoldingsCount, DateTime ConnectedAt, 
 
 public sealed class ConnectIBKRCommandHandler(
     IIBKRCredentialRepository credentialRepository,
-    ICredentialEncryptionService encryption)
+    ICredentialEncryptionService encryption,
+    IIBeamContainerManager containerManager,
+    ICommandHandler<SyncIBKRHoldingsCommand, SyncIBKRHoldingsResult> syncHandler)
     : ICommandHandler<ConnectIBKRCommand, ConnectIBKRResult>
 {
     public async Task<ConnectIBKRResult> Handle(ConnectIBKRCommand command, CancellationToken cancellationToken)
@@ -45,7 +47,21 @@ public sealed class ConnectIBKRCommandHandler(
         await credentialRepository.AddAsync(credential, cancellationToken);
         await credentialRepository.SaveChangesAsync(cancellationToken);
 
-        // Holdings sync + AccountId discovery move to stage 2 (Docker orchestration).
-        return new ConnectIBKRResult(0, DateTime.UtcNow, string.Empty);
+        await containerManager.SpawnAsync(
+            credential.Id, command.Username, command.Password, cancellationToken);
+
+        var authenticated = await containerManager.WaitForAuthAsync(credential.Id, cancellationToken);
+        if (!authenticated)
+            throw new BrokerAuthException(
+                "IBKR gateway did not authenticate within the configured timeout. Check the credentials and gateway logs.",
+                "IBKR");
+
+        var syncResult = await syncHandler.Handle(
+            new SyncIBKRHoldingsCommand(command.UserId), cancellationToken);
+
+        return new ConnectIBKRResult(
+            syncResult.HoldingsCount,
+            syncResult.SyncedAt,
+            credential.AccountId ?? string.Empty);
     }
 }

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/DisconnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/DisconnectIBKRCommand.cs
@@ -1,6 +1,7 @@
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 
 namespace FinanceSentry.Modules.BrokerageSync.Application.Commands;
 
@@ -8,7 +9,8 @@ public sealed record DisconnectIBKRCommand(Guid UserId) : ICommand<Unit>;
 
 public sealed class DisconnectIBKRCommandHandler(
     IIBKRCredentialRepository credentialRepository,
-    IBrokerageHoldingRepository holdingRepository)
+    IBrokerageHoldingRepository holdingRepository,
+    IIBeamContainerManager containerManager)
     : ICommandHandler<DisconnectIBKRCommand, Unit>
 {
     public async Task<Unit> Handle(DisconnectIBKRCommand command, CancellationToken cancellationToken)
@@ -16,6 +18,8 @@ public sealed class DisconnectIBKRCommandHandler(
         var credential = await credentialRepository.GetByUserIdAsync(command.UserId, cancellationToken)
             ?? throw new BrokerAccountNotFoundException(
                 $"No active IBKR account found for user {command.UserId}.");
+
+        await containerManager.StopAndRemoveAsync(credential.Id, cancellationToken);
 
         credential.Deactivate();
         credentialRepository.Update(credential);

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/SyncIBKRHoldingsCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/SyncIBKRHoldingsCommand.cs
@@ -32,12 +32,18 @@ public sealed class SyncIBKRHoldingsCommandHandler : ICommandHandler<SyncIBKRHol
 
         try
         {
-            await _adapter.EnsureSessionAsync(ct);
+            await _adapter.EnsureSessionAsync(credential.Id, ct);
 
             var accountId = credential.AccountId
-                ?? await _adapter.GetAccountIdAsync(ct);
+                ?? await _adapter.GetAccountIdAsync(credential.Id, ct);
 
-            var positions = await _adapter.GetPositionsAsync(accountId, ct);
+            if (credential.AccountId is null)
+            {
+                credential.UpdateAccountId(accountId);
+                _credentialRepository.Update(credential);
+            }
+
+            var positions = await _adapter.GetPositionsAsync(credential.Id, accountId, ct);
 
             var syncedAt = DateTime.UtcNow;
 
@@ -56,7 +62,6 @@ public sealed class SyncIBKRHoldingsCommandHandler : ICommandHandler<SyncIBKRHol
             await _holdingRepository.UpsertRangeAsync(holdings, ct);
             await _holdingRepository.SaveChangesAsync(ct);
 
-            // Re-apply avg cost on entities that already existed (UpsertRangeAsync only updates qty + value).
             var positionByKey = positions.ToDictionary(p => p.Symbol, StringComparer.Ordinal);
             var persisted = await _holdingRepository.GetByUserIdAsync(request.UserId, ct);
             foreach (var h in persisted)

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/BrokerageSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/BrokerageSyncModule.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.BrokerageSync;
 
+using Docker.DotNet;
 using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Modules.BrokerageSync.Application.Services;
 using FinanceSentry.Modules.BrokerageSync.Domain.Interfaces;
@@ -12,7 +13,6 @@ using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 public static class BrokerageSyncModule
 {
@@ -37,20 +37,26 @@ public static class BrokerageSyncModule
         services.AddDbContext<BrokerageSyncDbContext>(
             o => o.UseNpgsql(config.GetConnectionString("Default")!, b => b.MigrationsHistoryTable("__EFMigrationsHistory", "public")));
 
+        services.Configure<IBeamOptions>(config.GetSection(IBeamOptions.SectionName));
+
         services.AddHttpClient<IBKRGatewayClient>(client =>
                 client.DefaultRequestHeaders.UserAgent.ParseAdd("FinanceSentry/1.0"))
-            .ConfigurePrimaryHttpMessageHandler(sp =>
+            .ConfigurePrimaryHttpMessageHandler(_ => new HttpClientHandler
             {
-                var env = sp.GetRequiredService<IHostEnvironment>();
-                var allowSelfSigned = config.GetValue<bool>("IBKR:AllowSelfSignedCert") || env.IsDevelopment();
-                return new HttpClientHandler
-                {
-                    UseCookies = false,
-                    ServerCertificateCustomValidationCallback = allowSelfSigned
-                        ? HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                        : null,
-                };
+                UseCookies = false,
+                // IBeam serves a self-signed cert; trust is anchored on the
+                // private Docker network the API and gateway share.
+                ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
             });
+
+        services.AddSingleton<IDockerClient>(sp =>
+        {
+            var options = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<IBeamOptions>>().Value;
+            return new DockerClientConfiguration(new Uri(options.DockerEndpoint)).CreateClient();
+        });
+
+        services.AddSingleton<IIBeamGatewayResolver, IBeamGatewayResolver>();
+        services.AddSingleton<IIBeamContainerManager, IBeamContainerManager>();
 
         services.AddScoped<IBrokerAdapter, IBKRAdapter>();
         services.AddScoped<IIBKRCredentialRepository, IBKRCredentialRepository>();

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/Interfaces/IBrokerAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/Interfaces/IBrokerAdapter.cs
@@ -3,16 +3,17 @@ namespace FinanceSentry.Modules.BrokerageSync.Domain.Interfaces;
 /// <summary>
 /// Abstraction over a brokerage adapter.
 ///
-/// Authentication is intentionally absent: under the current single-tenant
-/// IBKR-via-IBeam model the gateway sidecar owns the broker session lifecycle,
-/// so the application code only needs to verify status and read data.
+/// Each method takes the id of the calling user's <c>IBKRCredential</c> so the
+/// adapter can resolve the per-user IBeam gateway URL. Under the per-user
+/// container model (stage 2) each user gets their own IBeam and the API talks
+/// to it by DNS name on the shared Docker network.
 /// </summary>
 public interface IBrokerAdapter
 {
     string BrokerName { get; }
-    Task EnsureSessionAsync(CancellationToken ct = default);
-    Task<string> GetAccountIdAsync(CancellationToken ct = default);
-    Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(string accountId, CancellationToken ct = default);
+    Task EnsureSessionAsync(Guid credentialId, CancellationToken ct = default);
+    Task<string> GetAccountIdAsync(Guid credentialId, CancellationToken ct = default);
+    Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(Guid credentialId, string accountId, CancellationToken ct = default);
 }
 
 public sealed record BrokerPosition(

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/FinanceSentry.Modules.BrokerageSync.csproj
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/FinanceSentry.Modules.BrokerageSync.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="FluentResults" />
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Hangfire.Core" />

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRAdapter.cs
@@ -6,35 +6,40 @@ namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 public sealed class IBKRAdapter : IBrokerAdapter
 {
     private readonly IBKRGatewayClient _client;
+    private readonly IIBeamGatewayResolver _resolver;
 
-    public IBKRAdapter(IBKRGatewayClient client)
+    public IBKRAdapter(IBKRGatewayClient client, IIBeamGatewayResolver resolver)
     {
         _client = client;
+        _resolver = resolver;
     }
 
     public string BrokerName => "IBKR";
 
-    public async Task EnsureSessionAsync(CancellationToken ct = default)
+    public async Task EnsureSessionAsync(Guid credentialId, CancellationToken ct = default)
     {
-        var status = await _client.GetAuthStatusAsync(ct);
+        var baseUrl = _resolver.BaseUrl(credentialId);
+        var status = await _client.GetAuthStatusAsync(baseUrl, ct);
         if (!status.Authenticated)
             throw new BrokerAuthException(
-                "IBKR gateway is not authenticated. Configure IBKR_ACCOUNT/IBKR_PASSWORD in docker/.env and ensure the ibkr-gateway container is running.",
+                "IBKR gateway is not authenticated for this user. The IBeam container may still be starting or the stored credentials may be invalid.",
                 "IBKR");
     }
 
-    public async Task<string> GetAccountIdAsync(CancellationToken ct = default)
+    public async Task<string> GetAccountIdAsync(Guid credentialId, CancellationToken ct = default)
     {
-        var accountsResponse = await _client.GetAccountsAsync(ct);
+        var baseUrl = _resolver.BaseUrl(credentialId);
+        var accountsResponse = await _client.GetAccountsAsync(baseUrl, ct);
         if (accountsResponse.Accounts.Count == 0)
             throw new InvalidOperationException("No IBKR accounts found for the authenticated session.");
 
         return accountsResponse.Accounts[0];
     }
 
-    public async Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(string accountId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<BrokerPosition>> GetPositionsAsync(Guid credentialId, string accountId, CancellationToken ct = default)
     {
-        var positions = await _client.GetPositionsAsync(accountId, ct);
+        var baseUrl = _resolver.BaseUrl(credentialId);
+        var positions = await _client.GetPositionsAsync(baseUrl, accountId, ct);
         return positions
             .Select(p => new BrokerPosition(
                 Symbol: p.ContractDesc,

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRGatewayClient.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRGatewayClient.cs
@@ -1,36 +1,25 @@
 using System.Net.Http.Json;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 
 /// <summary>
-/// HTTP client for the IBKR Client Portal Gateway, served by the IBeam sidecar.
-///
-/// The gateway holds its own session — authenticated by IBeam from
-/// <c>IBKR_ACCOUNT</c>/<c>IBKR_PASSWORD</c> env vars. We never POST credentials
-/// from this client; we only check session status and read portfolio data.
+/// HTTP client for the IBKR Client Portal Gateway, served by a per-user IBeam
+/// sidecar container. The base URL is supplied per call so a single instance of
+/// this client can talk to any user's gateway.
 /// </summary>
-public sealed class IBKRGatewayClient(HttpClient http, IConfiguration configuration, ILogger<IBKRGatewayClient> logger)
+public sealed class IBKRGatewayClient(HttpClient http, ILogger<IBKRGatewayClient> logger)
 {
-    private readonly HttpClient _http = InitHttp(http, configuration);
-
-    private static HttpClient InitHttp(HttpClient http, IConfiguration configuration)
-    {
-        http.BaseAddress = new Uri(configuration["IBKR:GatewayBaseUrl"] ?? "https://ibkr-gateway:5000");
-        return http;
-    }
-
-    public async Task<IBKRAuthStatusResponse> GetAuthStatusAsync(CancellationToken ct = default)
+    public async Task<IBKRAuthStatusResponse> GetAuthStatusAsync(Uri baseUrl, CancellationToken ct = default)
     {
         HttpResponseMessage response;
         try
         {
-            response = await _http.GetAsync("/v1/api/iserver/auth/status", ct);
+            response = await http.GetAsync(new Uri(baseUrl, "/v1/api/iserver/auth/status"), ct);
         }
         catch (HttpRequestException ex)
         {
-            logger.LogWarning("IBKR gateway unreachable: {Error}", ex.Message);
+            logger.LogWarning("IBKR gateway {BaseUrl} unreachable: {Error}", baseUrl, ex.Message);
             return new IBKRAuthStatusResponse(false, false);
         }
 
@@ -52,18 +41,18 @@ public sealed class IBKRGatewayClient(HttpClient http, IConfiguration configurat
         }
     }
 
-    public async Task<IBKRAccountsResponse> GetAccountsAsync(CancellationToken ct = default)
+    public async Task<IBKRAccountsResponse> GetAccountsAsync(Uri baseUrl, CancellationToken ct = default)
     {
-        var response = await _http.GetAsync("/v1/api/iserver/accounts", ct);
+        var response = await http.GetAsync(new Uri(baseUrl, "/v1/api/iserver/accounts"), ct);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadFromJsonAsync<IBKRAccountsResponse>(cancellationToken: ct)
             ?? new IBKRAccountsResponse([]);
     }
 
-    public async Task<IReadOnlyList<IBKRPositionResponse>> GetPositionsAsync(string accountId, CancellationToken ct = default)
+    public async Task<IReadOnlyList<IBKRPositionResponse>> GetPositionsAsync(Uri baseUrl, string accountId, CancellationToken ct = default)
     {
-        var response = await _http.GetAsync($"/v1/api/portfolio/{accountId}/positions/0", ct);
+        var response = await http.GetAsync(new Uri(baseUrl, $"/v1/api/portfolio/{accountId}/positions/0"), ct);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadFromJsonAsync<List<IBKRPositionResponse>>(cancellationToken: ct) ?? [];

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
@@ -1,0 +1,190 @@
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Spawns per-user IBeam containers via the Docker daemon (mounted docker.sock).
+/// Every connected user gets one container named after their credential id so
+/// the API can address them deterministically by DNS on the shared Docker
+/// network.
+/// </summary>
+public sealed class IBeamContainerManager : IIBeamContainerManager
+{
+    private const int GatewayContainerPort = 5000;
+    private const int AuthPollIntervalMs = 3000;
+
+    private readonly IDockerClient _docker;
+    private readonly IBeamOptions _options;
+    private readonly IIBeamGatewayResolver _resolver;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<IBeamContainerManager> _logger;
+
+    public IBeamContainerManager(
+        IDockerClient docker,
+        IOptions<IBeamOptions> options,
+        IIBeamGatewayResolver resolver,
+        IHttpClientFactory httpClientFactory,
+        ILogger<IBeamContainerManager> logger)
+    {
+        _docker = docker;
+        _options = options.Value;
+        _resolver = resolver;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task SpawnAsync(Guid credentialId, string ibkrUsername, string ibkrPassword, CancellationToken ct = default)
+    {
+        var containerName = _resolver.ContainerName(credentialId);
+
+        // Wipe any pre-existing container of the same name so spawn is idempotent.
+        await RemoveIfExistsAsync(containerName, ct);
+
+        await EnsureImageAsync(_options.Image, ct);
+
+        var createResp = await _docker.Containers.CreateContainerAsync(new CreateContainerParameters
+        {
+            Name = containerName,
+            Image = _options.Image,
+            Env =
+            [
+                $"IBEAM_ACCOUNT={ibkrUsername}",
+                $"IBEAM_PASSWORD={ibkrPassword}",
+                "IBEAM_GATEWAY_BASE_URL=https://localhost:5000",
+                "IBEAM_LOG_LEVEL=INFO",
+                "IBEAM_ERROR_SCREENSHOTS=True",
+            ],
+            HostConfig = new HostConfig
+            {
+                Binds = string.IsNullOrWhiteSpace(_options.ConfHostPath)
+                    ? null
+                    : [$"{_options.ConfHostPath}:/srv/inputs/conf.yaml:ro"],
+                NetworkMode = _options.Network,
+                RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
+            },
+            NetworkingConfig = new NetworkingConfig
+            {
+                EndpointsConfig = new Dictionary<string, EndpointSettings>
+                {
+                    [_options.Network] = new EndpointSettings
+                    {
+                        Aliases = [containerName],
+                    },
+                },
+            },
+        }, ct);
+
+        await _docker.Containers.StartContainerAsync(createResp.ID, new ContainerStartParameters(), ct);
+        _logger.LogInformation(
+            "Spawned IBeam container {Container} (id {Id}) for credential {CredentialId}",
+            containerName, createResp.ID, credentialId);
+    }
+
+    public async Task StopAndRemoveAsync(Guid credentialId, CancellationToken ct = default)
+    {
+        var containerName = _resolver.ContainerName(credentialId);
+        await RemoveIfExistsAsync(containerName, ct);
+    }
+
+    public async Task<bool> WaitForAuthAsync(Guid credentialId, CancellationToken ct = default)
+    {
+        var baseUrl = _resolver.BaseUrl(credentialId);
+        var deadline = DateTime.UtcNow.AddSeconds(_options.SpawnTimeoutSeconds);
+
+        using var http = CreateInsecureClient();
+
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                var response = await http.GetAsync(new Uri(baseUrl, "/v1/api/iserver/auth/status"), ct);
+                if (response.IsSuccessStatusCode)
+                {
+                    var body = await response.Content.ReadAsStringAsync(ct);
+                    if (body.Contains("\"authenticated\":true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogInformation("IBeam container for credential {CredentialId} authenticated", credentialId);
+                        return true;
+                    }
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // Container may still be starting; retry.
+            }
+
+            await Task.Delay(AuthPollIntervalMs, ct);
+        }
+
+        _logger.LogWarning(
+            "IBeam container for credential {CredentialId} did not authenticate within {Timeout}s",
+            credentialId, _options.SpawnTimeoutSeconds);
+        return false;
+    }
+
+    private async Task RemoveIfExistsAsync(string containerName, CancellationToken ct)
+    {
+        var existing = await _docker.Containers.ListContainersAsync(new ContainersListParameters
+        {
+            All = true,
+            Filters = new Dictionary<string, IDictionary<string, bool>>
+            {
+                ["name"] = new Dictionary<string, bool> { [containerName] = true },
+            },
+        }, ct);
+
+        foreach (var container in existing)
+        {
+            _logger.LogInformation("Removing existing IBeam container {Container} (id {Id})", containerName, container.ID);
+            try
+            {
+                await _docker.Containers.RemoveContainerAsync(container.ID, new ContainerRemoveParameters
+                {
+                    Force = true,
+                    RemoveVolumes = true,
+                }, ct);
+            }
+            catch (DockerContainerNotFoundException)
+            {
+                // Raced with another remove; safe to ignore.
+            }
+        }
+    }
+
+    private async Task EnsureImageAsync(string image, CancellationToken ct)
+    {
+        var images = await _docker.Images.ListImagesAsync(new ImagesListParameters
+        {
+            Filters = new Dictionary<string, IDictionary<string, bool>>
+            {
+                ["reference"] = new Dictionary<string, bool> { [image] = true },
+            },
+        }, ct);
+
+        if (images.Count > 0)
+            return;
+
+        _logger.LogInformation("Pulling IBeam image {Image}", image);
+        await _docker.Images.CreateImageAsync(
+            new ImagesCreateParameters { FromImage = image },
+            authConfig: null,
+            new Progress<JSONMessage>(),
+            ct);
+    }
+
+    private HttpClient CreateInsecureClient()
+    {
+        // IBeam serves a self-signed cert. We only speak to the container over
+        // the private Docker network so validating identity provides no extra
+        // security here — trust is anchored on the network topology.
+        var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+        };
+        return new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamGatewayResolver.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamGatewayResolver.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Options;
+
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+public sealed class IBeamGatewayResolver(IOptions<IBeamOptions> options) : IIBeamGatewayResolver
+{
+    private const int ShortIdLength = 8;
+    private const int GatewayPort = 5000;
+
+    private readonly IBeamOptions _options = options.Value;
+
+    public string ContainerName(Guid credentialId)
+    {
+        var shortId = credentialId.ToString("N")[..ShortIdLength];
+        return $"{_options.ContainerNamePrefix}-{shortId}";
+    }
+
+    public Uri BaseUrl(Guid credentialId)
+        => new($"https://{ContainerName(credentialId)}:{GatewayPort}");
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
@@ -1,0 +1,49 @@
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Configuration for the per-user IBeam Docker orchestration.
+///
+/// The API container spawns one <c>voyz/ibeam</c> container per connected user.
+/// Each container joins <see cref="Network"/>, mounts the conf file from
+/// <see cref="ConfHostPath"/>, and gets a stable name so the API can address it
+/// by DNS at <c>https://finance-sentry-ibkr-{shortId}:5000</c>.
+/// </summary>
+public sealed class IBeamOptions
+{
+    public const string SectionName = "IBeam";
+
+    /// <summary>
+    /// Docker image reference for IBeam. Defaults to <c>voyz/ibeam:latest</c>.
+    /// </summary>
+    public string Image { get; set; } = "voyz/ibeam:latest";
+
+    /// <summary>
+    /// Compose network name to attach spawned containers to. Must match the
+    /// network the API itself is on so it can resolve container names via DNS.
+    /// </summary>
+    public string Network { get; set; } = "docker_finance-sentry-network";
+
+    /// <summary>
+    /// Absolute path on the host to <c>docker/ibkr/conf.yaml</c>. The API bind
+    /// mounts this into every spawned IBeam at <c>/srv/inputs/conf.yaml</c>.
+    /// </summary>
+    public string ConfHostPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Prefix for spawned container names. Full name is
+    /// <c>{ContainerNamePrefix}-{shortId}</c> where shortId is the first 8 chars
+    /// of the credential's Guid.
+    /// </summary>
+    public string ContainerNamePrefix { get; set; } = "finance-sentry-ibkr";
+
+    /// <summary>
+    /// Max seconds to wait for the gateway to auth after spawn.
+    /// </summary>
+    public int SpawnTimeoutSeconds { get; set; } = 120;
+
+    /// <summary>
+    /// URI to reach the Docker daemon. Defaults to the unix socket bound into
+    /// the API container.
+    /// </summary>
+    public string DockerEndpoint { get; set; } = "unix:///var/run/docker.sock";
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamContainerManager.cs
@@ -1,0 +1,30 @@
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Spawns, stops, and inspects per-user IBeam containers via the Docker daemon.
+/// One container per user, named after the user's IBKR credential id so the
+/// gateway resolver can address it deterministically.
+/// </summary>
+public interface IIBeamContainerManager
+{
+    /// <summary>
+    /// Ensures a running IBeam container exists for the given credential id
+    /// with the supplied IBKR username and password. Idempotent: if a
+    /// container with the target name already exists it is removed first so
+    /// this call always produces a fresh session.
+    /// </summary>
+    Task SpawnAsync(Guid credentialId, string ibkrUsername, string ibkrPassword, CancellationToken ct = default);
+
+    /// <summary>
+    /// Stops and removes the user's IBeam container if it exists. No-op when
+    /// the container is already gone.
+    /// </summary>
+    Task StopAndRemoveAsync(Guid credentialId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Waits until the user's IBeam container reports an authenticated session
+    /// (auth/status returns <c>authenticated=true</c>) or the configured
+    /// timeout is reached. Returns true on success, false on timeout.
+    /// </summary>
+    Task<bool> WaitForAuthAsync(Guid credentialId, CancellationToken ct = default);
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamGatewayResolver.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamGatewayResolver.cs
@@ -1,0 +1,20 @@
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Resolves the per-user IBeam gateway location. In stage 2 the container name
+/// is derived from the IBKRCredential Id so both the container spawn and the
+/// HTTP client resolve to the same address.
+/// </summary>
+public interface IIBeamGatewayResolver
+{
+    /// <summary>
+    /// Returns the container name (used both for spawn and as DNS name on the
+    /// shared Docker network) for the given credential id.
+    /// </summary>
+    string ContainerName(Guid credentialId);
+
+    /// <summary>
+    /// Returns the base URL the API uses to reach the user's IBeam gateway.
+    /// </summary>
+    Uri BaseUrl(Guid credentialId);
+}

--- a/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/BrokerageControllerConnectContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/BrokerageControllerConnectContractTests.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using FinanceSentry.Modules.BrokerageSync.Domain;
 using FinanceSentry.Modules.BrokerageSync.Domain.Interfaces;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 using FinanceSentry.Modules.BrokerageSync.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
@@ -40,7 +41,7 @@ public class BrokerageControllerConnectContractTests(BrokerageApiFactory factory
     }
 
     [Fact]
-    public async Task Connect_StoresEncryptedCredential_Returns201()
+    public async Task Connect_StoresEncryptedCredential_SpawnsGateway_Returns201()
     {
         _factory.SetupSuccessfulConnect();
 
@@ -48,13 +49,23 @@ public class BrokerageControllerConnectContractTests(BrokerageApiFactory factory
             "/api/v1/brokerage/ibkr/connect",
             new { Username = "u", Password = "p" });
 
+        if (response.StatusCode != HttpStatusCode.Created)
+        {
+            var bodyText = await response.Content.ReadAsStringAsync();
+            throw new Xunit.Sdk.XunitException($"Expected 201, got {(int)response.StatusCode}. Body: {bodyText}");
+        }
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var body = await response.Content.ReadFromJsonAsync<BrokerageConnectResponseShape>();
         body.Should().NotBeNull();
-        // AccountId + HoldingsCount discovery move to stage 2 (Docker orchestration).
-        body!.AccountId.Should().BeEmpty();
-        body.HoldingsCount.Should().Be(0);
-        body.ConnectedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+        body!.ConnectedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+
+        // Container was actually spawned and awaited.
+        _factory.ContainerManagerMock.Verify(
+            m => m.SpawnAsync(It.IsAny<Guid>(), "u", "p", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _factory.ContainerManagerMock.Verify(
+            m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -95,6 +106,7 @@ public class BrokerageApiFactory : WebApplicationFactory<Program>
     public Mock<IIBKRCredentialRepository> CredentialRepoMock { get; } = new(MockBehavior.Loose);
     public Mock<IBrokerageHoldingRepository> HoldingRepoMock { get; } = new(MockBehavior.Loose);
     public Mock<IBrokerAdapter> AdapterMock { get; } = new(MockBehavior.Loose);
+    public Mock<IIBeamContainerManager> ContainerManagerMock { get; } = new(MockBehavior.Loose);
 
     public Guid TestUserId { get; } = Guid.NewGuid();
 
@@ -105,6 +117,7 @@ public class BrokerageApiFactory : WebApplicationFactory<Program>
             ReplaceService(services, CredentialRepoMock.Object);
             ReplaceService(services, HoldingRepoMock.Object);
             ReplaceService<IBrokerAdapter>(services, AdapterMock.Object);
+            ReplaceService(services, ContainerManagerMock.Object);
 
             ReplaceDbContextWithInMemory<FinanceSentry.Modules.BankSync.Infrastructure.Persistence.BankSyncDbContext>(
                 services, $"BrokerageTestBankSync_{Guid.NewGuid()}");
@@ -135,6 +148,16 @@ public class BrokerageApiFactory : WebApplicationFactory<Program>
 
     public void SetupSuccessfulConnect()
     {
+        ContainerManagerMock
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        ContainerManagerMock
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        ContainerManagerMock
+            .Setup(m => m.StopAndRemoveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
         var mockCredential = new IBKRCredential(TestUserId, [1], [2], [3], [4], [5], [6], keyVersion: 1);
 
         CredentialRepoMock
@@ -152,13 +175,13 @@ public class BrokerageApiFactory : WebApplicationFactory<Program>
             .Setup(r => r.Update(It.IsAny<IBKRCredential>()));
 
         AdapterMock
-            .Setup(a => a.EnsureSessionAsync(It.IsAny<CancellationToken>()))
+            .Setup(a => a.EnsureSessionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         AdapterMock
-            .Setup(a => a.GetAccountIdAsync(It.IsAny<CancellationToken>()))
+            .Setup(a => a.GetAccountIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("U1234567");
         AdapterMock
-            .Setup(a => a.GetPositionsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(a => a.GetPositionsAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IReadOnlyList<BrokerPosition>)[]);
         AdapterMock
             .Setup(a => a.BrokerName)
@@ -171,6 +194,9 @@ public class BrokerageApiFactory : WebApplicationFactory<Program>
         HoldingRepoMock
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
     }
 
     public HttpClient CreateAuthenticatedClient()

--- a/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/IBKRAdapterContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/IBKRAdapterContractTests.cs
@@ -3,26 +3,19 @@ using System.Text;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace FinanceSentry.Tests.Integration.BrokerageSync;
 
 public class IBKRAdapterContractTests
 {
-    private static IBKRGatewayClient CreateClient(HttpMessageHandler handler)
-    {
-        var http = new HttpClient(handler);
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["IBKR:GatewayBaseUrl"] = "http://ibkr-gateway:5000",
-            })
-            .Build();
-        return new IBKRGatewayClient(http, config, Microsoft.Extensions.Logging.Abstractions.NullLogger<IBKRGatewayClient>.Instance);
-    }
+    private static readonly Guid TestCredentialId = Guid.Parse("11111111-2222-3333-4444-555555555555");
 
-    private static IBKRAdapter CreateAdapter(IBKRGatewayClient client) => new(client);
+    private static IBKRGatewayClient CreateClient(HttpMessageHandler handler)
+        => new(new HttpClient(handler), Microsoft.Extensions.Logging.Abstractions.NullLogger<IBKRGatewayClient>.Instance);
+
+    private static IBKRAdapter CreateAdapter(IBKRGatewayClient client)
+        => new(client, new StaticResolver(new Uri("http://ibkr-gateway:5000")));
 
     [Fact]
     public async Task EnsureSessionAsync_Succeeds_WhenGatewayReturnsAuthenticated()
@@ -33,7 +26,7 @@ public class IBKRAdapterContractTests
         });
 
         var adapter = CreateAdapter(CreateClient(handler));
-        var act = async () => await adapter.EnsureSessionAsync();
+        var act = async () => await adapter.EnsureSessionAsync(TestCredentialId);
         await act.Should().NotThrowAsync();
     }
 
@@ -46,7 +39,7 @@ public class IBKRAdapterContractTests
         });
 
         var adapter = CreateAdapter(CreateClient(handler));
-        var act = async () => await adapter.EnsureSessionAsync();
+        var act = async () => await adapter.EnsureSessionAsync(TestCredentialId);
 
         await act.Should().ThrowAsync<BrokerAuthException>()
             .WithMessage("*not authenticated*");
@@ -61,7 +54,7 @@ public class IBKRAdapterContractTests
         });
 
         var adapter = CreateAdapter(CreateClient(handler));
-        var accountId = await adapter.GetAccountIdAsync();
+        var accountId = await adapter.GetAccountIdAsync(TestCredentialId);
 
         accountId.Should().Be("U1234567");
     }
@@ -80,7 +73,7 @@ public class IBKRAdapterContractTests
         });
 
         var adapter = CreateAdapter(CreateClient(handler));
-        var positions = await adapter.GetPositionsAsync("U1234567");
+        var positions = await adapter.GetPositionsAsync(TestCredentialId, "U1234567");
 
         positions.Should().HaveCount(2);
         positions[0].Symbol.Should().Be("AAPL");
@@ -105,7 +98,7 @@ public class IBKRAdapterContractTests
         });
 
         var adapter = CreateAdapter(CreateClient(handler));
-        var positions = await adapter.GetPositionsAsync("U1234567");
+        var positions = await adapter.GetPositionsAsync(TestCredentialId, "U1234567");
 
         positions.Should().HaveCount(2);
         positions[1].Symbol.Should().Be("EXPOPT");
@@ -114,6 +107,12 @@ public class IBKRAdapterContractTests
 }
 
 // ── Test doubles ──────────────────────────────────────────────────────────────
+
+internal sealed class StaticResolver(Uri baseUrl) : IIBeamGatewayResolver
+{
+    public string ContainerName(Guid credentialId) => $"test-ibeam-{credentialId:N}"[..20];
+    public Uri BaseUrl(Guid credentialId) => baseUrl;
+}
 
 public sealed class FakeIBKRMultiHandler(Dictionary<string, (string body, HttpStatusCode code)> responses)
     : HttpMessageHandler

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
@@ -1,8 +1,10 @@
+using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Infrastructure.Encryption;
 using FinanceSentry.Modules.BrokerageSync.Application.Commands;
 using FinanceSentry.Modules.BrokerageSync.Domain;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -13,14 +15,16 @@ public class ConnectIBKRCommandTests
 {
     private readonly Mock<IIBKRCredentialRepository> _credentialRepo = new(MockBehavior.Strict);
     private readonly Mock<ICredentialEncryptionService> _encryption = new(MockBehavior.Strict);
+    private readonly Mock<IIBeamContainerManager> _containerManager = new(MockBehavior.Strict);
+    private readonly Mock<ICommandHandler<SyncIBKRHoldingsCommand, SyncIBKRHoldingsResult>> _syncHandler = new(MockBehavior.Strict);
 
     private ConnectIBKRCommandHandler CreateHandler() =>
-        new(_credentialRepo.Object, _encryption.Object);
+        new(_credentialRepo.Object, _encryption.Object, _containerManager.Object, _syncHandler.Object);
 
     private static IBKRCredential ExistingCredential(Guid userId) =>
         new(userId, [1], [2], [3], [4], [5], [6], keyVersion: 1);
 
-    private void SetupHappyPath(Guid userId, IBKRCredential? savedInto = null)
+    private void SetupHappyPath(Guid userId, bool authResult = true)
     {
         _credentialRepo
             .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
@@ -34,6 +38,15 @@ public class ConnectIBKRCommandTests
         _credentialRepo
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(authResult);
+        _syncHandler
+            .Setup(h => h.Handle(It.IsAny<SyncIBKRHoldingsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SyncIBKRHoldingsResult(0, DateTime.UtcNow));
     }
 
     [Fact]
@@ -63,6 +76,43 @@ public class ConnectIBKRCommandTests
     }
 
     [Fact]
+    public async Task Handle_SpawnsContainerWithPlaintextCredentials()
+    {
+        var userId = Guid.NewGuid();
+        SetupHappyPath(userId);
+
+        await CreateHandler().Handle(new ConnectIBKRCommand(userId, "ibkr-user", "ibkr-pass"), default);
+
+        _containerManager.Verify(
+            m => m.SpawnAsync(It.IsAny<Guid>(), "ibkr-user", "ibkr-pass", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesSyncAfterGatewayAuthenticates()
+    {
+        var userId = Guid.NewGuid();
+        SetupHappyPath(userId);
+
+        await CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
+
+        _syncHandler.Verify(
+            h => h.Handle(It.Is<SyncIBKRHoldingsCommand>(c => c.UserId == userId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AuthTimeout_ThrowsBrokerAuthException()
+    {
+        var userId = Guid.NewGuid();
+        SetupHappyPath(userId, authResult: false);
+
+        var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
+
+        await act.Should().ThrowAsync<BrokerAuthException>();
+    }
+
+    [Fact]
     public async Task Handle_PersistsEncryptedCredentialBoundToUser()
     {
         var userId = Guid.NewGuid();
@@ -81,6 +131,15 @@ public class ConnectIBKRCommandTests
         _credentialRepo
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _syncHandler
+            .Setup(h => h.Handle(It.IsAny<SyncIBKRHoldingsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SyncIBKRHoldingsResult(0, DateTime.UtcNow));
 
         await CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
 
@@ -90,17 +149,5 @@ public class ConnectIBKRCommandTests
         saved.EncryptedUsername.Should().NotBeEmpty();
         saved.EncryptedPassword.Should().NotBeEmpty();
         saved.KeyVersion.Should().Be(1);
-    }
-
-    [Fact]
-    public async Task Handle_AccountIdDiscoveryDeferredToStage2()
-    {
-        var userId = Guid.NewGuid();
-        SetupHappyPath(userId);
-
-        var result = await CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
-
-        result.AccountId.Should().BeEmpty();
-        result.HoldingsCount.Should().Be(0);
     }
 }

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -41,8 +41,13 @@ services:
       Jwt__Issuer: "https://finance-sentry.local"
       Deduplication__MasterKeyBase64: dGVzdC1kZWR1cGxpY2F0aW9uLWtleS1jaGFuZ2UtaW4tcHJvZHVjdGlvbg==
       GOOGLEOAUTH__CLIENTID: "${GOOGLE_CLIENT_ID:-}"
-      IBKR__GatewayBaseUrl: "https://ibkr-gateway:5000"
-      IBKR__AllowSelfSignedCert: "true"
+      # Per-user IBeam orchestration
+      IBeam__Image: "voyz/ibeam:latest"
+      IBeam__Network: "docker_finance-sentry-network"
+      IBeam__ConfHostPath: "${PWD}/ibkr/conf.yaml"
+      IBeam__ContainerNamePrefix: "finance-sentry-ibkr"
+      IBeam__SpawnTimeoutSeconds: "120"
+      IBeam__DockerEndpoint: "unix:///var/run/docker.sock"
     ports:
       - "5001:5000"
     depends_on:
@@ -57,6 +62,8 @@ services:
       retries: 5
     volumes:
       - ./logs:/app/logs
+      # Docker socket for per-user IBeam container orchestration
+      - /var/run/docker.sock:/var/run/docker.sock
 
   mcp:
     build:
@@ -82,28 +89,9 @@ services:
     networks:
       - finance-sentry-network
 
-  ibkr-gateway:
-    image: voyz/ibeam:latest
-    container_name: finance-sentry-ibkr-gateway
-    restart: unless-stopped
-    environment:
-      IBEAM_ACCOUNT: ${IBKR_ACCOUNT:-}
-      IBEAM_PASSWORD: ${IBKR_PASSWORD:-}
-      IBEAM_GATEWAY_BASE_URL: "https://localhost:5000"
-      IBEAM_LOG_LEVEL: INFO
-      IBEAM_ERROR_SCREENSHOTS: "True"
-    volumes:
-      - ./ibkr/conf.yaml:/srv/inputs/conf.yaml
-    ports:
-      - "5055:5000"
-    networks:
-      - finance-sentry-network
-    healthcheck:
-      test: ["CMD", "curl", "-skf", "https://localhost:5000/v1/api/iserver/auth/status"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
+  # Per-user IBeam gateway containers are spawned dynamically by the API via
+  # Docker socket (mounted above). No shared single-tenant ibkr-gateway
+  # service — connect via POST /api/v1/brokerage/ibkr/connect to spin one up.
 
   postgres:
     image: postgres:14-alpine

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -19,6 +19,13 @@ services:
       Jwt__ExpirationMinutes: ${JWT_EXPIRATION_MINUTES:-60}
       Encryption__MasterKey: ${ENCRYPTION_MASTER_KEY}
       Encryption__KeyVersion: ${ENCRYPTION_KEY_VERSION:-1}
+      # Per-user IBeam orchestration
+      IBeam__Image: "voyz/ibeam:latest"
+      IBeam__Network: "${IBEAM_NETWORK:-docker_finance-sentry-network}"
+      IBeam__ConfHostPath: "${PWD}/ibkr/conf.yaml"
+      IBeam__ContainerNamePrefix: "finance-sentry-ibkr"
+      IBeam__SpawnTimeoutSeconds: "120"
+      IBeam__DockerEndpoint: "unix:///var/run/docker.sock"
     ports:
       - "${API_PORT:-5000}:5000"
     depends_on:
@@ -34,6 +41,8 @@ services:
       start_period: 40s
     volumes:
       - api_logs:/app/logs
+      # Docker socket for per-user IBeam container orchestration
+      - /var/run/docker.sock:/var/run/docker.sock
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Summary
Spawns one \`voyz/ibeam\` container per connected IBKR user via the Docker socket mounted in the API service. Containers are named \`finance-sentry-ibkr-{shortId}\` and joined to the shared compose network so the API resolves them by DNS.

Builds on **#225** (stage 1: encrypted credentials).

### Backend
- \`IBeamOptions\` + \`IBeamGatewayResolver\` derive container name and base URL from the credential id (shortId = first 8 chars of Guid).
- \`IBeamContainerManager\` (via \`Docker.DotNet\`) implements idempotent \`SpawnAsync\` (wipes any same-named container first), \`StopAndRemoveAsync\`, and \`WaitForAuthAsync\` that polls \`/v1/api/iserver/auth/status\`.
- \`IBrokerAdapter\` interface now takes \`credentialId\` so the impl can resolve the per-user URL. \`IBKRAdapter\` + \`IBKRGatewayClient\` updated end-to-end; base URL is passed per call, not baked into the HttpClient.
- \`ConnectIBKRCommand\`: encrypt + store creds → spawn container → wait for auth → dispatch initial holdings sync. On auth timeout throws \`BrokerAuthException\`.
- \`DisconnectIBKRCommand\`: stops + removes the user's container before deactivating the credential.

### Compose
- \`docker-compose.dev.yml\` + \`docker-compose.prod.yml\`: mount \`/var/run/docker.sock\` into the api service, set \`IBeam::*\` env vars, **drop the single-tenant \`ibkr-gateway\` service entirely** — per-user containers are spawned on connect.

### Roadmap
- ✅ **Stage 1 (#225)** — Encrypted credentials in DB.
- ✅ **Stage 2 (this)** — Docker orchestrator, adapter routing, compose wiring.
- Stage 3 — Frontend IBKR form: user + password inputs (Binance-form pattern).
- Stage 4 — Startup respawn, health checks, cleanup on disconnect.

### After merge — one-time cleanup
The old shared \`finance-sentry-ibkr-gateway\` container will still be running from before this change. \`docker stop finance-sentry-ibkr-gateway && docker rm finance-sentry-ibkr-gateway\` on dev + VPS after deploy.

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test --filter IBKR|Brokerage\` — 27/27 pass
- [ ] End-to-end: log in as test user → connect IBKR with real creds → verify a \`finance-sentry-ibkr-{shortId}\` container spawns, authenticates, and holdings sync populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)