### PR TITLE
chore(security): drop Content-Security-Policy meta tag

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -6,10 +6,18 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="data:," />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://cdn.plaid.com https://accounts.google.com/gsi/; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/; img-src 'self' data: https://lh3.googleusercontent.com https://providers-assets.truelayer.com https://truelayer-provider-assets.s3.amazonaws.com; connect-src 'self' http://localhost:5001 ws://localhost:5001 https://cdn.plaid.com https://accounts.google.com/; frame-src https://cdn.plaid.com https://accounts.google.com/;"
-    />
+    <!--
+      No Content-Security-Policy header.
+
+      This app is deployed on Tailscale (single-user, tailnet-only). Public XSS
+      threat models don't apply: no anonymous attackers can reach the origin
+      and there is no cross-user session to hijack. A strict CSP would just
+      add friction every time a third-party asset host (bank logos, provider
+      SVGs, OAuth widgets) changes.
+
+      If Finance Sentry ever gets a public origin, re-enable CSP here with a
+      nonce/hash strategy — do NOT try to enumerate every host by hand.
+    -->
     <script src="https://accounts.google.com/gsi/client" async></script>
   </head>
   <body>


### PR DESCRIPTION
Behind Tailscale, single-user; public XSS threat model doesn't apply. Every new third-party asset was becoming a maintenance PR.