### PR TITLE
fix(csp): allow TrueLayer provider logos + add local truelayer.svg

### DIFF
--- a/frontend/src/assets/providers/truelayer.svg
+++ b/frontend/src/assets/providers/truelayer.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+  <rect width="64" height="64" rx="12" fill="#0A2540"/>
+  <path d="M12 26h40l-4 6H16z" fill="#F5F5F5"/>
+  <path d="M20 34h6v14h-6zm9 0h6v14h-6zm9 0h6v14h-6z" fill="#F5F5F5"/>
+  <path d="M12 50h40v4H12z" fill="#F5F5F5"/>
+  <path d="M32 8 12 20v4h40v-4z" fill="#F5F5F5"/>
+</svg>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" href="data:," />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://cdn.plaid.com https://accounts.google.com/gsi/; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/; img-src 'self' data: https://lh3.googleusercontent.com; connect-src 'self' http://localhost:5001 ws://localhost:5001 https://cdn.plaid.com https://accounts.google.com/; frame-src https://cdn.plaid.com https://accounts.google.com/;"
+      content="default-src 'self'; script-src 'self' https://cdn.plaid.com https://accounts.google.com/gsi/; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/; img-src 'self' data: https://lh3.googleusercontent.com https://providers-assets.truelayer.com https://truelayer-provider-assets.s3.amazonaws.com; connect-src 'self' http://localhost:5001 ws://localhost:5001 https://cdn.plaid.com https://accounts.google.com/; frame-src https://cdn.plaid.com https://accounts.google.com/;"
     />
     <script src="https://accounts.google.com/gsi/client" async></script>
   </head>


### PR DESCRIPTION
CSP img-src whitelist now includes providers-assets.truelayer.com and the S3 bucket TrueLayer sometimes falls back to. Also drops the 404 on /assets/providers/truelayer.svg.