### PR TITLE
fix(bank-sync): wire per-account recurring sync, tighten cadence to 30 min

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
@@ -37,6 +37,22 @@ public static class BankSyncModule
         public void RegisterJobs(IServiceProvider sp)
         {
             var mgr = sp.GetRequiredService<IRecurringJobManager>();
+
+            mgr.AddOrUpdate<SyncScheduler>(
+                "bank-account-sync-scheduler",
+                s => s.ScheduleAllActiveAccounts(CancellationToken.None),
+                "*/10 * * * *");
+
+            mgr.AddOrUpdate<DataRetentionJob>(
+                "data-retention",
+                job => job.RunAsync(false, CancellationToken.None),
+                Cron.Monthly());
+
+            mgr.AddOrUpdate<CredentialBackupJob>(
+                "credential-backup",
+                job => job.RunAsync(CancellationToken.None),
+                Cron.Weekly());
+
             mgr.AddOrUpdate<UnusualSpendDetectionJob>(
                 "unusual-spend-detection",
                 job => job.ExecuteAsync(CancellationToken.None),
@@ -45,6 +61,9 @@ public static class BankSyncModule
                 "subscription-detection",
                 job => job.ExecuteAsync(CancellationToken.None),
                 Cron.Daily());
+
+            BackgroundJob.Enqueue<SyncScheduler>(
+                s => s.ScheduleAllActiveAccounts(CancellationToken.None));
         }
     }
 

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs
@@ -32,30 +32,22 @@ public class SyncScheduler(
     IBankAccountRepository accounts,
     IRecurringJobManager recurringJobs)
 {
+    private const string PerAccountCron = "*/30 * * * *";
+
     private readonly IBankAccountRepository _accounts = accounts;
     private readonly IRecurringJobManager _recurringJobs = recurringJobs;
 
     public async Task ScheduleAllActiveAccounts(CancellationToken ct = default)
     {
         var activeAccounts = await _accounts.GetAllActiveAsync(ct);
+        var activeIds = new HashSet<Guid>(activeAccounts.Select(a => a.Id));
 
         foreach (var account in activeAccounts)
         {
             _recurringJobs.AddOrUpdate<ScheduledSyncJob>(
                 $"sync-account-{account.Id}",
                 job => job.ExecuteSyncAsync(account.Id),
-                "0 */2 * * *");
+                PerAccountCron);
         }
-
-        _recurringJobs.AddOrUpdate<DataRetentionJob>(
-            "data-retention",
-            job => job.RunAsync(false, CancellationToken.None),
-            Cron.Monthly());
-
-        _recurringJobs.AddOrUpdate<CredentialBackupJob>(
-            "credential-backup",
-            job => job.RunAsync(CancellationToken.None),
-            Cron.Weekly());
-
     }
 }


### PR DESCRIPTION
## Summary

`SyncScheduler.ScheduleAllActiveAccounts()` was defined but never called anywhere in the codebase, so no per-account recurring cron ever got registered in Hangfire.

Observed on VPS just now:
| Provider | Freshest | Stalest |
|---|---|---|
| Plaid (Chase, Citi, TD, AIB) | 75 days | 75 days |
| TrueLayer (Revolut IE, AIB) | 3 days | 3 days |
| Monobank (5 accounts) | 2 days | 2 days |

Bank data was only fresh at the moment of connect, then went stale forever unless the user manually poked a reconnect.

## Fix

- `BankSyncModule.JobRegistrar` now registers `bank-account-sync-scheduler` (every 10 min) which calls `ScheduleAllActiveAccounts` to (re)register a `ScheduledSyncJob` for every active account.
- Also `BackgroundJob.Enqueue` on startup so the first schedule pass fires immediately — Hangfire in-memory storage wipes recurring jobs on API restart, so this matters after every deploy.
- Per-account sync cron tightened from `0 */2 * * *` (every 2h) to `*/30 * * * *` (every 30 min) — matches the near-real-time expectation while leaving Plaid/TrueLayer/Monobank plenty of rate-limit headroom.
- `DataRetentionJob` (monthly) and `CredentialBackupJob` (weekly) moved from `SyncScheduler` into `JobRegistrar` next to the other bank-sync recurring jobs, so `JobRegistrar` owns all recurring registration in one place.

IBKR + Binance already sync every 15 min via their own `JobRegistrar`s and are unaffected.

## Test plan
- [x] Solution builds with 0 new warnings
- [ ] After deploy: within 1 min of API restart, `Hangfire` recurring list contains `sync-account-<id>` per active account
- [ ] Within 30 min of deploy: `bank_sync.BankAccounts.UpdatedAt` shows all providers < 30 min stale
- [ ] Newly connected account: `bank-account-sync-scheduler` picks it up within 10 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)