### PR TITLE
feat(brokerage): IBeam lifecycle + recovery (stage 4 of 4)

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/BrokerageSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/BrokerageSyncModule.cs
@@ -26,8 +26,12 @@ public static class BrokerageSyncModule
     {
         public void RegisterJobs(IServiceProvider sp)
         {
-            sp.GetRequiredService<IRecurringJobManager>()
-                .AddOrUpdate<IBKRSyncJob>("ibkr-sync", job => job.ExecuteAsync(), "*/15 * * * *");
+            var mgr = sp.GetRequiredService<IRecurringJobManager>();
+            mgr.AddOrUpdate<IBKRSyncJob>("ibkr-sync", job => job.ExecuteAsync(), "*/15 * * * *");
+            mgr.AddOrUpdate<IBeamHealthCheckJob>(
+                "ibeam-health-check",
+                job => job.ExecuteAsync(CancellationToken.None),
+                "*/5 * * * *");
         }
     }
 
@@ -62,7 +66,11 @@ public static class BrokerageSyncModule
         services.AddScoped<IIBKRCredentialRepository, IBKRCredentialRepository>();
         services.AddScoped<IBrokerageHoldingRepository, BrokerageHoldingRepository>();
         services.AddScoped<IBrokerageHoldingsReader, BrokerageHoldingsReader>();
+        services.AddScoped<IIBeamReconciler, IBeamReconciler>();
         services.AddScoped<IBKRSyncJob>();
+        services.AddScoped<IBeamHealthCheckJob>();
+
+        services.AddHostedService<IBeamStartupReconcilerHostedService>();
 
         services.AddSingleton<IJobRegistrar, JobRegistrar>();
 

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
@@ -89,6 +89,21 @@ public sealed class IBeamContainerManager : IIBeamContainerManager
         await RemoveIfExistsAsync(containerName, ct);
     }
 
+    public async Task<bool> IsRunningAsync(Guid credentialId, CancellationToken ct = default)
+    {
+        var containerName = _resolver.ContainerName(credentialId);
+        var containers = await _docker.Containers.ListContainersAsync(new ContainersListParameters
+        {
+            All = true,
+            Filters = new Dictionary<string, IDictionary<string, bool>>
+            {
+                ["name"] = new Dictionary<string, bool> { [containerName] = true },
+            },
+        }, ct);
+
+        return containers.Any(c => string.Equals(c.State, "running", StringComparison.OrdinalIgnoreCase));
+    }
+
     public async Task<bool> WaitForAuthAsync(Guid credentialId, CancellationToken ct = default)
     {
         var baseUrl = _resolver.BaseUrl(credentialId);

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamReconciler.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamReconciler.cs
@@ -1,0 +1,59 @@
+using FinanceSentry.Infrastructure.Encryption;
+using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+public sealed class IBeamReconciler(
+    IIBKRCredentialRepository credentialRepository,
+    IIBeamContainerManager containerManager,
+    ICredentialEncryptionService encryption,
+    ILogger<IBeamReconciler> logger) : IIBeamReconciler
+{
+    public async Task ReconcileAllAsync(CancellationToken ct = default)
+    {
+        var credentials = await credentialRepository.GetAllActiveAsync(ct);
+
+        foreach (var credential in credentials)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (await containerManager.IsRunningAsync(credential.Id, ct))
+                {
+                    logger.LogDebug(
+                        "IBeam container for credential {CredentialId} already running — skipping.",
+                        credential.Id);
+                    continue;
+                }
+
+                var username = encryption.Decrypt(
+                    credential.EncryptedUsername,
+                    credential.UsernameIv,
+                    credential.UsernameAuthTag,
+                    credential.KeyVersion);
+                var password = encryption.Decrypt(
+                    credential.EncryptedPassword,
+                    credential.PasswordIv,
+                    credential.PasswordAuthTag,
+                    credential.KeyVersion);
+
+                logger.LogInformation(
+                    "Reconciling: spawning IBeam container for credential {CredentialId}.",
+                    credential.Id);
+                await containerManager.SpawnAsync(credential.Id, username, password, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Failed to reconcile IBeam container for credential {CredentialId}.",
+                    credential.Id);
+            }
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamStartupReconcilerHostedService.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamStartupReconcilerHostedService.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Runs the IBeam reconciler once shortly after the API comes up so every
+/// active credential has its per-user gateway container running again — even
+/// after a full compose down/up.
+/// </summary>
+public sealed class IBeamStartupReconcilerHostedService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<IBeamStartupReconcilerHostedService> logger) : BackgroundService
+{
+    // Small delay so DB migrations + Hangfire setup finish before we touch
+    // credentials.
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(StartupDelay, stoppingToken);
+
+            using var scope = scopeFactory.CreateScope();
+            var reconciler = scope.ServiceProvider.GetRequiredService<IIBeamReconciler>();
+            await reconciler.ReconcileAllAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Shutting down before the startup reconcile finished — fine.
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "IBeam startup reconciliation failed.");
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamContainerManager.cs
@@ -27,4 +27,11 @@ public interface IIBeamContainerManager
     /// timeout is reached. Returns true on success, false on timeout.
     /// </summary>
     Task<bool> WaitForAuthAsync(Guid credentialId, CancellationToken ct = default);
+
+    /// <summary>
+    /// True when a container with the user's target name exists AND is
+    /// currently running. False if it is missing, exited, or in any other
+    /// non-running state.
+    /// </summary>
+    Task<bool> IsRunningAsync(Guid credentialId, CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamReconciler.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IIBeamReconciler.cs
@@ -1,0 +1,11 @@
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+
+/// <summary>
+/// Walks every active IBKR credential and ensures its per-user IBeam container
+/// is running. Used both at API startup and on a periodic Hangfire schedule so
+/// containers survive Docker restarts, crashes, and API restarts.
+/// </summary>
+public interface IIBeamReconciler
+{
+    Task ReconcileAllAsync(CancellationToken ct = default);
+}

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/Jobs/IBeamHealthCheckJob.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/Jobs/IBeamHealthCheckJob.cs
@@ -1,0 +1,29 @@
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.Jobs;
+
+/// <summary>
+/// Recurring Hangfire job that runs the IBeam reconciler so any per-user
+/// gateway container which has died, been removed, or is otherwise not
+/// running gets respawned.
+/// </summary>
+public sealed class IBeamHealthCheckJob(
+    IIBeamReconciler reconciler,
+    ILogger<IBeamHealthCheckJob> logger)
+{
+    [AutomaticRetry(Attempts = 0)]
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await reconciler.ReconcileAllAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "IBeam health-check reconciliation failed.");
+            throw;
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBeamReconcilerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBeamReconcilerTests.cs
@@ -1,0 +1,99 @@
+using FinanceSentry.Infrastructure.Encryption;
+using FinanceSentry.Modules.BrokerageSync.Domain;
+using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace FinanceSentry.Tests.Unit.BrokerageSync;
+
+public class IBeamReconcilerTests
+{
+    private readonly Mock<IIBKRCredentialRepository> _repo = new(MockBehavior.Strict);
+    private readonly Mock<IIBeamContainerManager> _containerManager = new(MockBehavior.Strict);
+    private readonly Mock<ICredentialEncryptionService> _encryption = new(MockBehavior.Strict);
+
+    private IBeamReconciler CreateSut() =>
+        new(_repo.Object, _containerManager.Object, _encryption.Object, NullLogger<IBeamReconciler>.Instance);
+
+    private static IBKRCredential MakeCredential() =>
+        new(Guid.NewGuid(), [1], [2], [3], [4], [5], [6], keyVersion: 1);
+
+    [Fact]
+    public async Task ReconcileAllAsync_SkipsRunningContainers()
+    {
+        var credential = MakeCredential();
+        _repo.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync([credential]);
+        _containerManager
+            .Setup(m => m.IsRunningAsync(credential.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await CreateSut().ReconcileAllAsync(default);
+
+        _containerManager.Verify(
+            m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _encryption.Verify(e => e.Decrypt(It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileAllAsync_DecryptsAndSpawns_WhenContainerNotRunning()
+    {
+        var credential = MakeCredential();
+        _repo.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>())).ReturnsAsync([credential]);
+        _containerManager
+            .Setup(m => m.IsRunningAsync(credential.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _encryption
+            .Setup(e => e.Decrypt(credential.EncryptedUsername, credential.UsernameIv, credential.UsernameAuthTag, 1))
+            .Returns("user1");
+        _encryption
+            .Setup(e => e.Decrypt(credential.EncryptedPassword, credential.PasswordIv, credential.PasswordAuthTag, 1))
+            .Returns("pw1");
+        _containerManager
+            .Setup(m => m.SpawnAsync(credential.Id, "user1", "pw1", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await CreateSut().ReconcileAllAsync(default);
+
+        _containerManager.Verify(
+            m => m.SpawnAsync(credential.Id, "user1", "pw1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ReconcileAllAsync_ContinuesAfterFailure_OnFollowingCredentials()
+    {
+        var failing = MakeCredential();
+        var succeeding = MakeCredential();
+        _repo.Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([failing, succeeding]);
+
+        _containerManager
+            .Setup(m => m.IsRunningAsync(failing.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _encryption
+            .Setup(e => e.Decrypt(failing.EncryptedUsername, failing.UsernameIv, failing.UsernameAuthTag, 1))
+            .Throws(new InvalidOperationException("decrypt fail"));
+
+        _containerManager
+            .Setup(m => m.IsRunningAsync(succeeding.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _encryption
+            .Setup(e => e.Decrypt(succeeding.EncryptedUsername, succeeding.UsernameIv, succeeding.UsernameAuthTag, 1))
+            .Returns("user2");
+        _encryption
+            .Setup(e => e.Decrypt(succeeding.EncryptedPassword, succeeding.PasswordIv, succeeding.PasswordAuthTag, 1))
+            .Returns("pw2");
+        _containerManager
+            .Setup(m => m.SpawnAsync(succeeding.Id, "user2", "pw2", It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await CreateSut().ReconcileAllAsync(default);
+
+        _containerManager.Verify(
+            m => m.SpawnAsync(succeeding.Id, "user2", "pw2", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
Final stage of the per-user IBKR rollout. Ensures per-user IBeam containers survive Docker restarts, host reboots, and API redeploys — without manual intervention.

Builds on **#227** (stage 3 — frontend form).

### Container manager
- \`IIBeamContainerManager\` gains \`IsRunningAsync(credentialId)\` so callers can cheaply distinguish \"running\" from \"exists but stopped\" or \"missing\".

### Reconciler (\`IBeamReconciler\`)
- Walks every active \`IBKRCredential\`, skips containers already running, decrypts the stored username/password via \`ICredentialEncryptionService\`, and calls \`SpawnAsync\`.
- Failures on one credential are logged and swallowed so they don't block the rest.

### Startup
- \`IBeamStartupReconcilerHostedService\` (\`BackgroundService\`) waits 15s after API bootstrap (past DB migrations + Hangfire wiring), then runs the reconciler once. After \`docker compose down/up\`, every user's gateway is back automatically.

### Periodic health check
- \`IBeamHealthCheckJob\`: Hangfire recurring job on \`*/5 * * * *\`. Same reconciler under the hood — any container the daemon killed between checks gets respawned within five minutes.

### Test coverage
- \`IBeamReconcilerTests\`: skip-when-running, decrypt-then-spawn-when-not-running, continue-after-single-credential-failure.

### Complete IBKR rollout
- ✅ **Stage 1 (#225)** — Encrypted credentials in DB.
- ✅ **Stage 2 (#226)** — Docker orchestrator + adapter routing + compose wiring.
- ✅ **Stage 3 (#227)** — Frontend user/password form.
- ✅ **Stage 4 (this)** — Startup respawn, periodic health check, cleanup.

## Test plan
- [x] \`dotnet build\` — 0 warnings, 0 errors
- [x] \`dotnet test --filter IBKR|Brokerage|IBeam\` — 30/30 pass
- [ ] After deploy: restart docker compose, verify user's IBeam container respawns automatically within ~30s; stop a user's container manually, verify Hangfire respawns within 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)