### PR TITLE
feat(brokerage): frontend IBKR user/password form (stage 3 of 4)

### DIFF
--- a/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.html
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.html
@@ -1,8 +1,25 @@
-<div class="flex flex-col gap-cmn-6">
-  <p class="text-cmn-sm text-text-secondary">
-    The IBKR gateway sidecar holds the session for this deployment. Click connect to verify the
-    gateway is authenticated and link your IBKR account.
-  </p>
+<form [formGroup]="form" (ngSubmit)="submit()" class="flex flex-col gap-cmn-6">
+  <cmn-form-field
+    [control]="form.controls.username"
+    label="IBKR username"
+    hint="The IBKR Client Portal username. Use a paper-trading or read-only account whenever possible."
+  >
+    <cmn-input
+      formControlName="username"
+      type="text"
+      autocomplete="username"
+      placeholder="IBKR username"
+    />
+  </cmn-form-field>
+
+  <cmn-form-field [control]="form.controls.password" label="IBKR password">
+    <cmn-input
+      formControlName="password"
+      type="password"
+      autocomplete="current-password"
+      placeholder="IBKR password"
+    />
+  </cmn-form-field>
 
   @if (isDuplicateError()) {
     <cmn-alert variant="error">
@@ -17,20 +34,20 @@
     <cmn-alert variant="error">{{ store.errorMessage() }}</cmn-alert>
   }
 
-  <cmn-alert variant="accent" icon="ShieldCheck" title="Single-tenant gateway">
-    No credentials are entered here. The gateway sidecar (IBeam) authenticates with IBKR using the
-    credentials in <code>docker/.env</code>.
+  <cmn-alert variant="accent" icon="ShieldCheck" title="Per-user gateway">
+    Credentials are encrypted at rest (AES-256-GCM). A dedicated IBeam gateway container is
+    spawned for your account and holds the IBKR session privately.
   </cmn-alert>
 
   <cmn-dialog-actions align="between">
     <cmn-button (clicked)="back()" variant="secondary" icon="ArrowLeft">Back</cmn-button>
     <cmn-button
       [loading]="store.isBusy()"
-      [disabled]="store.isBusy()"
-      (clicked)="connect()"
+      [disabled]="form.invalid || store.isBusy()"
       variant="primary"
+      type="submit"
     >
       Connect IBKR
     </cmn-button>
   </cmn-dialog-actions>
-</div>
+</form>

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.spec.ts
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.spec.ts
@@ -50,15 +50,32 @@ describe('IbkrFormComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  it('connect() dispatches store.connect with the injected strategy and undefined payload', () => {
+  it('submit() dispatches store.connect with the trimmed credentials', () => {
     const store = buildConnectStore();
     const strategy = buildStrategy();
     configure(store, buildHoldingsStore(), strategy);
 
     const fixture = TestBed.createComponent(IbkrFormComponent);
-    fixture.componentInstance.connect();
+    const cmp = fixture.componentInstance;
+    cmp.form.setValue({username: '  ibkr-user  ', password: 'ibkr-pass'});
 
-    expect(store.connect).toHaveBeenCalledWith({strategy, payload: undefined});
+    cmp.submit();
+
+    expect(store.connect).toHaveBeenCalledWith({
+      strategy,
+      payload: {username: 'ibkr-user', password: 'ibkr-pass'},
+    });
+  });
+
+  it('submit() blocks and marks touched when the form is invalid', () => {
+    const store = buildConnectStore();
+    configure(store, buildHoldingsStore(), buildStrategy());
+
+    const fixture = TestBed.createComponent(IbkrFormComponent);
+    fixture.componentInstance.submit();
+
+    expect(store.connect).not.toHaveBeenCalled();
+    expect(fixture.componentInstance.form.controls.username.touched).toBe(true);
   });
 
   it('isDuplicateError flips when error code is IBKR_DUPLICATE', () => {
@@ -69,23 +86,20 @@ describe('IbkrFormComponent', () => {
     expect(fixture.componentInstance.isDuplicateError()).toBe(true);
   });
 
-  it('disconnectExisting calls holdingsStore.disconnectIBKR and resets error', () => {
+  it('disconnectExisting calls holdingsStore.disconnectIBKR, resets error, and clears the form', () => {
     const store = buildConnectStore('IBKR_DUPLICATE');
     const holdings = buildHoldingsStore();
     configure(store, holdings, buildStrategy());
 
     const fixture = TestBed.createComponent(IbkrFormComponent);
-    fixture.componentInstance.disconnectExisting();
+    const cmp = fixture.componentInstance;
+    cmp.form.setValue({username: 'x', password: 'y'});
+
+    cmp.disconnectExisting();
 
     expect(holdings.disconnectIBKR).toHaveBeenCalledOnce();
     expect(store.resetError).toHaveBeenCalledOnce();
-  });
-
-  it('renders the single-tenant gateway notice', () => {
-    configure(buildConnectStore(), buildHoldingsStore(), buildStrategy());
-
-    const fixture = TestBed.createComponent(IbkrFormComponent);
-    fixture.detectChanges();
-    expect((fixture.nativeElement as HTMLElement).textContent).toContain('gateway');
+    expect(cmp.form.controls.username.value).toBe('');
+    expect(cmp.form.controls.password.value).toBe('');
   });
 });

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.ts
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/ibkr-form.component.ts
@@ -1,5 +1,12 @@
 import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
-import {AlertComponent, ButtonComponent, DialogActionsComponent} from '@dsdevq-common/ui';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {
+  AlertComponent,
+  ButtonComponent,
+  DialogActionsComponent,
+  FormFieldComponent,
+  InputComponent,
+} from '@dsdevq-common/ui';
 
 import {HoldingsStore} from '../../../holdings/store/holdings.store';
 import {ConnectStore} from '../../store/connect/connect.store';
@@ -8,7 +15,14 @@ import {CONNECT_STRATEGY} from '../../strategies/connect-strategy.token';
 @Component({
   selector: 'fns-ibkr-form',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [AlertComponent, ButtonComponent, DialogActionsComponent],
+  imports: [
+    AlertComponent,
+    ButtonComponent,
+    DialogActionsComponent,
+    FormFieldComponent,
+    InputComponent,
+    ReactiveFormsModule,
+  ],
   templateUrl: './ibkr-form.component.html',
 })
 export class IbkrFormComponent {
@@ -17,10 +31,23 @@ export class IbkrFormComponent {
 
   public readonly store = inject(ConnectStore);
 
+  public readonly form = new FormGroup({
+    username: new FormControl<string>('', {nonNullable: true, validators: [Validators.required]}),
+    password: new FormControl<string>('', {nonNullable: true, validators: [Validators.required]}),
+  });
+
   public readonly isDuplicateError = computed(() => this.store.errorCode() === 'IBKR_DUPLICATE');
 
-  public connect(): void {
-    this.store.connect({strategy: this.strategy, payload: undefined});
+  public submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    const {username, password} = this.form.getRawValue();
+    this.store.connect({
+      strategy: this.strategy,
+      payload: {username: username.trim(), password},
+    });
   }
 
   public back(): void {
@@ -30,5 +57,6 @@ export class IbkrFormComponent {
   public disconnectExisting(): void {
     this.holdingsStore?.disconnectIBKR();
     this.store.resetError();
+    this.form.reset({username: '', password: ''});
   }
 }

--- a/frontend/src/app/modules/bank-sync/models/ibkr/ibkr.model.ts
+++ b/frontend/src/app/modules/bank-sync/models/ibkr/ibkr.model.ts
@@ -1,8 +1,12 @@
 /**
- * Single-tenant IBKR connect: the gateway sidecar (IBeam) holds the session,
- * so the connect endpoint takes no body. The frontend ignores the response
- * payload — the success outcome is signalled by the 201 Created status.
+ * Per-user IBKR connect: username + password are POSTed and encrypted at rest.
+ * The backend then spawns a per-user IBeam gateway container using them.
  */
+export interface ConnectIBKRRequest {
+  username: string;
+  password: string;
+}
+
 export interface ConnectIBKRResponse {
   accountId: string;
   holdingsCount: number;

--- a/frontend/src/app/modules/bank-sync/services/ibkr.service.ts
+++ b/frontend/src/app/modules/bank-sync/services/ibkr.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {ApiService} from '@dsdevq-common/core';
 import {type Observable} from 'rxjs';
 
-import {type ConnectIBKRResponse} from '../models/ibkr/ibkr.model';
+import {type ConnectIBKRRequest, type ConnectIBKRResponse} from '../models/ibkr/ibkr.model';
 
 @Injectable({providedIn: 'root'})
 export class IBKRService extends ApiService {
@@ -10,8 +10,8 @@ export class IBKRService extends ApiService {
     super('brokerage/ibkr');
   }
 
-  public connect(): Observable<ConnectIBKRResponse> {
-    return this.post<ConnectIBKRResponse>('connect');
+  public connect(payload: ConnectIBKRRequest): Observable<ConnectIBKRResponse> {
+    return this.post<ConnectIBKRResponse>('connect', payload);
   }
 
   public disconnect(): Observable<void> {

--- a/frontend/src/app/modules/bank-sync/strategies/ibkr.strategy.spec.ts
+++ b/frontend/src/app/modules/bank-sync/strategies/ibkr.strategy.spec.ts
@@ -17,16 +17,19 @@ describe('IbkrConnectStrategy', () => {
     strategy = TestBed.inject(IbkrConnectStrategy);
   });
 
-  it('calls IBKRService.connect with no arguments (single-tenant gateway)', () => {
+  it('forwards the username/password payload to IBKRService.connect', () => {
     ibkr.connect.mockReturnValue(of({holdingsCount: 4, accountId: 'DU123', connectedAt: 'now'}));
-    strategy.submit().subscribe();
-    expect(ibkr.connect).toHaveBeenCalledWith();
+    const payload = {username: 'ibkr-user', password: 'ibkr-pass'};
+
+    strategy.submit(payload).subscribe();
+
+    expect(ibkr.connect).toHaveBeenCalledWith(payload);
   });
 
   it('maps the holdingsCount into a broker/POLLING outcome', () => {
     ibkr.connect.mockReturnValue(of({holdingsCount: 4, accountId: 'DU123', connectedAt: 'now'}));
     let outcome: unknown;
-    strategy.submit().subscribe(o => (outcome = o));
+    strategy.submit({username: 'u', password: 'p'}).subscribe(o => (outcome = o));
     expect(outcome).toEqual({successCode: 'POLLING', count: 4, institutionType: 'broker'});
   });
 

--- a/frontend/src/app/modules/bank-sync/strategies/ibkr.strategy.ts
+++ b/frontend/src/app/modules/bank-sync/strategies/ibkr.strategy.ts
@@ -3,6 +3,7 @@ import {map, type Observable} from 'rxjs';
 
 import {type Provider} from '../../../shared/models/provider/provider.model';
 import {IbkrFormComponent} from '../components/connect-modal/ibkr-form.component';
+import {type ConnectIBKRRequest} from '../models/ibkr/ibkr.model';
 import {IBKRService} from '../services/ibkr.service';
 import {type ConnectOutcome, type ConnectStrategy} from './connect-strategy';
 
@@ -13,8 +14,9 @@ export class IbkrConnectStrategy implements ConnectStrategy {
   public readonly slug: Provider = 'ibkr';
   public readonly formComponent: Type<unknown> = IbkrFormComponent;
 
-  public submit(): Observable<ConnectOutcome> {
-    return this.ibkr.connect().pipe(
+  public submit(input: unknown): Observable<ConnectOutcome> {
+    const payload = input as ConnectIBKRRequest;
+    return this.ibkr.connect(payload).pipe(
       map(response => ({
         successCode: 'POLLING' as const,
         count: response.holdingsCount,


### PR DESCRIPTION
## Summary
Replaces the old \"no credentials\" notice on the IBKR connect form with real user/password inputs. Wires the payload end-to-end through service → strategy → backend command (which lives in **#226**).

### Frontend changes
- \`ConnectIBKRRequest\` now carries \`{ username, password }\`; \`IBKRService.connect\` POSTs the payload.
- \`IbkrConnectStrategy.submit(input)\` forwards \`input\` to the service.
- \`IbkrFormComponent\` mirrors the Binance form pattern: \`FormGroup\` with required \`username\` + \`password\`, \`submit()\` trims the username and dispatches, \`disconnectExisting()\` clears the fields.
- Copy updated: form title/description explains the per-user gateway model.

### Test coverage
- Strategy: payload forwarding + broker/POLLING outcome mapping.
- Form component: valid-submit dispatch, invalid-form blocking, disconnect clears form.

Builds on **#226** (stage 2 — Docker orchestrator).

## Test plan
- [x] \`npx eslint\` clean on all touched files
- [x] Form tests written (Vitest)
- [ ] After deploy: connect flow shows the form, submitting spawns a container and holdings sync populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)