### PR TITLE
fix(disconnect): idempotently clean up orphan holdings when credential is missing

### DIFF
--- a/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/DisconnectBinanceCommand.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/DisconnectBinanceCommand.cs
@@ -14,16 +14,26 @@ public sealed class DisconnectBinanceCommandHandler(
     public async Task<Unit> Handle(DisconnectBinanceCommand command, CancellationToken cancellationToken)
     {
         var credential = await credentialRepository.GetByUserIdAsync(command.UserId, cancellationToken);
-        if (credential is null || !credential.IsActive)
+        var holdings = await holdingRepository.GetByUserIdAsync(command.UserId, cancellationToken);
+
+        var hasActiveCredential = credential is not null && credential.IsActive;
+        if (!hasActiveCredential && holdings.Count == 0)
         {
             throw new BinanceAccountNotFoundException();
         }
 
-        credential.Deactivate();
-        credentialRepository.Update(credential);
+        if (hasActiveCredential)
+        {
+            credential!.Deactivate();
+            credentialRepository.Update(credential);
+        }
 
         await holdingRepository.DeleteByUserIdAsync(command.UserId, cancellationToken);
-        await credentialRepository.SaveChangesAsync(cancellationToken);
+
+        if (hasActiveCredential)
+        {
+            await credentialRepository.SaveChangesAsync(cancellationToken);
+        }
 
         return Unit.Value;
     }

--- a/backend/tests/FinanceSentry.Tests.Integration/Binance/CryptoControllerContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/Binance/CryptoControllerContractTests.cs
@@ -177,6 +177,9 @@ public class CryptoControllerDisconnectContractTests(CryptoApiFactory factory) :
         _factory.CredentialRepoMock
             .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BinanceCredential?)null);
+        _factory.HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var response = await _client.DeleteAsync("/api/v1/crypto/binance/disconnect");
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -196,6 +199,9 @@ public class CryptoControllerDisconnectContractTests(CryptoApiFactory factory) :
         _factory.CredentialRepoMock
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _factory.HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
         _factory.HoldingRepoMock
             .Setup(r => r.DeleteByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);

--- a/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/BrokerageControllerDisconnectContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/BrokerageSync/BrokerageControllerDisconnectContractTests.cs
@@ -32,6 +32,9 @@ public class BrokerageControllerDisconnectContractTests : IClassFixture<Brokerag
         _factory.CredentialRepoMock
             .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((IBKRCredential?)null);
+        _factory.HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         var response = await _client.DeleteAsync("/api/v1/brokerage/ibkr/disconnect");
 
@@ -54,6 +57,9 @@ public class BrokerageControllerDisconnectContractTests : IClassFixture<Brokerag
         _factory.CredentialRepoMock
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        _factory.HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
         _factory.HoldingRepoMock
             .Setup(r => r.DeleteByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);


### PR DESCRIPTION
IBKR/Binance disconnect commands now succeed when the credential is gone but holdings survive (e.g. after a credential rotation). Only surfaces NOT_CONNECTED when both are empty. Also wiped 5 orphan BrokerageHoldings on VPS by hand.