### PR TITLE
fix(disconnect): call ibkr/disconnect and binance/disconnect endpoints

### DIFF
--- a/frontend/src/app/modules/bank-sync/services/binance.service.ts
+++ b/frontend/src/app/modules/bank-sync/services/binance.service.ts
@@ -18,6 +18,6 @@ export class BinanceService extends ApiService {
   }
 
   public disconnect(): Observable<void> {
-    return this.delete<void>();
+    return this.delete<void>('disconnect');
   }
 }

--- a/frontend/src/app/modules/bank-sync/services/ibkr.service.ts
+++ b/frontend/src/app/modules/bank-sync/services/ibkr.service.ts
@@ -15,6 +15,6 @@ export class IBKRService extends ApiService {
   }
 
   public disconnect(): Observable<void> {
-    return this.delete<void>();
+    return this.delete<void>('disconnect');
   }
 }


### PR DESCRIPTION
Frontend services were hitting the bare provider path. Adds the missing /disconnect suffix.