### PR TITLE
fix(bank-sync): populate lastSyncTimestamp on GET /accounts response

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetAccountsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetAccountsQuery.cs
@@ -76,7 +76,7 @@ public class GetAccountsQueryHandler(IBankAccountRepository accounts) : IQueryHa
             a.CurrentBalance,
             null,
             a.SyncStatus,
-            null,
+            a.UpdatedAt,
             a.CreatedAt,
             a.Provider
         )).ToList();


### PR DESCRIPTION
## Summary

`GetAccountsQueryHandler` was passing a hardcoded `null` for the `LastSyncTimestamp` field of `BankAccountDto` — the frontend always saw `"lastSyncTimestamp": null` regardless of actual sync freshness, so users saw stale "synced Nh ago" chips even right after a fresh sync.

Maps it to `BankAccount.UpdatedAt`, which is bumped every time a sync touches the entity (see `BankAccount.MarkSynced` / `MarkSyncFailed`).

This complements PR #251 (recurring bank-sync wire-up). Together they resolve Denys's report that his Revolut balance looked 75h stale even though the underlying data was fine.

## Test plan
- [x] Solution builds clean
- [ ] After deploy: `GET /api/v1/accounts` returns non-null `lastSyncTimestamp` for every account, matching the DB `UpdatedAt`
- [ ] Frontend "last synced" chip reflects real freshness (should show minutes/seconds, not days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)