### PR TITLE
fix(deploy): grant API access to host docker socket via runtime supplementary gid

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -28,6 +28,15 @@ echo "[deploy] decrypt docker/.env.sops"
 SOPS_AGE_KEY_FILE="$KEYFILE" sops --decrypt --input-type dotenv --output-type dotenv docker/.env.sops > docker/.env
 chmod 600 docker/.env
 
+echo "[deploy] detect host docker gid for socket access"
+if [[ -S /var/run/docker.sock ]]; then
+  DOCKER_GID="$(stat -c '%g' /var/run/docker.sock)"
+  export DOCKER_GID
+  echo "[deploy] DOCKER_GID=${DOCKER_GID}"
+else
+  echo "warning: /var/run/docker.sock missing on host — IBeam orchestration will not work" >&2
+fi
+
 echo "[deploy] docker compose build + up"
 docker compose -f docker/docker-compose.prod.yml --env-file docker/.env up -d --build --remove-orphans
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -67,6 +67,12 @@ services:
       - api_logs:/app/logs
       # Docker socket for per-user IBeam container orchestration
       - /var/run/docker.sock:/var/run/docker.sock
+    # The image runs as `nobody` (Dockerfile hardening). To let the API talk to
+    # /var/run/docker.sock (root:docker on the host), we add the host's docker
+    # gid as a supplementary group. deploy.sh exports DOCKER_GID from
+    # `stat -c '%g' /var/run/docker.sock`. Default 999 covers common Linux hosts.
+    group_add:
+      - "${DOCKER_GID:-999}"
     logging:
       driver: json-file
       options: { max-size: "10m", max-file: "3" }


### PR DESCRIPTION
## Summary

- On the first IBKR connect after #242 landed, POST `/api/v1/brokerage/ibkr/connect` responded with `{"errorCode":"INTERNAL_ERROR"}`. API logs showed `HttpRequestException: Connection failed` from every `IBeamContainerManager` docker call (`SpawnAsync`, `IsRunningAsync`, `StopAndRemoveAsync`), and the periodic `IBeamReconciler` sweep failing with the same trace once a minute.
- **Root cause**: the API image runs as `USER nobody` (Dockerfile hardening at line 43). The docker socket on the VPS is `srw-rw---- root:990 /var/run/docker.sock`. `nobody` is not in gid 990, so the socket is unreachable at the transport layer — the daemon never sees the request.
- **Fix at the deploy layer, not the image**: the required gid is host-specific (990 on this VPS, 999 on most other Linux boxes). Hardcoding into the Dockerfile would break local dev / other environments.
  - `docker/deploy.sh`: detect `DOCKER_GID` from `stat -c '%g' /var/run/docker.sock` and export before `docker compose up`. Warns (not errors) when the socket is absent, so non-brokerage deploys still work.
  - `docker/docker-compose.prod.yml`: API service now has `group_add: ["${DOCKER_GID:-999}"]`. Applied at container creation, so the compose config-hash change forces a recreate on next deploy — no manual `--force-recreate api` needed.
- The `Reactivate` code path from #242 already ran correctly on VPS (`UPDATE IBKRCredentials SET AccountId=..., IsActive=@p4` visible in logs) — the failure is downstream at the docker-socket boundary.

## Follow-up (separate PR)

- `ConnectIBKRCommand` leaves an active credential row when `WaitForAuthAsync` times out — no compensating cleanup. That is what originally put Denys's VPS row into the stuck state. Independent of this PR.

## Test plan

- [x] `docker compose -f docker/docker-compose.prod.yml config` — parses clean with new `group_add`
- [x] `bash -n docker/deploy.sh` — syntax OK
- [ ] **After deploy**: `docker exec finance-sentry-api sh -c 'id'` should list a supplementary group matching the host docker gid. Then hit Connect in the UI — expect either a successful sync or `BrokerAuthException` (the still-open auth-timeout bug) — but no more `HttpRequestException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)