### PR TITLE
fix(ui): show native currency balance with '~ $USD' approximation

### DIFF
--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
@@ -69,7 +69,7 @@ public class WealthAggregationService(
             {
                 var accounts = holdings.Select(h => new AccountBalanceDto(
                     Guid.Empty, "Binance", "crypto", h.Asset, "binance", "crypto",
-                    "USD", h.FreeQuantity + h.LockedQuantity, h.UsdValue, "synced", h.SyncedAt))
+                    h.Asset, h.FreeQuantity + h.LockedQuantity, h.UsdValue, "synced", h.SyncedAt))
                     .ToList<AccountBalanceDto>();
 
                 var institutionsByProvider = holdings
@@ -97,7 +97,7 @@ public class WealthAggregationService(
                 var accounts = holdings.Select(h => new AccountBalanceDto(
                     Guid.Empty, "IBKR", "brokerage",
                     h.Symbol.Length >= 4 ? h.Symbol[..4] : h.Symbol,
-                    "ibkr", "brokerage", "USD", h.Quantity, h.UsdValue,
+                    "ibkr", "brokerage", h.Symbol, h.Quantity, h.UsdValue,
                     DateTime.UtcNow - h.SyncedAt > StaleThreshold ? "stale" : "synced", h.SyncedAt))
                     .ToList<AccountBalanceDto>();
 

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -143,7 +143,11 @@
                       <td
                         class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
                       >
-                        {{ account | accountBalance }}
+                        @let bal = account | accountBalance;
+                        <div>{{ bal.native }}</div>
+                        @if (bal.usd) {
+                          <div class="text-cmn-xs text-text-secondary">{{ bal.usd }}</div>
+                        }
                       </td>
                     </tr>
                   }
@@ -219,7 +223,11 @@
                       <td
                         class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
                       >
-                        {{ account | accountBalance }}
+                        @let bal = account | accountBalance;
+                        <div>{{ bal.native }}</div>
+                        @if (bal.usd) {
+                          <div class="text-cmn-xs text-text-secondary">{{ bal.usd }}</div>
+                        }
                       </td>
                     </tr>
                   }
@@ -295,7 +303,11 @@
                       <td
                         class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
                       >
-                        {{ account | accountBalance }}
+                        @let bal = account | accountBalance;
+                        <div>{{ bal.native }}</div>
+                        @if (bal.usd) {
+                          <div class="text-cmn-xs text-text-secondary">{{ bal.usd }}</div>
+                        }
                       </td>
                     </tr>
                   }

--- a/frontend/src/app/modules/bank-sync/pipes/account-balance.pipe.ts
+++ b/frontend/src/app/modules/bank-sync/pipes/account-balance.pipe.ts
@@ -3,12 +3,32 @@ import {inject, Pipe, type PipeTransform} from '@angular/core';
 
 import {type AccountBalanceItem} from '../../../shared/models/wealth/wealth.model';
 
+export interface FormattedBalance {
+  native: string;
+  usd: Nullable<string>;
+}
+
 @Pipe({name: 'accountBalance'})
 export class AccountBalancePipe implements PipeTransform {
   private readonly decimalPipe = inject(DecimalPipe);
 
-  public transform({balanceInBaseCurrency, currentBalance, currency}: AccountBalanceItem): string {
-    const value = balanceInBaseCurrency ?? currentBalance;
-    return `${currency} ${this.decimalPipe.transform(value) ?? ''}`;
+  public transform({
+    currentBalance,
+    currency,
+    balanceInBaseCurrency,
+  }: AccountBalanceItem): FormattedBalance {
+    const nativeAmount = this.decimalPipe.transform(currentBalance, '1.2-2') ?? '';
+    const native = `${nativeAmount} ${currency}`;
+
+    if (
+      currency === 'USD' ||
+      balanceInBaseCurrency === null ||
+      balanceInBaseCurrency === currentBalance
+    ) {
+      return {native, usd: null};
+    }
+
+    const usdAmount = this.decimalPipe.transform(balanceInBaseCurrency, '1.0-0') ?? '';
+    return {native, usd: `~ $${usdAmount}`};
   }
 }

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -147,7 +147,11 @@
                         <td
                           class="py-2 pr-4 text-right font-mono tabular-nums text-neutral-900 dark:text-neutral-100"
                         >
-                          {{ account | holdingBalance }}
+                          @let bal = account | holdingBalance;
+                          <div>{{ bal.native }}</div>
+                          @if (bal.usd) {
+                            <div class="text-xs text-neutral-400">{{ bal.usd }}</div>
+                          }
                         </td>
                       </tr>
                     }

--- a/frontend/src/app/modules/holdings/pipes/holding-balance.pipe.ts
+++ b/frontend/src/app/modules/holdings/pipes/holding-balance.pipe.ts
@@ -2,13 +2,29 @@ import {DecimalPipe} from '@angular/common';
 import {inject, Pipe, type PipeTransform} from '@angular/core';
 
 import {type AccountBalanceItem} from '../../../shared/models/wealth/wealth.model';
+import {type FormattedBalance} from '../../bank-sync/pipes/account-balance.pipe';
 
 @Pipe({name: 'holdingBalance'})
 export class HoldingBalancePipe implements PipeTransform {
   private readonly decimalPipe = inject(DecimalPipe);
 
-  public transform({balanceInBaseCurrency, currentBalance}: AccountBalanceItem): string {
-    const value = balanceInBaseCurrency ?? currentBalance;
-    return this.decimalPipe.transform(value) ?? '';
+  public transform({
+    currentBalance,
+    currency,
+    balanceInBaseCurrency,
+  }: AccountBalanceItem): FormattedBalance {
+    const nativeAmount = this.decimalPipe.transform(currentBalance, '1.2-2') ?? '';
+    const native = `${nativeAmount} ${currency}`;
+
+    if (
+      currency === 'USD' ||
+      balanceInBaseCurrency === null ||
+      balanceInBaseCurrency === currentBalance
+    ) {
+      return {native, usd: null};
+    }
+
+    const usdAmount = this.decimalPipe.transform(balanceInBaseCurrency, '1.0-0') ?? '';
+    return {native, usd: `~ $${usdAmount}`};
   }
 }


### PR DESCRIPTION
Fixes the misleading display: a 46,600 UAH Monobank card was rendering as 'UAH 1,118' (USD-converted value mislabeled as UAH). Now primary line = '46,600.00 UAH', secondary line = '~ $1,118'. Also fixes crypto/brokerage rows where the DTO was emitting currency='USD' while currentBalance was in asset units (BTC quantity, share count) — now emits the asset symbol as currency.