### PR TITLE
fix(bank-sync): hard-delete accounts on institution disconnect

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/DisconnectInstitutionCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/DisconnectInstitutionCommand.cs
@@ -36,9 +36,8 @@ public sealed class DisconnectInstitutionCommandHandler(
 
         foreach (var account in childAccounts)
         {
-            await transactions.SoftDeleteByAccountIdAsync(account.Id, ct);
             await alerts.DeleteAlertsForAccountAsync(account.Id, ct);
-            await accounts.DeleteAsync(account.Id, ct);
+            await accounts.HardDeleteAsync(account.Id, ct);
         }
 
         switch (provider)

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
@@ -38,6 +38,13 @@ public interface IBankAccountRepository
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Hard-remove the bank account row from the DB (used by the institution
+    /// disconnect flow so the parent credential/connection can be removed
+    /// without a dangling FK).
+    /// </summary>
+    Task<bool> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get accounts with specific sync status.
     /// </summary>
     Task<IEnumerable<BankAccount>> GetBySyncStatusAsync(string status, CancellationToken cancellationToken = default);

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
@@ -62,6 +62,21 @@ public class BankAccountRepository(BankSyncDbContext context) : IBankAccountRepo
         return true;
     }
 
+    public async Task<bool> HardDeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var account = await _context.BankAccounts
+            .Include(ba => ba.Transactions)
+            .Include(ba => ba.SyncJobs)
+            .Include(ba => ba.EncryptedCredential)
+            .FirstOrDefaultAsync(ba => ba.Id == id, cancellationToken);
+        if (account == null)
+            return false;
+
+        _context.BankAccounts.Remove(account);
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
     public async Task<IEnumerable<BankAccount>> GetBySyncStatusAsync(string status, CancellationToken cancellationToken = default)
     {
         return await _context.BankAccounts


### PR DESCRIPTION
Fixes the 'token already connected' error after Monobank disconnect. IBankAccountRepository.DeleteAsync was a soft delete (IsActive = false), which left MonobankCredentialId populated on the rows and blocked the parent credential removal. New HardDeleteAsync removes the row + cascades to its transactions/sync-jobs/encrypted credential.