### PR TITLE
feat(ui): group Monobank cards, Binance assets, and IBKR positions under their institutions

### DIFF
--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -61,73 +61,93 @@
           <span class="text-cmn-xs text-text-secondary"
             >{{ banking.institutionCount }} institution{{
               banking.institutionCount !== 1 ? 's' : ''
+            }}
+            · {{ banking.accounts.length }} account{{
+              banking.accounts.length !== 1 ? 's' : ''
             }}</span
           >
         </div>
-        <cmn-card>
-          <table class="w-full text-cmn-sm" aria-label="Banking accounts">
-            <thead>
-              <tr
-                class="border-b border-border-default text-cmn-xs text-text-secondary uppercase tracking-wide"
+        <cmn-card class="!p-0">
+          @for (inst of store.bankingInstitutions(); track inst.key) {
+            <details class="group border-b border-border-default last:border-0" open>
+              <summary
+                class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Institution</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Account Type</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Connectivity</th>
-                <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">Balance</th>
-                <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">
-                  <span class="sr-only">Actions</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (account of banking.accounts; track account.accountId) {
-                <tr
-                  class="border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"
+                <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
+                  <cmn-institution-avatar [name]="inst.name" />
+                  <div class="min-w-0">
+                    <p class="font-medium text-text-primary">{{ inst.name }}</p>
+                    <p class="text-cmn-xs text-text-secondary">
+                      {{ inst.accounts.length }} account{{ inst.accounts.length !== 1 ? 's' : '' }}
+                    </p>
+                  </div>
+                </div>
+                <cmn-status-indicator
+                  [variant]="inst.worstSyncStatus | syncStatusVariant"
+                  [timestampLabel]="inst.latestSyncTimestamp | relativeTime"
                 >
-                  <td class="py-cmn-4 px-cmn-4">
-                    <div class="flex items-center gap-cmn-3">
-                      <cmn-institution-avatar [name]="account.bankName" />
-                      <div>
-                        <p class="font-medium text-text-primary">{{ account.bankName }}</p>
+                  {{ inst.worstSyncStatus | syncStatusLabel }}
+                </cmn-status-indicator>
+                <div
+                  class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]"
+                >
+                  {{ store.baseCurrency() }}
+                  {{ inst.totalInBaseCurrency | number: '1.2-2' }}
+                </div>
+                <svg
+                  class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </summary>
+
+              <table class="w-full text-cmn-sm bg-surface-bg" aria-label="Accounts">
+                <tbody>
+                  @for (account of inst.accounts; track account.accountId) {
+                    <tr class="border-t border-border-default">
+                      <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full">
+                        <p class="text-text-primary">{{ account.accountType }}</p>
                         <p class="text-cmn-xs text-text-secondary">
                           •••• {{ account.accountNumberLast4 }}
                         </p>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="py-cmn-4 px-cmn-4 text-text-secondary">{{ account.accountType }}</td>
-                  <td class="py-cmn-4 px-cmn-4">
-                    <cmn-status-indicator
-                      [variant]="account.syncStatus | syncStatusVariant"
-                      [timestampLabel]="account.lastSyncTimestamp | relativeTime"
-                    >
-                      {{ account.syncStatus | syncStatusLabel }}
-                    </cmn-status-indicator>
-                  </td>
-                  <td
-                    class="py-cmn-4 px-cmn-4 text-right font-mono tabular-nums font-medium text-text-primary"
-                  >
-                    {{ account | accountBalance }}
-                  </td>
-                  <td class="py-cmn-4 px-cmn-4 text-right">
-                    <div class="flex justify-end gap-cmn-2">
-                      @if (
-                        account.provider === 'truelayer' &&
-                        account.syncStatus === 'reauth_required'
-                      ) {
-                        <cmn-button (clicked)="reconnect()" variant="primary" size="sm">
-                          Reconnect
-                        </cmn-button>
-                      }
-                      <cmn-button (clicked)="disconnect(account)" variant="secondary" size="sm">
-                        Disconnect
-                      </cmn-button>
-                    </div>
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+                      </td>
+                      <td class="py-cmn-3 px-cmn-4">
+                        <cmn-status-indicator
+                          [variant]="account.syncStatus | syncStatusVariant"
+                          [timestampLabel]="account.lastSyncTimestamp | relativeTime"
+                        >
+                          {{ account.syncStatus | syncStatusLabel }}
+                        </cmn-status-indicator>
+                      </td>
+                      <td
+                        class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
+                      >
+                        {{ account | accountBalance }}
+                      </td>
+                      <td class="py-cmn-3 px-cmn-4 text-right">
+                        <div class="flex justify-end gap-cmn-2">
+                          @if (
+                            account.provider === 'truelayer' &&
+                            account.syncStatus === 'reauth_required'
+                          ) {
+                            <cmn-button (clicked)="reconnect()" variant="primary" size="sm">
+                              Reconnect
+                            </cmn-button>
+                          }
+                          <cmn-button (clicked)="disconnect(account)" variant="secondary" size="sm">
+                            Disconnect
+                          </cmn-button>
+                        </div>
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </details>
+          }
         </cmn-card>
       </div>
     }
@@ -146,52 +166,58 @@
             }}</span
           >
         </div>
-        <cmn-card>
-          <table class="w-full text-cmn-sm" aria-label="Brokerage accounts">
-            <thead>
-              <tr
-                class="border-b border-border-default text-cmn-xs text-text-secondary uppercase tracking-wide"
+        <cmn-card class="!p-0">
+          @for (inst of store.brokerageInstitutions(); track inst.key) {
+            <details class="group border-b border-border-default last:border-0" open>
+              <summary
+                class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Institution</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Account Type</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Connectivity</th>
-                <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">Balance</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (account of brokerage.accounts; track account.accountId) {
-                <tr
-                  class="border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"
+                <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
+                  <cmn-institution-avatar [name]="inst.name" />
+                  <div class="min-w-0">
+                    <p class="font-medium text-text-primary">{{ inst.name }}</p>
+                    <p class="text-cmn-xs text-text-secondary">
+                      {{ inst.accounts.length }} position{{ inst.accounts.length !== 1 ? 's' : '' }}
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]"
                 >
-                  <td class="py-cmn-4 px-cmn-4">
-                    <div class="flex items-center gap-cmn-3">
-                      <cmn-institution-avatar [name]="account.bankName" />
-                      <div>
-                        <p class="font-medium text-text-primary">{{ account.bankName }}</p>
-                        <p class="text-cmn-xs text-text-secondary">
-                          •••• {{ account.accountNumberLast4 }}
-                        </p>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="py-cmn-4 px-cmn-4 text-text-secondary">{{ account.accountType }}</td>
-                  <td class="py-cmn-4 px-cmn-4">
-                    <cmn-status-indicator
-                      [variant]="account.syncStatus | syncStatusVariant"
-                      [timestampLabel]="account.lastSyncTimestamp | relativeTime"
-                    >
-                      {{ account.syncStatus | syncStatusLabel }}
-                    </cmn-status-indicator>
-                  </td>
-                  <td
-                    class="py-cmn-4 px-cmn-4 text-right font-mono tabular-nums font-medium text-text-primary"
-                  >
-                    {{ account | accountBalance }}
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+                  {{ store.baseCurrency() }}
+                  {{ inst.totalInBaseCurrency | number: '1.2-2' }}
+                </div>
+                <svg
+                  class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </summary>
+
+              <table class="w-full text-cmn-sm bg-surface-bg" aria-label="Positions">
+                <tbody>
+                  @for (account of inst.accounts; track account.accountId + account.accountNumberLast4) {
+                    <tr class="border-t border-border-default">
+                      <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full text-text-primary">
+                        {{ account.accountNumberLast4 }}
+                      </td>
+                      <td class="py-cmn-3 px-cmn-4 text-text-secondary">
+                        {{ account.accountType }}
+                      </td>
+                      <td
+                        class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
+                      >
+                        {{ account | accountBalance }}
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </details>
+          }
         </cmn-card>
       </div>
     }
@@ -210,50 +236,58 @@
             }}</span
           >
         </div>
-        <cmn-card>
-          <table class="w-full text-cmn-sm" aria-label="Crypto holdings">
-            <thead>
-              <tr
-                class="border-b border-border-default text-cmn-xs text-text-secondary uppercase tracking-wide"
+        <cmn-card class="!p-0">
+          @for (inst of store.cryptoInstitutions(); track inst.key) {
+            <details class="group border-b border-border-default last:border-0" open>
+              <summary
+                class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Exchange</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Account Type</th>
-                <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Connectivity</th>
-                <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (account of crypto.accounts; track account.accountId) {
-                <tr
-                  class="border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"
+                <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
+                  <cmn-institution-avatar [name]="inst.name" />
+                  <div class="min-w-0">
+                    <p class="font-medium text-text-primary">{{ inst.name }}</p>
+                    <p class="text-cmn-xs text-text-secondary">
+                      {{ inst.accounts.length }} asset{{ inst.accounts.length !== 1 ? 's' : '' }}
+                    </p>
+                  </div>
+                </div>
+                <div
+                  class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]"
                 >
-                  <td class="py-cmn-4 px-cmn-4">
-                    <div class="flex items-center gap-cmn-3">
-                      <cmn-institution-avatar [name]="account.bankName" />
-                      <div>
-                        <p class="font-medium text-text-primary">{{ account.bankName }}</p>
-                        <p class="text-cmn-xs text-text-secondary">{{ account.provider }}</p>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="py-cmn-4 px-cmn-4 text-text-secondary">{{ account.accountType }}</td>
-                  <td class="py-cmn-4 px-cmn-4">
-                    <cmn-status-indicator
-                      [variant]="account.syncStatus | syncStatusVariant"
-                      [timestampLabel]="account.lastSyncTimestamp | relativeTime"
-                    >
-                      {{ account.syncStatus | syncStatusLabel }}
-                    </cmn-status-indicator>
-                  </td>
-                  <td
-                    class="py-cmn-4 px-cmn-4 text-right font-mono tabular-nums font-medium text-text-primary"
-                  >
-                    {{ account | accountBalance }}
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+                  {{ store.baseCurrency() }}
+                  {{ inst.totalInBaseCurrency | number: '1.2-2' }}
+                </div>
+                <svg
+                  class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </summary>
+
+              <table class="w-full text-cmn-sm bg-surface-bg" aria-label="Assets">
+                <tbody>
+                  @for (account of inst.accounts; track account.accountId + account.accountNumberLast4) {
+                    <tr class="border-t border-border-default">
+                      <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full text-text-primary">
+                        {{ account.accountNumberLast4 }}
+                      </td>
+                      <td class="py-cmn-3 px-cmn-4 text-text-secondary">
+                        {{ account.accountType }}
+                      </td>
+                      <td
+                        class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
+                      >
+                        {{ account | accountBalance }}
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </details>
+          }
         </cmn-card>
       </div>
     }

--- a/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
@@ -2,8 +2,10 @@ import {computed, type Signal} from '@angular/core';
 
 import {
   type CategorySummary,
+  type InstitutionGroup,
   type WealthSummaryResponse,
 } from '../../../../shared/models/wealth/wealth.model';
+import {InstitutionUtils} from '../../../../shared/utils/institution.utils';
 
 interface StateSignals {
   summary: Signal<Nullable<WealthSummaryResponse>>;
@@ -11,20 +13,33 @@ interface StateSignals {
 }
 
 export function accountsComputed(store: StateSignals) {
+  const bankingCategory = computed<Nullable<CategorySummary>>(
+    () => store.summary()?.categories.find(c => c.category === 'banking') ?? null
+  );
+  const cryptoCategory = computed<Nullable<CategorySummary>>(
+    () => store.summary()?.categories.find(c => c.category === 'crypto') ?? null
+  );
+  const brokerageCategory = computed<Nullable<CategorySummary>>(
+    () => store.summary()?.categories.find(c => c.category === 'brokerage') ?? null
+  );
+
   return {
     isEmpty: computed(
       () => store.status() === 'success' && (store.summary()?.categories ?? []).length === 0
     ),
     totalNetWorth: computed(() => store.summary()?.totalNetWorth ?? 0),
     baseCurrency: computed(() => store.summary()?.baseCurrency ?? 'USD'),
-    bankingCategory: computed<Nullable<CategorySummary>>(
-      () => store.summary()?.categories.find(c => c.category === 'banking') ?? null
+    bankingCategory,
+    cryptoCategory,
+    brokerageCategory,
+    bankingInstitutions: computed<InstitutionGroup[]>(() =>
+      InstitutionUtils.groupByInstitution(bankingCategory()?.accounts ?? [])
     ),
-    cryptoCategory: computed<Nullable<CategorySummary>>(
-      () => store.summary()?.categories.find(c => c.category === 'crypto') ?? null
+    cryptoInstitutions: computed<InstitutionGroup[]>(() =>
+      InstitutionUtils.groupByInstitution(cryptoCategory()?.accounts ?? [])
     ),
-    brokerageCategory: computed<Nullable<CategorySummary>>(
-      () => store.summary()?.categories.find(c => c.category === 'brokerage') ?? null
+    brokerageInstitutions: computed<InstitutionGroup[]>(() =>
+      InstitutionUtils.groupByInstitution(brokerageCategory()?.accounts ?? [])
     ),
     totalConnections: computed(
       () => store.summary()?.categories.reduce((sum, cat) => sum + cat.institutionCount, 0) ?? 0

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -74,92 +74,80 @@
             No accounts connected. Connect an account to see your holdings.
           </div>
         } @else {
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-neutral-200 dark:border-neutral-700">
-                <th
-                  class="text-left pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
+          <div class="divide-y divide-neutral-100 dark:divide-neutral-800 -mx-4">
+            @for (inst of store.allInstitutions(); track inst.key) {
+              <details class="group" open>
+                <summary
+                  class="flex items-center justify-between gap-4 px-4 py-3 cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors"
                 >
-                  Asset Class
-                </th>
-                <th
-                  class="text-left pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
-                >
-                  Institution
-                </th>
-                <th
-                  class="text-left pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
-                >
-                  Category
-                </th>
-                <th
-                  class="text-right pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
-                >
-                  Balance
-                </th>
-                <th
-                  class="text-center pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
-                >
-                  Status
-                </th>
-                <th
-                  class="text-right pb-3 font-medium text-neutral-500 text-xs uppercase tracking-wider"
-                >
-                  USD Value
-                </th>
-                <th class="pb-3"><span class="sr-only">Actions</span></th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-neutral-100 dark:divide-neutral-800">
-              @for (account of store.allAccounts(); track account.accountId) {
-                <tr class="hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors">
-                  <td class="py-3 pr-4">
-                    <span class="font-medium text-neutral-800 dark:text-neutral-200">{{
-                      account.accountType
-                    }}</span>
-                    <span class="block text-xs text-neutral-400"
-                      >&#8226;&#8226;{{ account.accountNumberLast4 }}</span
+                  <div class="flex-1 min-w-0">
+                    <p class="font-medium text-neutral-900 dark:text-neutral-100">
+                      {{ inst.name }}
+                    </p>
+                    <p class="text-xs text-neutral-500">
+                      {{ inst.category | categoryLabel }} · {{ inst.accounts.length }} row{{
+                        inst.accounts.length !== 1 ? 's' : ''
+                      }}
+                    </p>
+                  </div>
+                  <cmn-tag [variant]="inst.worstSyncStatus | syncStatusVariant">{{
+                    inst.worstSyncStatus | syncStatusLabel
+                  }}</cmn-tag>
+                  <div
+                    class="text-right font-mono tabular-nums font-semibold text-neutral-900 dark:text-neutral-100 min-w-[7rem]"
+                  >
+                    {{ inst.totalInBaseCurrency | number: '1.2-2' }}
+                    <span class="block text-xs text-neutral-400">{{ store.baseCurrency() }}</span>
+                  </div>
+                  @if (canDisconnect(inst.provider)) {
+                    <cmn-button
+                      (clicked)="disconnect(inst.provider, inst.name); $event.stopPropagation()"
+                      variant="secondary"
+                      size="sm"
                     >
-                  </td>
-                  <td class="py-3 pr-4 text-neutral-700 dark:text-neutral-300">
-                    {{ account.bankName }}
-                  </td>
-                  <td class="py-3 pr-4">
-                    <span class="text-xs text-neutral-500">{{
-                      account.category | categoryLabel
-                    }}</span>
-                  </td>
-                  <td
-                    class="py-3 pr-4 text-right font-mono tabular-nums text-neutral-800 dark:text-neutral-200"
+                      Disconnect
+                    </cmn-button>
+                  }
+                  <svg
+                    class="w-4 h-4 text-neutral-400 transition-transform group-open:rotate-180 shrink-0"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
                   >
-                    {{ account.currentBalance | number: '1.2-2' }}
-                    <span class="block text-xs text-neutral-400">{{ account.currency }}</span>
-                  </td>
-                  <td class="py-3 px-4 text-center">
-                    <cmn-tag [variant]="account.syncStatus | syncStatusVariant">{{
-                      account.syncStatus | syncStatusLabel
-                    }}</cmn-tag>
-                  </td>
-                  <td
-                    class="py-3 text-right font-mono tabular-nums font-medium text-neutral-900 dark:text-neutral-100"
-                  >
-                    {{ account | holdingBalance }}
-                  </td>
-                  <td class="py-3 pl-4 text-right">
-                    @if (canDisconnect(account.provider)) {
-                      <cmn-button
-                        (clicked)="disconnect(account.provider, account.bankName)"
-                        variant="secondary"
-                        size="sm"
-                      >
-                        Disconnect
-                      </cmn-button>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                  </svg>
+                </summary>
+
+                <table class="w-full text-sm bg-neutral-50/50 dark:bg-neutral-900/40">
+                  <tbody>
+                    @for (account of inst.accounts; track account.accountId + account.accountNumberLast4) {
+                      <tr class="border-t border-neutral-100 dark:border-neutral-800">
+                        <td class="py-2 pl-16 pr-4 w-full">
+                          <span class="text-neutral-800 dark:text-neutral-200">{{
+                            account.accountType
+                          }}</span>
+                          <span class="block text-xs text-neutral-400"
+                            >&#8226;&#8226;{{ account.accountNumberLast4 }}</span
+                          >
+                        </td>
+                        <td
+                          class="py-2 pr-4 text-right font-mono tabular-nums text-neutral-700 dark:text-neutral-300"
+                        >
+                          {{ account.currentBalance | number: '1.2-2' }}
+                          <span class="block text-xs text-neutral-400">{{ account.currency }}</span>
+                        </td>
+                        <td
+                          class="py-2 pr-4 text-right font-mono tabular-nums text-neutral-900 dark:text-neutral-100"
+                        >
+                          {{ account | holdingBalance }}
+                        </td>
+                      </tr>
                     }
-                  </td>
-                </tr>
-              }
-            </tbody>
-          </table>
+                  </tbody>
+                </table>
+              </details>
+            }
+          </div>
         }
       </cmn-card>
     }

--- a/frontend/src/app/modules/holdings/store/holdings.computed.ts
+++ b/frontend/src/app/modules/holdings/store/holdings.computed.ts
@@ -4,7 +4,9 @@ import {ErrorMessageService} from '@dsdevq-common/core';
 import {
   type AccountBalanceItem,
   type CategorySummary,
+  type InstitutionGroup,
 } from '../../../shared/models/wealth/wealth.model';
+import {InstitutionUtils} from '../../../shared/utils/institution.utils';
 import {type Position} from '../models/position/position.model';
 import {type HoldingsState} from './holdings.state';
 
@@ -47,6 +49,11 @@ export function holdingsComputed(store: StateSignals) {
     ),
     allAccounts: computed(
       (): AccountBalanceItem[] => store.summary()?.categories.flatMap(c => c.accounts) ?? []
+    ),
+    allInstitutions: computed((): InstitutionGroup[] =>
+      InstitutionUtils.groupByInstitution(
+        store.summary()?.categories.flatMap(c => c.accounts) ?? []
+      )
     ),
     positions: computed((): Position[] => store.positions()),
     isPositionsLoading: computed(() => store.positionsStatus() === 'loading'),

--- a/frontend/src/app/shared/models/wealth/wealth.model.ts
+++ b/frontend/src/app/shared/models/wealth/wealth.model.ts
@@ -20,6 +20,23 @@ export interface CategorySummary {
   accounts: AccountBalanceItem[];
 }
 
+/**
+ * Client-side grouping of accounts under one institution
+ * (Monobank cards, Binance assets, IBKR positions, …).
+ * Produced by `InstitutionUtils.groupByInstitution` from a flat
+ * {@link AccountBalanceItem} list — the backend still returns per-row data.
+ */
+export interface InstitutionGroup {
+  key: string;
+  name: string;
+  provider: string;
+  category: AccountCategory;
+  accounts: AccountBalanceItem[];
+  totalInBaseCurrency: number;
+  worstSyncStatus: SyncStatus;
+  latestSyncTimestamp: Nullable<string>;
+}
+
 export interface AppliedFilters {
   category: Nullable<AccountCategory>;
   provider: Nullable<string>;

--- a/frontend/src/app/shared/utils/institution.utils.spec.ts
+++ b/frontend/src/app/shared/utils/institution.utils.spec.ts
@@ -1,0 +1,111 @@
+import {describe, expect, it} from 'vitest';
+
+import {type AccountBalanceItem} from '../models/wealth/wealth.model';
+import {InstitutionUtils} from './institution.utils';
+
+function acct(overrides: Partial<AccountBalanceItem>): AccountBalanceItem {
+  return {
+    accountId: 'a',
+    bankName: 'Monobank',
+    accountType: 'card',
+    accountNumberLast4: '0000',
+    provider: 'monobank',
+    category: 'banking',
+    currency: 'UAH',
+    currentBalance: 0,
+    balanceInBaseCurrency: 0,
+    syncStatus: 'synced',
+    lastSyncTimestamp: null,
+    ...overrides,
+  } as AccountBalanceItem;
+}
+
+describe('InstitutionUtils.groupByInstitution', () => {
+  it('collapses monobank cards under a single institution row', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({accountId: '1', accountNumberLast4: '1111', balanceInBaseCurrency: 100}),
+      acct({accountId: '2', accountNumberLast4: '2222', balanceInBaseCurrency: 250}),
+      acct({accountId: '3', accountNumberLast4: '3333', balanceInBaseCurrency: 50}),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe('Monobank');
+    expect(groups[0].accounts).toHaveLength(3);
+    expect(groups[0].totalInBaseCurrency).toBe(400);
+  });
+
+  it('keeps different bankName rows in separate institutions (Revolut vs AIB)', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({provider: 'truelayer', bankName: 'Revolut', balanceInBaseCurrency: 1000}),
+      acct({provider: 'truelayer', bankName: 'AIB', balanceInBaseCurrency: 500}),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map(g => g.name).sort()).toEqual(['AIB', 'Revolut']);
+  });
+
+  it('sorts institutions by totalInBaseCurrency desc', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({provider: 'truelayer', bankName: 'AIB', balanceInBaseCurrency: 500}),
+      acct({provider: 'monobank', bankName: 'Monobank', balanceInBaseCurrency: 2000}),
+      acct({provider: 'truelayer', bankName: 'Revolut', balanceInBaseCurrency: 1000}),
+    ]);
+
+    expect(groups.map(g => g.name)).toEqual(['Monobank', 'Revolut', 'AIB']);
+  });
+
+  it('groups Binance assets and IBKR positions under one row each', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({
+        provider: 'binance',
+        bankName: 'Binance',
+        category: 'crypto',
+        balanceInBaseCurrency: 1000,
+      }),
+      acct({
+        provider: 'binance',
+        bankName: 'Binance',
+        category: 'crypto',
+        balanceInBaseCurrency: 500,
+      }),
+      acct({
+        provider: 'ibkr',
+        bankName: 'IBKR',
+        category: 'brokerage',
+        balanceInBaseCurrency: 10000,
+      }),
+    ]);
+
+    expect(groups).toHaveLength(2);
+    const binance = groups.find(g => g.name === 'Binance')!;
+    const ibkr = groups.find(g => g.name === 'IBKR')!;
+    expect(binance.accounts).toHaveLength(2);
+    expect(binance.totalInBaseCurrency).toBe(1500);
+    expect(ibkr.accounts).toHaveLength(1);
+    expect(ibkr.totalInBaseCurrency).toBe(10000);
+  });
+
+  it('worstSyncStatus surfaces the most degraded state across accounts', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({accountId: '1', syncStatus: 'synced'}),
+      acct({accountId: '2', syncStatus: 'failed'}),
+      acct({accountId: '3', syncStatus: 'synced'}),
+    ]);
+
+    expect(groups[0].worstSyncStatus).toBe('failed');
+  });
+
+  it('latestSyncTimestamp picks the max across accounts', () => {
+    const groups = InstitutionUtils.groupByInstitution([
+      acct({accountId: '1', lastSyncTimestamp: '2026-06-01T00:00:00Z'}),
+      acct({accountId: '2', lastSyncTimestamp: '2026-07-01T00:00:00Z'}),
+      acct({accountId: '3', lastSyncTimestamp: null}),
+    ]);
+
+    expect(groups[0].latestSyncTimestamp).toBe('2026-07-01T00:00:00Z');
+  });
+
+  it('returns an empty array when input is empty', () => {
+    expect(InstitutionUtils.groupByInstitution([])).toEqual([]);
+  });
+});

--- a/frontend/src/app/shared/utils/institution.utils.ts
+++ b/frontend/src/app/shared/utils/institution.utils.ts
@@ -1,0 +1,70 @@
+import {
+  type AccountBalanceItem,
+  type InstitutionGroup,
+  type SyncStatus,
+} from '../models/wealth/wealth.model';
+
+const SYNC_STATUS_PRIORITY: Record<SyncStatus, number> = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  reauth_required: 0,
+  failed: 1,
+  stale: 2,
+  pending: 3,
+  syncing: 4,
+  synced: 5,
+};
+
+export class InstitutionUtils {
+  /**
+   * Group a flat list of account rows into institution-level groups.
+   * Grouping key is `(provider, bankName)` — Monobank cards collapse under
+   * their bank, Binance assets under "Binance", IBKR positions under "IBKR".
+   */
+  public static groupByInstitution(accounts: AccountBalanceItem[]): InstitutionGroup[] {
+    const buckets = new Map<string, InstitutionGroup>();
+
+    for (const account of accounts) {
+      const key = `${account.provider}::${account.bankName}`;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.accounts.push(account);
+        existing.totalInBaseCurrency += account.balanceInBaseCurrency ?? 0;
+        existing.worstSyncStatus = InstitutionUtils.worseStatus(
+          existing.worstSyncStatus,
+          account.syncStatus
+        );
+        existing.latestSyncTimestamp = InstitutionUtils.laterTimestamp(
+          existing.latestSyncTimestamp,
+          account.lastSyncTimestamp
+        );
+      } else {
+        buckets.set(key, {
+          key,
+          name: account.bankName,
+          provider: account.provider,
+          category: account.category,
+          accounts: [account],
+          totalInBaseCurrency: account.balanceInBaseCurrency ?? 0,
+          worstSyncStatus: account.syncStatus,
+          latestSyncTimestamp: account.lastSyncTimestamp,
+        });
+      }
+    }
+
+    return [...buckets.values()].sort((a, b) => b.totalInBaseCurrency - a.totalInBaseCurrency);
+  }
+
+  private static worseStatus(a: SyncStatus, b: SyncStatus): SyncStatus {
+    return SYNC_STATUS_PRIORITY[a] <= SYNC_STATUS_PRIORITY[b] ? a : b;
+  }
+
+  private static laterTimestamp(a: Nullable<string>, b: Nullable<string>): Nullable<string> {
+    if (a === null) {
+      return b;
+    }
+    if (b === null) {
+      return a;
+    }
+    return a > b ? a : b;
+  }
+}


### PR DESCRIPTION
## Summary
Follow-up to the read-model institution-count fix (#221). That PR corrected the header ('3 institutions' instead of '8 accounts') but the tables still rendered one row per Monobank card / Binance asset / IBKR position. This PR does the actual visual grouping.

Every accounts + holdings view now collapses sub-rows under a parent institution row:
- Monobank's 8 cards → one 'Monobank' row that expands to reveal each card
- Binance's assets → one 'Binance' row
- IBKR positions → one 'IBKR' row

Pure frontend change — no backend contract changes.

### What ships
- \`InstitutionUtils.groupByInstitution\`: pure client-side grouping by \`(provider, bankName)\`. Aggregates USD totals, picks the worst sync status across children, surfaces the latest sync timestamp.
- \`AccountsStore\` gets \`bankingInstitutions / cryptoInstitutions / brokerageInstitutions\` computeds; \`HoldingsStore\` gets \`allInstitutions\`.
- \`accounts-list.component.html\` + \`holdings.component.html\`: templates iterate institutions and wrap each in \`<details><summary>\` so users can click to reveal sub-rows.

### Also on this branch
Not code, but worth noting: the empty net-worth history chart was investigated separately. Root cause: only one historical snapshot existed (2026-06-30 month-end) because the previous monthly cadence hadn't produced a July row yet. Inserted today's snapshot manually so the chart draws a line; the daily job (already deployed via #224) will accumulate points from here on.

## Test plan
- [x] \`npx vitest run institution.utils.spec.ts\` — 7/7 pass (grouping, sort, worst-status, latest-timestamp, empty, etc.)
- [x] ESLint clean on all touched TS files
- [ ] Live check on VPS after auto-deploy: Accounts list shows collapsible institution rows; Holdings detail table shows collapsible institutions with sub-rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)