### PR TITLE
fix(ibkr): idempotent Connect + budget for cold-start + human 2FA

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IBKRConnectOrchestrator.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IBKRConnectOrchestrator.cs
@@ -10,6 +10,22 @@ public sealed class IBKRConnectOrchestrator(
 {
     public Guid Start(Guid userId, string username, string password)
     {
+        // Idempotency: if the user already has a session mid-flight (they
+        // impatiently clicked Connect a second time while the first one was
+        // still spawning IBeam / waiting on 2FA), return the existing id so
+        // the frontend keeps polling the SAME session. Without this, click 2
+        // would race click 1: it hits credentialRepo, sees IsActive=true from
+        // click 1's Reactivate, and short-circuits with IBKR_DUPLICATE — which
+        // surfaces a misleading "already connected" toast to the user.
+        var existing = sessionStore.FindActiveByUser(userId);
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "IBKR connect: user {UserId} already has an in-flight session {SessionId}; returning that id instead of starting a new one",
+                userId, existing.Value);
+            return existing.Value;
+        }
+
         var (sessionId, sessionToken) = sessionStore.Create(userId);
 
         // Fire-and-forget: the runner owns the session lifecycle from here.

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IBKRConnectSessionStore.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IBKRConnectSessionStore.cs
@@ -29,6 +29,21 @@ public sealed class IBKRConnectSessionStore : IIBKRConnectSessionStore, IDisposa
         return (sessionId, cts.Token);
     }
 
+    public Guid? FindActiveByUser(Guid userId)
+    {
+        foreach (var entry in _sessions.Values)
+        {
+            if (entry.UserId != userId)
+                continue;
+            lock (entry.SyncRoot)
+            {
+                if (!IsTerminal(entry.Status))
+                    return entry.Id;
+            }
+        }
+        return null;
+    }
+
     public IBKRConnectSessionSnapshot? Get(Guid sessionId, Guid userId)
     {
         if (!_sessions.TryGetValue(sessionId, out var entry) || entry.UserId != userId)

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IIBKRConnectSessionStore.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Connect/IIBKRConnectSessionStore.cs
@@ -13,6 +13,12 @@ public interface IIBKRConnectSessionStore
     /// orchestrator should observe.</summary>
     (Guid SessionId, CancellationToken Token) Create(Guid userId);
 
+    /// <summary>Find a non-terminal session for the user. Used by the
+    /// orchestrator to make Start(...) idempotent — rapid re-clicks return
+    /// the sessionId of the in-flight run instead of racing a new one against
+    /// the credential row and the still-warming IBeam container.</summary>
+    Guid? FindActiveByUser(Guid userId);
+
     /// <summary>Fetch a snapshot. Returns null when the session doesn't
     /// exist or belongs to a different user (never reveal cross-user state).</summary>
     IBKRConnectSessionSnapshot? Get(Guid sessionId, Guid userId);

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
@@ -56,11 +56,12 @@ public sealed class IBeamContainerManager : IIBeamContainerManager
                 "IBEAM_GATEWAY_BASE_URL=https://localhost:5000",
                 "IBEAM_LOG_LEVEL=INFO",
                 "IBEAM_ERROR_SCREENSHOTS=True",
-                // Post-login DOM wait. Default is 15s — too short for IB Key push
-                // 2FA where the user has to unlock a phone and tap approve. 90s
-                // gives realistic headroom without exceeding our .NET-side
-                // SpawnTimeoutSeconds=120 budget.
-                "IBEAM_PAGE_LOAD_TIMEOUT=90",
+                // Post-login DOM wait. Default is 15s — too short for IB Key
+                // push 2FA where the user has to unlock a phone and tap
+                // approve, and the round-trip alone is 5–20s. 180s covers the
+                // realistic slow-tap case; must stay under SpawnTimeoutSeconds
+                // (300s) so our .NET wrapper is the outer bound.
+                "IBEAM_PAGE_LOAD_TIMEOUT=180",
                 // Fail-fast on bad credentials / unhandled auth screens. IBeam's
                 // default is 5, which is enough to trip IBKR's account lockout
                 // counter before the caller ever sees a response.

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
@@ -37,9 +37,14 @@ public sealed class IBeamOptions
     public string ContainerNamePrefix { get; set; } = "finance-sentry-ibkr";
 
     /// <summary>
-    /// Max seconds to wait for the gateway to auth after spawn.
+    /// Max seconds to wait for the gateway to auth after spawn. Must cover:
+    /// IBeam cold-start (~90–120s for Java + Selenium), form submit + IBKR
+    /// 2FA push round-trip (~5–20s), human tap-approve time (up to ~60s),
+    /// and post-login DOM transition (~5s). 300s (5 min) gives comfortable
+    /// headroom without being so long that a genuinely failed connect
+    /// leaves the user waiting forever.
     /// </summary>
-    public int SpawnTimeoutSeconds { get; set; } = 120;
+    public int SpawnTimeoutSeconds { get; set; } = 300;
 
     /// <summary>
     /// URI to reach the Docker daemon. Defaults to the unix socket bound into

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRConnectOrchestratorTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRConnectOrchestratorTests.cs
@@ -1,0 +1,74 @@
+using FinanceSentry.Modules.BrokerageSync.Application.Connect;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace FinanceSentry.Tests.Unit.BrokerageSync;
+
+public class IBKRConnectOrchestratorTests
+{
+    [Fact]
+    public void Start_WhenNoInFlightSession_CreatesNew()
+    {
+        var store = new IBKRConnectSessionStore();
+        var scopeFactory = new NoOpScopeFactory();
+        var sut = new IBKRConnectOrchestrator(
+            scopeFactory, store, NullLogger<IBKRConnectOrchestrator>.Instance);
+
+        var userId = Guid.NewGuid();
+        var sessionId = sut.Start(userId, "u", "p");
+
+        sessionId.Should().NotBe(Guid.Empty);
+        store.Get(sessionId, userId).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Start_WhenInFlightSessionExists_ReturnsExistingSessionId()
+    {
+        var store = new IBKRConnectSessionStore();
+        var scopeFactory = new NoOpScopeFactory();
+        var sut = new IBKRConnectOrchestrator(
+            scopeFactory, store, NullLogger<IBKRConnectOrchestrator>.Instance);
+
+        var userId = Guid.NewGuid();
+        var (existing, _) = store.Create(userId);
+
+        var returned = sut.Start(userId, "u", "p");
+
+        returned.Should().Be(existing);
+    }
+
+    [Fact]
+    public void Start_WhenPriorSessionIsTerminal_CreatesNewSession()
+    {
+        var store = new IBKRConnectSessionStore();
+        var scopeFactory = new NoOpScopeFactory();
+        var sut = new IBKRConnectOrchestrator(
+            scopeFactory, store, NullLogger<IBKRConnectOrchestrator>.Instance);
+
+        var userId = Guid.NewGuid();
+        var (dead, _) = store.Create(userId);
+        store.MarkFailed(dead, "IBKR_INVALID_CREDENTIALS", "…");
+
+        var fresh = sut.Start(userId, "u", "p");
+
+        fresh.Should().NotBe(dead);
+    }
+
+    private sealed class NoOpScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope() => new NoOpScope();
+
+        private sealed class NoOpScope : IServiceScope
+        {
+            public IServiceProvider ServiceProvider { get; } = new EmptyProvider();
+            public void Dispose() { }
+        }
+
+        private sealed class EmptyProvider : IServiceProvider
+        {
+            public object? GetService(Type serviceType) => null;
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRConnectRunnerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRConnectRunnerTests.cs
@@ -240,4 +240,33 @@ public class IBKRConnectRunnerTests
 
         _sessionStore.Cancel(sessionId, attacker).Should().BeFalse();
     }
+
+    [Fact]
+    public void Store_FindActiveByUser_ReturnsInFlightSession()
+    {
+        var userId = Guid.NewGuid();
+        var (sessionId, _) = _sessionStore.Create(userId);
+
+        _sessionStore.FindActiveByUser(userId).Should().Be(sessionId);
+    }
+
+    [Fact]
+    public void Store_FindActiveByUser_IgnoresTerminalSessions()
+    {
+        var userId = Guid.NewGuid();
+        var (sessionId, _) = _sessionStore.Create(userId);
+        _sessionStore.MarkFailed(sessionId, "IBKR_INVALID_CREDENTIALS", "…");
+
+        _sessionStore.FindActiveByUser(userId).Should().BeNull();
+    }
+
+    [Fact]
+    public void Store_FindActiveByUser_IsolatesUsers()
+    {
+        var owner = Guid.NewGuid();
+        var attacker = Guid.NewGuid();
+        _sessionStore.Create(owner);
+
+        _sessionStore.FindActiveByUser(attacker).Should().BeNull();
+    }
 }

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -47,7 +47,7 @@ services:
       IBeam__Network: "${IBEAM_NETWORK:-finance-sentry}"
       IBeam__ConfHostPath: "${IBEAM_CONF_HOST_PATH:-/srv/finance-sentry/docker/ibkr/conf.yaml}"
       IBeam__ContainerNamePrefix: "finance-sentry-ibkr"
-      IBeam__SpawnTimeoutSeconds: "120"
+      IBeam__SpawnTimeoutSeconds: "300"
       IBeam__DockerEndpoint: "unix:///var/run/docker.sock"
     ports:
       - "127.0.0.1:${API_PORT:-5001}:5000"


### PR DESCRIPTION
## Summary

Second live IBKR connect attempt on VPS today reproduced two failure modes that combined to break the flow even with the async-session design from #246.

### 1. Cold-start + 2FA timing math is too tight

IBeam takes ~2:30 (Java + Chrome/Selenium warmup) before it can submit the login form. IBKR then pushes a 2FA notification to the phone. Realistic human tap-approve time is 30–60s (unlock phone, notice notification, open app, tap).

Under the previous budgets:
- `SpawnTimeoutSeconds = 120` (whole .NET-side wrapper)
- `IBEAM_PAGE_LOAD_TIMEOUT = 90` (Selenium post-submit DOM wait)

The effective 2FA window was **negative** — Selenium had already declared the login failed and `IBEAM_MAX_FAILED_AUTH=1` killed the container before Denys tapped approve. His approve landed on an abandoned session.

Bump:
- `IBeamOptions.SpawnTimeoutSeconds` 120 → **300** (5 min).
- `IBEAM_PAGE_LOAD_TIMEOUT` env 90 → **180** (3 min).
- `docker/docker-compose.prod.yml` `IBeam__SpawnTimeoutSeconds` override updated.
- `IBEAM_MAX_FAILED_AUTH=1` stays — it counts login-submit failures, not the 2FA wait window itself.

### 2. Rapid re-clicks surfaced misleading `IBKR_DUPLICATE`

While session 1 was mid-flight, Denys clicked Connect 4 more times over a minute (the UI didn't communicate progress clearly). Each subsequent `POST` created a *new* session; the runner immediately saw session 1's Reactivated credential (`IsActive=true`) and short-circuited with `IBKR_DUPLICATE`. Frontend surfaced *"IBKR account already connected. Disconnect the existing one to reconnect."* — confusing him into abandoning the flow while session 1 was still churning.

Fix — idempotent Start:
- New `IIBKRConnectSessionStore.FindActiveByUser(userId)` — O(n) scan for a non-terminal session belonging to the user.
- `IBKRConnectOrchestrator.Start()` short-circuits: if the user has an in-flight session, returns *that* sessionId instead of creating a new one. Rapid re-clicks converge on the same session and just keep polling. No more spurious `IBKR_DUPLICATE`, no more racing the runner against its own credential row.

## Test plan

- [x] `dotnet build FinanceSentry.sln` — clean (only long-standing `BankSync` warning).
- [x] `dotnet test --filter '~BrokerageSync|~IBKR'` — **20/20 unit** (6 new store/orchestrator tests) + **12/12 integration** pass.
- [ ] **After deploy**: retry Connect. Watch that (a) rapid re-clicks all return the same sessionId and none surface `IBKR_DUPLICATE`, and (b) the 2FA tap has time to land before IBeam gives up.

## Still not in scope

Frontend button-lock (disable Connect while a session is in-flight, show explicit progress indicator per status). The backend idempotency guard eliminates the confusing error toast, but proper UX still wants the button disabled + a progress state visible so the user knows to wait instead of re-clicking. Worth a separate frontend-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)