### PR TITLE
fix(banking): use production TrueLayer URLs on prod, not sandbox

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -30,9 +30,12 @@ services:
       Jwt__ExpirationMinutes: ${JWT_EXPIRATION_MINUTES:-60}
       Deduplication__MasterKeyBase64: ${DEDUPLICATION_MASTER_KEY_BASE64}
       GOOGLEOAUTH__CLIENTID: ${GOOGLE_CLIENT_ID:-}
-      # TrueLayer (Open Banking EU/UK). Sandbox creds by default.
-      TrueLayer__AuthBaseUrl: ${TRUELAYER_AUTH_BASE_URL:-https://auth.truelayer-sandbox.com}
-      TrueLayer__ApiBaseUrl: ${TRUELAYER_API_BASE_URL:-https://api.truelayer-sandbox.com}
+      # TrueLayer (Open Banking EU/UK). Production URLs — creds in .env are the
+      # live console.truelayer.com set, not sandbox. Override with
+      # TRUELAYER_AUTH_BASE_URL=https://auth.truelayer-sandbox.com to force
+      # sandbox for testing.
+      TrueLayer__AuthBaseUrl: ${TRUELAYER_AUTH_BASE_URL:-https://auth.truelayer.com}
+      TrueLayer__ApiBaseUrl: ${TRUELAYER_API_BASE_URL:-https://api.truelayer.com}
       TrueLayer__ClientId: ${TRUELAYER_CLIENT_ID:-}
       TrueLayer__ClientSecret: ${TRUELAYER_CLIENT_SECRET:-}
       TrueLayer__FrontendRedirectBase: ${TRUELAYER_FRONTEND_REDIRECT_BASE:-https://lifekit-vps.tail1cb676.ts.net:4200}


### PR DESCRIPTION
Local dev already hits auth.truelayer.com; prod compose was defaulting to auth.truelayer-sandbox.com. Real credentials were talking to the mock endpoint, which is why the returned accounts/transactions were all mocked.