### PR TITLE
feat(accounts): disconnect buttons on IBKR and Binance rows

### DIFF
--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -192,6 +192,13 @@
                   {{ store.baseCurrency() }}
                   {{ inst.totalInBaseCurrency | number: '1.2-2' }}
                 </div>
+                <cmn-button
+                  (clicked)="disconnectInstitution(inst); $event.stopPropagation()"
+                  variant="secondary"
+                  size="sm"
+                >
+                  Disconnect
+                </cmn-button>
                 <svg
                   class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
                   fill="none"
@@ -272,6 +279,13 @@
                   {{ store.baseCurrency() }}
                   {{ inst.totalInBaseCurrency | number: '1.2-2' }}
                 </div>
+                <cmn-button
+                  (clicked)="disconnectInstitution(inst); $event.stopPropagation()"
+                  variant="secondary"
+                  size="sm"
+                >
+                  Disconnect
+                </cmn-button>
                 <svg
                   class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
                   fill="none"

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.ts
@@ -136,6 +136,14 @@ export class AccountsListComponent implements OnInit {
         if (confirmed !== true) {
           return;
         }
+        if (institution.provider === 'ibkr') {
+          this.store.disconnectIBKR();
+          return;
+        }
+        if (institution.provider === 'binance') {
+          this.store.disconnectBinance();
+          return;
+        }
         this.store.disconnectInstitution({
           provider: institution.provider,
           institutionId: institution.institutionId,

--- a/frontend/src/app/modules/bank-sync/store/accounts/accounts.effects.ts
+++ b/frontend/src/app/modules/bank-sync/store/accounts/accounts.effects.ts
@@ -5,6 +5,8 @@ import {catchError, EMPTY, pipe, switchMap, tap} from 'rxjs';
 
 import {type WealthSummaryResponse} from '../../../../shared/models/wealth/wealth.model';
 import {BankSyncService} from '../../services/bank-sync.service';
+import {BinanceService} from '../../services/binance.service';
+import {IBKRService} from '../../services/ibkr.service';
 import {WealthService} from '../../services/wealth.service';
 
 interface EffectsStore {
@@ -17,6 +19,8 @@ interface EffectsStore {
 export function accountsEffects(store: EffectsStore) {
   const wealthService = inject(WealthService);
   const bankSyncService = inject(BankSyncService);
+  const ibkrService = inject(IBKRService);
+  const binanceService = inject(BinanceService);
 
   const load = rxMethod<void>(
     pipe(
@@ -78,7 +82,42 @@ export function accountsEffects(store: EffectsStore) {
     )
   );
 
-  return {load, disconnectMonobank, disconnectAccount, disconnectInstitution};
+  const disconnectIBKR = rxMethod<void>(
+    pipe(
+      switchMap(() =>
+        ibkrService.disconnect().pipe(
+          tap(() => load()),
+          catchError((err: unknown) => {
+            store.setError(extractErrorCode(err));
+            return EMPTY;
+          })
+        )
+      )
+    )
+  );
+
+  const disconnectBinance = rxMethod<void>(
+    pipe(
+      switchMap(() =>
+        binanceService.disconnect().pipe(
+          tap(() => load()),
+          catchError((err: unknown) => {
+            store.setError(extractErrorCode(err));
+            return EMPTY;
+          })
+        )
+      )
+    )
+  );
+
+  return {
+    load,
+    disconnectMonobank,
+    disconnectAccount,
+    disconnectInstitution,
+    disconnectIBKR,
+    disconnectBinance,
+  };
 }
 
 interface HookStore {


### PR DESCRIPTION
Adds the same Disconnect button pattern that already exists on banking institutions to brokerage (IBKR) and crypto (Binance) rows. Routes provider === 'ibkr'/'binance' through the existing IBKRService/BinanceService disconnect endpoints (already institution-level) instead of the bank-sync-only institution disconnect endpoint. Reloads wealth summary after success.