### PR TITLE
fix(ibkr): reactivate stale credential + best-effort container stop on disconnect

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
@@ -34,17 +34,33 @@ public sealed class ConnectIBKRCommandHandler(
         var encryptedUsername = encryption.Encrypt(command.Username);
         var encryptedPassword = encryption.Encrypt(command.Password);
 
-        var credential = new IBKRCredential(
-            command.UserId,
-            encryptedUsername.Ciphertext,
-            encryptedUsername.Iv,
-            encryptedUsername.AuthTag,
-            encryptedPassword.Ciphertext,
-            encryptedPassword.Iv,
-            encryptedPassword.AuthTag,
-            encryptedUsername.KeyVersion);
-
-        await credentialRepository.AddAsync(credential, cancellationToken);
+        IBKRCredential credential;
+        if (existing is not null)
+        {
+            existing.Reactivate(
+                encryptedUsername.Ciphertext,
+                encryptedUsername.Iv,
+                encryptedUsername.AuthTag,
+                encryptedPassword.Ciphertext,
+                encryptedPassword.Iv,
+                encryptedPassword.AuthTag,
+                encryptedUsername.KeyVersion);
+            credentialRepository.Update(existing);
+            credential = existing;
+        }
+        else
+        {
+            credential = new IBKRCredential(
+                command.UserId,
+                encryptedUsername.Ciphertext,
+                encryptedUsername.Iv,
+                encryptedUsername.AuthTag,
+                encryptedPassword.Ciphertext,
+                encryptedPassword.Iv,
+                encryptedPassword.AuthTag,
+                encryptedUsername.KeyVersion);
+            await credentialRepository.AddAsync(credential, cancellationToken);
+        }
         await credentialRepository.SaveChangesAsync(cancellationToken);
 
         await containerManager.SpawnAsync(

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/DisconnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/DisconnectIBKRCommand.cs
@@ -2,6 +2,7 @@ using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
 using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceSentry.Modules.BrokerageSync.Application.Commands;
 
@@ -10,24 +11,47 @@ public sealed record DisconnectIBKRCommand(Guid UserId) : ICommand<Unit>;
 public sealed class DisconnectIBKRCommandHandler(
     IIBKRCredentialRepository credentialRepository,
     IBrokerageHoldingRepository holdingRepository,
-    IIBeamContainerManager containerManager)
+    IIBeamContainerManager containerManager,
+    ILogger<DisconnectIBKRCommandHandler> logger)
     : ICommandHandler<DisconnectIBKRCommand, Unit>
 {
     public async Task<Unit> Handle(DisconnectIBKRCommand command, CancellationToken cancellationToken)
     {
-        var credential = await credentialRepository.GetByUserIdAsync(command.UserId, cancellationToken)
-            ?? throw new BrokerAccountNotFoundException(
+        var credential = await credentialRepository.GetByUserIdAsync(command.UserId, cancellationToken);
+        var holdings = await holdingRepository.GetByUserIdAsync(command.UserId, cancellationToken);
+
+        var hasActiveCredential = credential is not null && credential.IsActive;
+        if (!hasActiveCredential && holdings.Count == 0)
+            throw new BrokerAccountNotFoundException(
                 $"No active IBKR account found for user {command.UserId}.");
 
-        await containerManager.StopAndRemoveAsync(credential.Id, cancellationToken);
+        if (credential is not null)
+        {
+            try
+            {
+                await containerManager.StopAndRemoveAsync(credential.Id, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // Best-effort: if Docker is unreachable or the container was already
+                // torn down out-of-band, we still need to release the credential row
+                // so the user can reconnect. The reconciler will clean up any leaked
+                // container on the next sweep.
+                logger.LogWarning(
+                    ex,
+                    "Failed to stop IBeam container for credential {CredentialId}; proceeding with disconnect anyway",
+                    credential.Id);
+            }
 
-        credential.Deactivate();
-        credentialRepository.Update(credential);
+            credential.Deactivate();
+            credentialRepository.Update(credential);
+        }
 
         await holdingRepository.DeleteByUserIdAsync(command.UserId, cancellationToken);
         await holdingRepository.SaveChangesAsync(cancellationToken);
 
-        await credentialRepository.SaveChangesAsync(cancellationToken);
+        if (credential is not null)
+            await credentialRepository.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;
     }

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/IBKRCredential.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/IBKRCredential.cs
@@ -63,4 +63,26 @@ public sealed class IBKRCredential
     public void RecordSyncError(string error) => LastSyncError = error;
 
     public void Deactivate() => IsActive = false;
+
+    public void Reactivate(
+        byte[] encryptedUsername,
+        byte[] usernameIv,
+        byte[] usernameAuthTag,
+        byte[] encryptedPassword,
+        byte[] passwordIv,
+        byte[] passwordAuthTag,
+        int keyVersion)
+    {
+        IsActive = true;
+        AccountId = null;
+        LastSyncAt = null;
+        LastSyncError = null;
+        EncryptedUsername = encryptedUsername;
+        UsernameIv = usernameIv;
+        UsernameAuthTag = usernameAuthTag;
+        EncryptedPassword = encryptedPassword;
+        PasswordIv = passwordIv;
+        PasswordAuthTag = passwordAuthTag;
+        KeyVersion = keyVersion;
+    }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
@@ -50,7 +50,7 @@ public class ConnectIBKRCommandTests
     }
 
     [Fact]
-    public async Task Handle_AlreadyConnected_ThrowsBrokerAlreadyConnectedException()
+    public async Task Handle_ExistingActiveCredential_ThrowsBrokerAlreadyConnectedException()
     {
         var userId = Guid.NewGuid();
 
@@ -61,6 +61,41 @@ public class ConnectIBKRCommandTests
         var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
 
         await act.Should().ThrowAsync<BrokerAlreadyConnectedException>();
+    }
+
+    [Fact]
+    public async Task Handle_ExistingInactiveCredential_RotatesInPlaceInsteadOfAdding()
+    {
+        var userId = Guid.NewGuid();
+        var stale = ExistingCredential(userId);
+        stale.Deactivate();
+        var staleId = stale.Id;
+
+        _credentialRepo
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stale);
+        _encryption
+            .Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns((string s) => new EncryptionResult([(byte)s.Length], [1], [2], 1));
+        _credentialRepo
+            .Setup(r => r.Update(It.IsAny<IBKRCredential>()));
+        _credentialRepo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _syncHandler
+            .Setup(h => h.Handle(It.IsAny<SyncIBKRHoldingsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SyncIBKRHoldingsResult(0, DateTime.UtcNow));
+
+        await CreateHandler().Handle(new ConnectIBKRCommand(userId, "u", "p"), default);
+
+        _credentialRepo.Verify(r => r.AddAsync(It.IsAny<IBKRCredential>(), It.IsAny<CancellationToken>()), Times.Never);
+        _credentialRepo.Verify(r => r.Update(It.Is<IBKRCredential>(c => c.Id == staleId && c.IsActive)), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **VPS repro**: on prod Denys saw `{"error":"An IBKR account is already connected for this user.","errorCode":"ALREADY_CONNECTED"}` on a fresh connect attempt even though he'd disconnected. Two compounding bugs.
- **Bug 1 — Disconnect aborted mid-flight.** `DisconnectIBKRCommand` called `containerManager.StopAndRemoveAsync(...)` **before** `credential.Deactivate()`. `StopAndRemoveAsync` only swallows `DockerContainerNotFoundException`; any other Docker error (daemon unreachable, permission error, transient API failure) propagated and the credential row was never deactivated → `IsActive=true` in DB → next connect throws `ALREADY_CONNECTED`.
- **Bug 2 — Reconnect couldn't reuse a soft-deleted row.** `ConnectIBKRCommand` always did `AddAsync(new IBKRCredential(...))`. `IBKRCredentials` has `HasIndex(e => e.UserId).IsUnique()` (M001), so even a clean disconnect + reconnect would hit the constraint on the next attempt.
- **Fix**:
  - `IBKRCredential.Reactivate(...)` — rotates the encrypted-cred bytes, flips `IsActive` back on, clears `AccountId` / `LastSyncAt` / `LastSyncError`. `Id` deliberately unchanged so EF change-tracking + IBeam container-name derivation stay stable.
  - `ConnectIBKRCommand` — active row still throws `ALREADY_CONNECTED`; inactive row now goes through `Reactivate + Update` instead of `AddAsync`.
  - `DisconnectIBKRCommand` — mirrors the Binance fix from #241: only throws `NOT_CONNECTED` when *both* credential and holdings are empty; wipes orphan holdings even when the credential row is missing; container stop wrapped in `try/catch` with `ILogger` warning so a Docker failure no longer aborts the deactivate step.

## Test plan

- [x] `dotnet build FinanceSentry.sln` — clean (1 pre-existing warning in `BankSync`, untouched by this PR)
- [x] `dotnet test tests/FinanceSentry.Tests.Unit --filter '~BrokerageSync|~IBKR'` — 13/13 pass, including the new `Handle_ExistingInactiveCredential_RotatesInPlaceInsteadOfAdding`
- [x] `dotnet test tests/FinanceSentry.Tests.Integration --filter '~BrokerageControllerDisconnect|~BrokerageControllerConnect'` — 6/6 pass
- [ ] **After VPS deploy**: on the affected user, hit `DELETE /api/v1/brokerage/ibkr/disconnect` once to force the deactivate through the new best-effort path, then `POST /api/v1/brokerage/ibkr/connect` — expect a fresh sync instead of `ALREADY_CONNECTED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)