### PR TITLE
fix(ibkr): roll back credential + container when connect fails after commit

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
@@ -4,6 +4,7 @@ using FinanceSentry.Modules.BrokerageSync.Domain;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
 using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceSentry.Modules.BrokerageSync.Application.Commands;
 
@@ -21,7 +22,8 @@ public sealed class ConnectIBKRCommandHandler(
     IIBKRCredentialRepository credentialRepository,
     ICredentialEncryptionService encryption,
     IIBeamContainerManager containerManager,
-    ICommandHandler<SyncIBKRHoldingsCommand, SyncIBKRHoldingsResult> syncHandler)
+    ICommandHandler<SyncIBKRHoldingsCommand, SyncIBKRHoldingsResult> syncHandler,
+    ILogger<ConnectIBKRCommandHandler> logger)
     : ICommandHandler<ConnectIBKRCommand, ConnectIBKRResult>
 {
     public async Task<ConnectIBKRResult> Handle(ConnectIBKRCommand command, CancellationToken cancellationToken)
@@ -63,21 +65,62 @@ public sealed class ConnectIBKRCommandHandler(
         }
         await credentialRepository.SaveChangesAsync(cancellationToken);
 
-        await containerManager.SpawnAsync(
-            credential.Id, command.Username, command.Password, cancellationToken);
+        // Everything below can fail (docker unreachable, IBKR auth timeout, sync
+        // error). Any failure must roll the credential back to IsActive=false and
+        // best-effort tear down the container, otherwise the row gets stuck
+        // active and the user's next Connect returns ALREADY_CONNECTED.
+        try
+        {
+            await containerManager.SpawnAsync(
+                credential.Id, command.Username, command.Password, cancellationToken);
 
-        var authenticated = await containerManager.WaitForAuthAsync(credential.Id, cancellationToken);
-        if (!authenticated)
-            throw new BrokerAuthException(
-                "IBKR gateway did not authenticate within the configured timeout. Check the credentials and gateway logs.",
-                "IBKR");
+            var authenticated = await containerManager.WaitForAuthAsync(credential.Id, cancellationToken);
+            if (!authenticated)
+                throw new BrokerAuthException(
+                    "IBKR gateway did not authenticate within the configured timeout. Check the credentials and gateway logs.",
+                    "IBKR");
 
-        var syncResult = await syncHandler.Handle(
-            new SyncIBKRHoldingsCommand(command.UserId), cancellationToken);
+            var syncResult = await syncHandler.Handle(
+                new SyncIBKRHoldingsCommand(command.UserId), cancellationToken);
 
-        return new ConnectIBKRResult(
-            syncResult.HoldingsCount,
-            syncResult.SyncedAt,
-            credential.AccountId ?? string.Empty);
+            return new ConnectIBKRResult(
+                syncResult.HoldingsCount,
+                syncResult.SyncedAt,
+                credential.AccountId ?? string.Empty);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await RollbackAsync(credential, cancellationToken);
+            throw;
+        }
+    }
+
+    private async Task RollbackAsync(IBKRCredential credential, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await containerManager.StopAndRemoveAsync(credential.Id, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(
+                ex,
+                "Rollback: failed to stop IBeam container for credential {CredentialId}; continuing with credential deactivation",
+                credential.Id);
+        }
+
+        try
+        {
+            credential.Deactivate();
+            credentialRepository.Update(credential);
+            await credentialRepository.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(
+                ex,
+                "Rollback: failed to deactivate credential {CredentialId} after connect failure. Row may be stuck IsActive=true and require manual intervention.",
+                credential.Id);
+        }
     }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
@@ -6,6 +6,7 @@ using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
 using FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -19,7 +20,12 @@ public class ConnectIBKRCommandTests
     private readonly Mock<ICommandHandler<SyncIBKRHoldingsCommand, SyncIBKRHoldingsResult>> _syncHandler = new(MockBehavior.Strict);
 
     private ConnectIBKRCommandHandler CreateHandler() =>
-        new(_credentialRepo.Object, _encryption.Object, _containerManager.Object, _syncHandler.Object);
+        new(
+            _credentialRepo.Object,
+            _encryption.Object,
+            _containerManager.Object,
+            _syncHandler.Object,
+            NullLogger<ConnectIBKRCommandHandler>.Instance);
 
     private static IBKRCredential ExistingCredential(Guid userId) =>
         new(userId, [1], [2], [3], [4], [5], [6], keyVersion: 1);
@@ -141,10 +147,97 @@ public class ConnectIBKRCommandTests
     {
         var userId = Guid.NewGuid();
         SetupHappyPath(userId, authResult: false);
+        SetupRollback();
 
         var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
 
         await act.Should().ThrowAsync<BrokerAuthException>();
+    }
+
+    [Fact]
+    public async Task Handle_AuthTimeout_RollsBackCredentialToInactive()
+    {
+        var userId = Guid.NewGuid();
+        IBKRCredential? saved = null;
+
+        _credentialRepo
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IBKRCredential?)null);
+        _encryption
+            .Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns((string s) => new EncryptionResult([(byte)s.Length], [1], [2], 1));
+        _credentialRepo
+            .Setup(r => r.AddAsync(It.IsAny<IBKRCredential>(), It.IsAny<CancellationToken>()))
+            .Callback<IBKRCredential, CancellationToken>((c, _) => saved = c)
+            .Returns(Task.CompletedTask);
+        _credentialRepo
+            .Setup(r => r.Update(It.IsAny<IBKRCredential>()));
+        _credentialRepo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _containerManager
+            .Setup(m => m.StopAndRemoveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
+
+        await act.Should().ThrowAsync<BrokerAuthException>();
+
+        saved.Should().NotBeNull();
+        saved!.IsActive.Should().BeFalse();
+        _containerManager.Verify(m => m.StopAndRemoveAsync(saved.Id, It.IsAny<CancellationToken>()), Times.Once);
+        _credentialRepo.Verify(r => r.Update(It.Is<IBKRCredential>(c => !c.IsActive)), Times.Once);
+        _credentialRepo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_SpawnFailure_RollsBackCredentialToInactive()
+    {
+        var userId = Guid.NewGuid();
+        IBKRCredential? saved = null;
+
+        _credentialRepo
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IBKRCredential?)null);
+        _encryption
+            .Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns((string s) => new EncryptionResult([(byte)s.Length], [1], [2], 1));
+        _credentialRepo
+            .Setup(r => r.AddAsync(It.IsAny<IBKRCredential>(), It.IsAny<CancellationToken>()))
+            .Callback<IBKRCredential, CancellationToken>((c, _) => saved = c)
+            .Returns(Task.CompletedTask);
+        _credentialRepo
+            .Setup(r => r.Update(It.IsAny<IBKRCredential>()));
+        _credentialRepo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Docker daemon unreachable"));
+        _containerManager
+            .Setup(m => m.StopAndRemoveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "user", "pass"), default);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+
+        saved!.IsActive.Should().BeFalse();
+        _credentialRepo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    private void SetupRollback()
+    {
+        _credentialRepo.Setup(r => r.Update(It.IsAny<IBKRCredential>()));
+        _containerManager
+            .Setup(m => m.StopAndRemoveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Third IBKR-connect bug from Denys's VPS repro. Independent of #242 and #243, and the reason the VPS row got stuck in the first place.
- **Root cause**: `ConnectIBKRCommand` persists the credential row (`IsActive=true`) *before* it spawns the IBeam container and waits on gateway auth. If any downstream step fails (`SpawnAsync`, `WaitForAuthAsync`, `SyncIBKRHoldingsCommand`), the row stays `IsActive=true` and the user's next Connect returns `ALREADY_CONNECTED` even though nothing actually connected. On VPS this fired when `WaitForAuthAsync` timed out — `LastSyncError` on the stuck row read *"IBKR gateway is not authenticated for this user..."*.
- **Fix**: wrap post-persist steps in try/catch. On failure, `RollbackAsync` runs:
  1. best-effort `StopAndRemoveAsync` on the container (logged if it fails, does not block the rollback);
  2. `credential.Deactivate() + Update + SaveChanges` so the row goes back to `IsActive=false`;
  3. original exception is rethrown so callers still see the real failure reason (e.g. `BrokerAuthException`).
- Handler now takes `ILogger<ConnectIBKRCommandHandler>` for the warning path; tests use `NullLogger<T>.Instance`.

## Test plan

- [x] `dotnet build FinanceSentry.sln` — clean (only the pre-existing `DisconnectInstitutionCommand.cs` warning I've been ignoring)
- [x] `dotnet test tests/FinanceSentry.Tests.Unit --filter '~ConnectIBKR|~BrokerageSync'` — 15/15 pass, including two new rollback tests
  - `Handle_AuthTimeout_RollsBackCredentialToInactive` — verifies `StopAndRemoveAsync` called, credential ends `IsActive=false`, `SaveChangesAsync` called exactly twice (persist + rollback)
  - `Handle_SpawnFailure_RollsBackCredentialToInactive` — same shape but the throw comes from `SpawnAsync` (docker unreachable)
- [ ] **After VPS deploy**: run a Connect with credentials that will time out at gateway auth. Expect `AUTH_TIMEOUT` response *and* the credential row rolled back to `IsActive=false`. Next Connect must NOT return `ALREADY_CONNECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)