### PR TITLE
fix(ibkr): safe defaults for 2FA + cancellation rollback

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/ConnectIBKRCommand.cs
@@ -66,9 +66,10 @@ public sealed class ConnectIBKRCommandHandler(
         await credentialRepository.SaveChangesAsync(cancellationToken);
 
         // Everything below can fail (docker unreachable, IBKR auth timeout, sync
-        // error). Any failure must roll the credential back to IsActive=false and
-        // best-effort tear down the container, otherwise the row gets stuck
-        // active and the user's next Connect returns ALREADY_CONNECTED.
+        // error, request cancellation). Any exit must roll the credential back
+        // to IsActive=false and best-effort tear down the container; otherwise
+        // the row gets stuck active and the container silently retries IBKR
+        // login in the background, which trips the account's lockout counter.
         try
         {
             await containerManager.SpawnAsync(
@@ -88,12 +89,17 @@ public sealed class ConnectIBKRCommandHandler(
                 syncResult.SyncedAt,
                 credential.AccountId ?? string.Empty);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch
         {
-            await RollbackAsync(credential, cancellationToken);
+            // Fresh, bounded token: if the caller cancelled us, we still need to
+            // finish the tear-down. Any leaked container keeps hammering IBKR.
+            using var rollbackCts = new CancellationTokenSource(RollbackTimeout);
+            await RollbackAsync(credential, rollbackCts.Token);
             throw;
         }
     }
+
+    private static readonly TimeSpan RollbackTimeout = TimeSpan.FromSeconds(30);
 
     private async Task RollbackAsync(IBKRCredential credential, CancellationToken cancellationToken)
     {

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
@@ -56,6 +56,16 @@ public sealed class IBeamContainerManager : IIBeamContainerManager
                 "IBEAM_GATEWAY_BASE_URL=https://localhost:5000",
                 "IBEAM_LOG_LEVEL=INFO",
                 "IBEAM_ERROR_SCREENSHOTS=True",
+                // Post-login DOM wait. Default is 15s — too short for IB Key push
+                // 2FA where the user has to unlock a phone and tap approve. 90s
+                // gives realistic headroom without exceeding our .NET-side
+                // SpawnTimeoutSeconds=120 budget.
+                "IBEAM_PAGE_LOAD_TIMEOUT=90",
+                // Fail-fast on bad credentials / unhandled auth screens. IBeam's
+                // default is 5, which is enough to trip IBKR's account lockout
+                // counter before the caller ever sees a response.
+                "IBEAM_MAX_FAILED_AUTH=1",
+                "IBEAM_REQUEST_RETRIES=1",
             ],
             HostConfig = new HostConfig
             {

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/ConnectIBKRCommandTests.cs
@@ -241,6 +241,48 @@ public class ConnectIBKRCommandTests
     }
 
     [Fact]
+    public async Task Handle_Cancellation_StillRollsBackCredentialAndContainer()
+    {
+        var userId = Guid.NewGuid();
+        IBKRCredential? saved = null;
+        using var cts = new CancellationTokenSource();
+
+        _credentialRepo
+            .Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IBKRCredential?)null);
+        _encryption
+            .Setup(e => e.Encrypt(It.IsAny<string>()))
+            .Returns((string s) => new EncryptionResult([(byte)s.Length], [1], [2], 1));
+        _credentialRepo
+            .Setup(r => r.AddAsync(It.IsAny<IBKRCredential>(), It.IsAny<CancellationToken>()))
+            .Callback<IBKRCredential, CancellationToken>((c, _) => saved = c)
+            .Returns(Task.CompletedTask);
+        _credentialRepo
+            .Setup(r => r.Update(It.IsAny<IBKRCredential>()));
+        _credentialRepo
+            .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.SpawnAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => cts.Cancel())
+            .Returns(Task.CompletedTask);
+        _containerManager
+            .Setup(m => m.WaitForAuthAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        _containerManager
+            .Setup(m => m.StopAndRemoveAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var act = () => CreateHandler().Handle(new ConnectIBKRCommand(userId, "u", "p"), cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        saved!.IsActive.Should().BeFalse();
+        _containerManager.Verify(m => m.StopAndRemoveAsync(saved.Id, It.IsAny<CancellationToken>()), Times.Once);
+        _credentialRepo.Verify(r => r.Update(It.Is<IBKRCredential>(c => !c.IsActive)), Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_PersistsEncryptedCredentialBoundToUser()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

Two related issues surfaced during live E2E on VPS today. Together they created the account-lockout risk (which already tripped once on Denys's read-only IBKR sub-user).

### 1. IBeam gave up on 2FA in 15 seconds

`IBeamContainerManager.SpawnAsync` was only setting 5 env vars. The IBeam Selenium login handler submits the form, waits `IBEAM_PAGE_LOAD_TIMEOUT` (default **15s**) for the post-login DOM to change, then declares the login failed and starts a fresh retry. That's way too short for the IB Key push-notification 2FA flow — realistic tap-approve time is 20–60s once you factor in phone unlock, app open, tap. Each retry sends a *new* login → *new* push notification → burns one attempt against IBKR's account-lockout counter.

Fix — add three env vars with safe defaults:
- `IBEAM_PAGE_LOAD_TIMEOUT=90` — realistic human 2FA window; fits within our .NET-side `SpawnTimeoutSeconds=120`.
- `IBEAM_MAX_FAILED_AUTH=1` — one attempt only. No retry storm.
- `IBEAM_REQUEST_RETRIES=1` — no gateway-readiness retry loop either.

### 2. Cancelled Connect leaked container + credential state

Nginx / Tailscale-serve cut `/api/v1/brokerage/ibkr/connect` at exactly 60s (client-close, HTTP 499). Our .NET handler caught the resulting `OperationCanceledException` but the previous try/catch (`when ex is not OperationCanceledException` from #244) deliberately skipped `RollbackAsync` on cancel. Consequence:
- Credential row stayed `IsActive=true`.
- IBeam container kept running in the background.
- IBeam's Selenium loop kept hammering IBKR with login attempts — still burning lockout-counter slots — with no one watching. Denys had to kill it manually via `docker rm -f`.

Fix — always run rollback:
- `catch` (no guard) → `RollbackAsync` runs on any exit path, including cancellation.
- Rollback uses a fresh **30s** `CancellationTokenSource` so tear-down isn't cancelled by the same token that aborted the main request.
- Original exception is still rethrown so callers see the real cause.

## Test plan

- [x] `dotnet build FinanceSentry.sln` — clean, only the long-standing `DisconnectInstitutionCommand.cs` warning
- [x] `dotnet test --filter '~ConnectIBKR|~BrokerageSync'` — **16/16 pass**, including new `Handle_Cancellation_StillRollsBackCredentialAndContainer` which:
  - Triggers cancellation from inside the `SpawnAsync` callback
  - Asserts `StopAndRemoveAsync` runs exactly once on the credential id
  - Asserts credential ends `IsActive=false`
  - Asserts the original `OperationCanceledException` is rethrown to the caller
- [ ] **After VPS deploy**: hit Connect with valid IBKR creds. Expect either
  1. Full success (2FA push tapped inside 90s), OR
  2. Clean `INVALID_CREDENTIALS` after one attempt (no retry storm on the lockout counter), OR
  3. Client-side cancellation with credential row rolled back to `IsActive=false` and container removed (verify via `docker ps -a --filter name=finance-sentry-ibkr`).

## Not in scope

The 60s upstream HTTP timeout is the root cause of the cancellation bug and deserves an async-status-poll refactor of the Connect controller. That's a bigger change — punting to a follow-up PR. This PR is the minimum safety fix to unblock 2FA attempts today without account-lockout risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)