### PR TITLE
fix(accounts): move sync chip to institution level, add for brokerage + crypto

### DIFF
--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -132,14 +132,6 @@
                           •••• {{ account.accountNumberLast4 }}
                         </p>
                       </td>
-                      <td class="py-cmn-3 px-cmn-4">
-                        <cmn-status-indicator
-                          [variant]="account.syncStatus | syncStatusVariant"
-                          [timestampLabel]="account.lastSyncTimestamp | relativeTime"
-                        >
-                          {{ account.syncStatus | syncStatusLabel }}
-                        </cmn-status-indicator>
-                      </td>
                       <td
                         class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
                       >
@@ -186,6 +178,12 @@
                     </p>
                   </div>
                 </div>
+                <cmn-status-indicator
+                  [variant]="inst.syncStatus | syncStatusVariant"
+                  [timestampLabel]="inst.lastSyncTimestamp | relativeTime"
+                >
+                  {{ inst.syncStatus | syncStatusLabel }}
+                </cmn-status-indicator>
                 <div
                   class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]"
                 >
@@ -273,6 +271,12 @@
                     </p>
                   </div>
                 </div>
+                <cmn-status-indicator
+                  [variant]="inst.syncStatus | syncStatusVariant"
+                  [timestampLabel]="inst.lastSyncTimestamp | relativeTime"
+                >
+                  {{ inst.syncStatus | syncStatusLabel }}
+                </cmn-status-indicator>
                 <div
                   class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]"
                 >


### PR DESCRIPTION
## Summary

Two related UI issues on the accounts list:

1. **Banking:** Monobank shows one institution with many per-currency cards. Repeating a "last synced" chip on every card row was noisy — Denys wanted just one chip per institution.
2. **Brokerage (IBKR) + Digital Assets (Binance):** no "last synced" chip at all, so users couldn't tell if positions were fresh.

## Fix

Frontend template only. Backend `WealthAggregationService` already computes and returns `Institution.lastSyncTimestamp` for both brokerage (`MAX(BrokerageHoldings.SyncedAt)`) and crypto (`MAX(CryptoHoldings.SyncedAt)`) — the template just wasn't rendering it.

- Removed the per-card `cmn-status-indicator` block from the banking accounts sub-rows.
- Added an institution-level `cmn-status-indicator` block on both the brokerage and crypto section headers, mirroring the banking header pattern.

## Test plan
- [x] ESLint passes
- [ ] Load `/accounts` — each of Banking/Brokerage/Digital Assets shows a single "synced X ago" chip per institution
- [ ] Monobank institution shows one chip; individual cards no longer show a chip
- [ ] Chip on IBKR + Binance reflects the freshest `SyncedAt` across holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)