### PR TITLE
fix(ibkr): revert aggressive env vars + drop conf.yaml mount

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamContainerManager.cs
@@ -49,6 +49,16 @@ public sealed class IBeamContainerManager : IIBeamContainerManager
         {
             Name = containerName,
             Image = _options.Image,
+            // Matches the env-var shape that empirically worked on the old
+            // single-tenant `ibkr-gateway` service (commit 233224a). The
+            // aggressive limits I added in #245 (IBEAM_MAX_FAILED_AUTH=1,
+            // IBEAM_REQUEST_RETRIES=1) turned out to fight IB Key push 2FA:
+            // IBeam counts "browser login DOM ok but /auth/status still false"
+            // as a failed attempt, and with =1 the container dies before the
+            // user can tap approve on their phone. Reverting to IBeam's own
+            // defaults (5 attempts) so the polling loop overlaps the human
+            // tap window. The PAGE_LOAD_TIMEOUT bump we keep — it's a pure
+            // widening of the Selenium DOM-wait, no downside.
             Env =
             [
                 $"IBEAM_ACCOUNT={ibkrUsername}",
@@ -56,23 +66,14 @@ public sealed class IBeamContainerManager : IIBeamContainerManager
                 "IBEAM_GATEWAY_BASE_URL=https://localhost:5000",
                 "IBEAM_LOG_LEVEL=INFO",
                 "IBEAM_ERROR_SCREENSHOTS=True",
-                // Post-login DOM wait. Default is 15s — too short for IB Key
-                // push 2FA where the user has to unlock a phone and tap
-                // approve, and the round-trip alone is 5–20s. 180s covers the
-                // realistic slow-tap case; must stay under SpawnTimeoutSeconds
-                // (300s) so our .NET wrapper is the outer bound.
                 "IBEAM_PAGE_LOAD_TIMEOUT=180",
-                // Fail-fast on bad credentials / unhandled auth screens. IBeam's
-                // default is 5, which is enough to trip IBKR's account lockout
-                // counter before the caller ever sees a response.
-                "IBEAM_MAX_FAILED_AUTH=1",
-                "IBEAM_REQUEST_RETRIES=1",
             ],
             HostConfig = new HostConfig
             {
-                Binds = string.IsNullOrWhiteSpace(_options.ConfHostPath)
-                    ? null
-                    : [$"{_options.ConfHostPath}:/srv/inputs/conf.yaml:ro"],
+                // No conf.yaml bind-mount. The old single-tenant service that
+                // worked with 2FA didn't mount one either, and the custom conf
+                // we were pinning (ip2loc, allow-ip ranges) is the most likely
+                // reason IBeam's CPG reported authenticated=false after login.
                 NetworkMode = _options.Network,
                 RestartPolicy = new RestartPolicy { Name = RestartPolicyKind.UnlessStopped },
             },

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBeamOptions.cs
@@ -3,10 +3,12 @@ namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR;
 /// <summary>
 /// Configuration for the per-user IBeam Docker orchestration.
 ///
-/// The API container spawns one <c>voyz/ibeam</c> container per connected user.
-/// Each container joins <see cref="Network"/>, mounts the conf file from
-/// <see cref="ConfHostPath"/>, and gets a stable name so the API can address it
-/// by DNS at <c>https://finance-sentry-ibkr-{shortId}:5000</c>.
+/// The API container spawns one <c>voyz/ibeam</c> container per connected user,
+/// joined to <see cref="Network"/> with a stable name so the API can address it
+/// by DNS at <c>https://finance-sentry-ibkr-{shortId}:5000</c>. IBeam uses its
+/// bundled default IBKR Client Portal Gateway conf; we no longer bind-mount a
+/// custom conf.yaml because the extra vars we were pinning (ip2loc, allow-ip
+/// ranges) interacted badly with the IB Key push 2FA flow.
 /// </summary>
 public sealed class IBeamOptions
 {
@@ -22,12 +24,6 @@ public sealed class IBeamOptions
     /// network the API itself is on so it can resolve container names via DNS.
     /// </summary>
     public string Network { get; set; } = "docker_finance-sentry-network";
-
-    /// <summary>
-    /// Absolute path on the host to <c>docker/ibkr/conf.yaml</c>. The API bind
-    /// mounts this into every spawned IBeam at <c>/srv/inputs/conf.yaml</c>.
-    /// </summary>
-    public string ConfHostPath { get; set; } = string.Empty;
 
     /// <summary>
     /// Prefix for spawned container names. Full name is

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -44,9 +44,8 @@ services:
       # Per-user IBeam orchestration
       IBeam__Image: "voyz/ibeam:latest"
       IBeam__Network: "docker_finance-sentry-network"
-      IBeam__ConfHostPath: "${PWD}/ibkr/conf.yaml"
       IBeam__ContainerNamePrefix: "finance-sentry-ibkr"
-      IBeam__SpawnTimeoutSeconds: "120"
+      IBeam__SpawnTimeoutSeconds: "300"
       IBeam__DockerEndpoint: "unix:///var/run/docker.sock"
     ports:
       - "5001:5000"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -45,7 +45,6 @@ services:
       # "finance-sentry" (no compose prefix — see networks: block at the bottom).
       IBeam__Image: "voyz/ibeam:latest"
       IBeam__Network: "${IBEAM_NETWORK:-finance-sentry}"
-      IBeam__ConfHostPath: "${IBEAM_CONF_HOST_PATH:-/srv/finance-sentry/docker/ibkr/conf.yaml}"
       IBeam__ContainerNamePrefix: "finance-sentry-ibkr"
       IBeam__SpawnTimeoutSeconds: "300"
       IBeam__DockerEndpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
## Summary

Live VPS test showed IB Key push 2FA looping — Denys tapped approve **3 times** and the IBeam container still concluded "reauth failed" and restarted the login flow (sending fresh 2FA prompts each cycle).

Root cause: **our env-var overlay is fighting the flow that used to work.** Diff of the current spawn against the old single-tenant `ibkr-gateway` service (commit `233224a` — Denys's last known-working IBKR connect) showed we added two aggressive limits + a bind-mount that the old flow never had.

## What changed

**Reverted (were causing the loop):**
- `IBEAM_MAX_FAILED_AUTH=1` → IBeam default (5). IBeam counts "browser login DOM ok but `/auth/status` still false" as a failed auth. With =1 the container dies after one such miss, before the user finishes tapping approve on their phone. With the default, IBeam gets 4 more chances and its polling loop overlaps the human tap window. The lockout-risk that motivated =1 in #245 is already covered by the default (5 total is nowhere near brute-force territory).
- `IBEAM_REQUEST_RETRIES=1` → IBeam default (5). Same story.
- `/srv/inputs/conf.yaml` bind-mount → removed. The old working flow didn't mount one. The custom CPG conf we were pinning (`ip2loc: "US"`, allow-IP ranges) is the most likely remaining reason IBKR's CPG kept returning `authenticated=false` after login. `IBeamOptions.ConfHostPath` + `HostConfig.Binds` branch + both compose overrides all deleted.

**Kept (know they help):**
- `IBEAM_PAGE_LOAD_TIMEOUT=180` — pure widening of Selenium DOM-wait, no downside. Keeps the 2FA-tap headroom win from #245/#247.
- `IBEAM_ERROR_SCREENSHOTS=True` — debug-only, harmless.
- `SpawnTimeoutSeconds=300` outer bound.
- Dev compose `SpawnTimeoutSeconds` bumped 120→300 for parity with prod.

## Test plan

- [x] `dotnet build FinanceSentry.sln` — clean (only long-standing `BankSync` warning).
- [x] `dotnet test --filter '~BrokerageSync|~IBKR'` — **20/20 unit** + **12/12 integration** pass. Env-var construction isn't asserted at the unit-test layer (integration factory mocks `IIBeamContainerManager`), so no test changes needed.
- [ ] **After deploy**: retry Connect. Expected sequence in IBeam logs:
  1. `Login attempt number 1` → form submit
  2. IBKR pushes to phone → Denys taps approve
  3. `Repeatedly reauthenticating…` may still appear once, but with default 5 retries IBeam's `/auth/status` poll should catch the authenticated state on retries 2-4 instead of dying at 1
  4. `authenticated=True` → `.NET` side sees success → session status `syncing` → `completed`.

## Not in scope

Long-term durable fix (pin IBeam image tag, or add first-class 2FA-code entry UI). This PR is the minimum change to reproduce the config that empirically worked before, without carrying over the constraints that broke it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)