### PR TITLE
Fix alert spam and make alert types legible

### DIFF
--- a/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
@@ -6,6 +6,10 @@ using FinanceSentry.Modules.Alerts.Domain.Repositories;
 
 public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorService
 {
+    private static readonly TimeSpan LowBalanceSilenceWindow = TimeSpan.FromHours(24);
+    private static readonly TimeSpan SyncFailureSilenceWindow = TimeSpan.FromHours(12);
+    private static readonly TimeSpan UnusualSpendSilenceWindow = TimeSpan.FromDays(7);
+
     private readonly IAlertRepository _alerts = alerts;
 
     public async Task GenerateLowBalanceAlertAsync(
@@ -14,6 +18,10 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
     {
         var existing = await _alerts.FindActiveAsync(userId, AlertType.LowBalance, accountId, ct);
         if (existing is not null) return;
+
+        var quietSince = DateTimeOffset.UtcNow - LowBalanceSilenceWindow;
+        if (await _alerts.HasRecentAsync(userId, AlertType.LowBalance, accountId, accountName, quietSince, ct))
+            return;
 
         await _alerts.AddAsync(new Alert
         {
@@ -41,6 +49,10 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
     {
         var existing = await _alerts.FindActiveAsync(userId, AlertType.SyncFailure, accountId, ct);
         if (existing is not null) return;
+
+        var quietSince = DateTimeOffset.UtcNow - SyncFailureSilenceWindow;
+        if (await _alerts.HasRecentAsync(userId, AlertType.SyncFailure, accountId, accountName, quietSince, ct))
+            return;
 
         var label = accountName ?? provider;
         var detail = errorCode is null ? string.Empty : $" (error: {errorCode})";
@@ -74,6 +86,10 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
     {
         var existing = await _alerts.FindActiveAsync(userId, AlertType.UnusualSpend, null, ct);
         if (existing is not null && existing.ReferenceLabel == category) return;
+
+        var quietSince = DateTimeOffset.UtcNow - UnusualSpendSilenceWindow;
+        if (await _alerts.HasRecentAsync(userId, AlertType.UnusualSpend, null, category, quietSince, ct))
+            return;
 
         await _alerts.AddAsync(new Alert
         {

--- a/backend/src/FinanceSentry.Modules.Alerts/Domain/Repositories/IAlertRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Domain/Repositories/IAlertRepository.cs
@@ -10,6 +10,10 @@ public interface IAlertRepository
     Task<Alert?> FindActiveAsync(
         Guid userId, string type, Guid? referenceId, CancellationToken ct = default);
 
+    Task<bool> HasRecentAsync(
+        Guid userId, string type, Guid? referenceId, string? referenceLabel, DateTimeOffset createdAfter,
+        CancellationToken ct = default);
+
     Task<bool> MarkReadAsync(Guid userId, Guid alertId, CancellationToken ct = default);
 
     Task MarkAllReadAsync(Guid userId, CancellationToken ct = default);

--- a/backend/src/FinanceSentry.Modules.Alerts/Infrastructure/Persistence/Repositories/AlertRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Infrastructure/Persistence/Repositories/AlertRepository.cs
@@ -53,6 +53,18 @@ public class AlertRepository(AlertsDbContext db) : IAlertRepository
             .FirstOrDefaultAsync(ct);
     }
 
+    public Task<bool> HasRecentAsync(
+        Guid userId, string type, Guid? referenceId, string? referenceLabel, DateTimeOffset createdAfter,
+        CancellationToken ct = default)
+    {
+        return _db.Alerts.AsNoTracking()
+            .AnyAsync(a => a.UserId == userId
+                        && a.Type == type
+                        && a.ReferenceId == referenceId
+                        && a.ReferenceLabel == referenceLabel
+                        && a.CreatedAt >= createdAfter, ct);
+    }
+
     public async Task<bool> MarkReadAsync(Guid userId, Guid alertId, CancellationToken ct = default)
     {
         var alert = await _db.Alerts.FirstOrDefaultAsync(a => a.Id == alertId && a.UserId == userId, ct);

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/DisconnectInstitutionCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/DisconnectInstitutionCommand.cs
@@ -18,7 +18,6 @@ public sealed record DisconnectInstitutionResult(int RemovedAccounts);
 
 public sealed class DisconnectInstitutionCommandHandler(
     IBankAccountRepository accounts,
-    ITransactionRepository transactions,
     IMonobankCredentialRepository monobankCredentials,
     ITrueLayerConnectionRepository trueLayerConnections,
     IAlertGeneratorService alerts)

--- a/backend/src/FinanceSentry.Modules.Wealth/Domain/Repositories/INetWorthSnapshotRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Domain/Repositories/INetWorthSnapshotRepository.cs
@@ -4,5 +4,6 @@ public interface INetWorthSnapshotRepository
 {
     Task PersistAsync(NetWorthSnapshot snapshot, CancellationToken ct = default);
     Task<bool> ExistsAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct = default);
+    Task<NetWorthSnapshot?> GetLatestByUserIdAsync(Guid userId, CancellationToken ct = default);
     Task<IReadOnlyList<NetWorthSnapshot>> GetByUserIdAsync(Guid userId, DateOnly? from, DateOnly? to, CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotBackfillService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotBackfillService.cs
@@ -1,0 +1,46 @@
+namespace FinanceSentry.Modules.Wealth.Infrastructure.Jobs;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Wealth.Domain.Repositories;
+
+public sealed class NetWorthSnapshotBackfillService(
+    IBankingTotalsReader bankingTotalsReader,
+    INetWorthSnapshotRepository snapshotRepository,
+    NetWorthSnapshotJob snapshotJob)
+{
+    private static readonly TimeSpan StaleSnapshotThreshold = TimeSpan.FromHours(20);
+
+    private readonly IBankingTotalsReader _bankingTotalsReader = bankingTotalsReader ?? throw new ArgumentNullException(nameof(bankingTotalsReader));
+    private readonly INetWorthSnapshotRepository _snapshotRepository = snapshotRepository ?? throw new ArgumentNullException(nameof(snapshotRepository));
+    private readonly NetWorthSnapshotJob _snapshotJob = snapshotJob ?? throw new ArgumentNullException(nameof(snapshotJob));
+
+    public async Task BackfillAsync(CancellationToken ct = default)
+    {
+        var activeUserIds = await _bankingTotalsReader.GetActiveUserIdsAsync(ct);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var now = DateTimeOffset.UtcNow;
+
+        foreach (var userId in activeUserIds)
+            await BackfillUserAsync(userId, today, now, ct);
+    }
+
+    private async Task BackfillUserAsync(Guid userId, DateOnly today, DateTimeOffset now, CancellationToken ct)
+    {
+        var latestSnapshot = await _snapshotRepository.GetLatestByUserIdAsync(userId, ct);
+
+        if (latestSnapshot is null)
+        {
+            await _snapshotJob.CaptureForUserAsync(userId, today, ct);
+            return;
+        }
+
+        var backfillStart = latestSnapshot.SnapshotDate.AddDays(1);
+        var backfillEnd = today.AddDays(-1);
+
+        for (var date = backfillStart; date <= backfillEnd; date = date.AddDays(1))
+            await _snapshotJob.CaptureForUserAsync(userId, date, ct);
+
+        if (latestSnapshot.SnapshotDate < today && now - latestSnapshot.TakenAt >= StaleSnapshotThreshold)
+            await _snapshotJob.CaptureForUserAsync(userId, today, ct);
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotCatchUpHostedService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotCatchUpHostedService.cs
@@ -1,0 +1,31 @@
+namespace FinanceSentry.Modules.Wealth.Infrastructure.Jobs;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public sealed class NetWorthSnapshotCatchUpHostedService(
+    IServiceScopeFactory scopeFactory,
+    ILogger<NetWorthSnapshotCatchUpHostedService> logger) : BackgroundService
+{
+    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(15);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await Task.Delay(StartupDelay, stoppingToken);
+
+            using var scope = scopeFactory.CreateScope();
+            var catchUpService = scope.ServiceProvider.GetRequiredService<NetWorthSnapshotBackfillService>();
+            await catchUpService.BackfillAsync(stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Net worth snapshot catch-up failed.");
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
@@ -16,17 +16,23 @@ public class NetWorthSnapshotJob(
 
     [AutomaticRetry(Attempts = 2)]
     public async Task ExecuteAsync(CancellationToken ct = default)
-    {
-        var userIds = await _bankingTotals.GetActiveUserIdsAsync(ct);
-        foreach (var userId in userIds)
-            await TakeSnapshotAsync(userId, ct);
-    }
+        => await CaptureAllUsersAsync(DateOnly.FromDateTime(DateTime.UtcNow), ct);
 
     [AutomaticRetry(Attempts = 2)]
     public async Task ExecuteForUserAsync(Guid userId, CancellationToken ct = default)
-        => await TakeSnapshotAsync(userId, ct);
+        => await CaptureForUserAsync(userId, DateOnly.FromDateTime(DateTime.UtcNow), ct);
 
-    private async Task TakeSnapshotAsync(Guid userId, CancellationToken ct)
+    public async Task CaptureAllUsersAsync(DateOnly snapshotDate, CancellationToken ct = default)
+    {
+        var userIds = await _bankingTotals.GetActiveUserIdsAsync(ct);
+        foreach (var userId in userIds)
+            await CaptureForUserAsync(userId, snapshotDate, ct);
+    }
+
+    public async Task CaptureForUserAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct = default)
+        => await TakeSnapshotAsync(userId, snapshotDate, ct);
+
+    private async Task TakeSnapshotAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct)
     {
         var bankingTotal = await _bankingTotals.GetTotalUsdAsync(userId, ct);
 
@@ -35,8 +41,6 @@ public class NetWorthSnapshotJob(
 
         var brokerageHoldings = await _brokerageReader.GetHoldingsAsync(userId, ct);
         var brokerageTotal = brokerageHoldings.Sum(h => h.UsdValue);
-
-        var snapshotDate = DateOnly.FromDateTime(DateTime.UtcNow);
 
         await _snapshotService.PersistSnapshotAsync(userId, new NetWorthSnapshotData(
             snapshotDate, bankingTotal, brokerageTotal, cryptoTotal), ct);

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Persistence/Repositories/NetWorthSnapshotRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Persistence/Repositories/NetWorthSnapshotRepository.cs
@@ -17,6 +17,13 @@ public class NetWorthSnapshotRepository(WealthDbContext db) : INetWorthSnapshotR
     public Task<bool> ExistsAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct = default)
         => _db.NetWorthSnapshots.AnyAsync(s => s.UserId == userId && s.SnapshotDate == snapshotDate, ct);
 
+    public Task<NetWorthSnapshot?> GetLatestByUserIdAsync(Guid userId, CancellationToken ct = default)
+        => _db.NetWorthSnapshots
+            .Where(s => s.UserId == userId)
+            .OrderByDescending(s => s.SnapshotDate)
+            .ThenByDescending(s => s.TakenAt)
+            .FirstOrDefaultAsync(ct);
+
     public async Task<IReadOnlyList<NetWorthSnapshot>> GetByUserIdAsync(Guid userId, DateOnly? from, DateOnly? to, CancellationToken ct = default)
     {
         var query = _db.NetWorthSnapshots.Where(s => s.UserId == userId);

--- a/backend/src/FinanceSentry.Modules.Wealth/WealthModule.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/WealthModule.cs
@@ -41,10 +41,12 @@ public static class WealthModule
 
         services.AddScoped<INetWorthSnapshotRepository, NetWorthSnapshotRepository>();
         services.AddScoped<INetWorthSnapshotService, NetWorthSnapshotService>();
+        services.AddScoped<NetWorthSnapshotBackfillService>();
         services.AddScoped<INetWorthSnapshotJobScheduler, NetWorthSnapshotJobScheduler>();
         services.AddScoped<IWealthAggregationService, WealthAggregationService>();
 
         services.AddScoped<NetWorthSnapshotJob>();
+        services.AddHostedService<NetWorthSnapshotCatchUpHostedService>();
 
         services.AddSingleton<IJobRegistrar, JobRegistrar>();
 

--- a/backend/tests/FinanceSentry.Tests.Unit/Alerts/AlertGeneratorServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Alerts/AlertGeneratorServiceTests.cs
@@ -23,6 +23,9 @@ public class AlertGeneratorServiceTests
     {
         _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.LowBalance, _accountId, default))
             .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.LowBalance, _accountId, "Chase", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(false);
 
         await _service.GenerateLowBalanceAlertAsync(_userId, _accountId, "Chase", 100m, 500m);
 
@@ -38,6 +41,25 @@ public class AlertGeneratorServiceTests
     {
         _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.LowBalance, _accountId, default))
             .ReturnsAsync(new Alert { Id = Guid.NewGuid() });
+
+        await _service.GenerateLowBalanceAlertAsync(_userId, _accountId, "Chase", 100m, 500m);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<Alert>(), default), Times.Never);
+        _repo.Verify(
+            r => r.HasRecentAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string?>(),
+                It.IsAny<DateTimeOffset>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateLowBalance_RecentDismissed_SkipsCreation()
+    {
+        _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.LowBalance, _accountId, default))
+            .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.LowBalance, _accountId, "Chase", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(true);
 
         await _service.GenerateLowBalanceAlertAsync(_userId, _accountId, "Chase", 100m, 500m);
 
@@ -72,6 +94,9 @@ public class AlertGeneratorServiceTests
     {
         _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.SyncFailure, _accountId, default))
             .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.SyncFailure, _accountId, "Chase", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(false);
 
         await _service.GenerateSyncFailureAlertAsync(_userId, "plaid", _accountId, "Chase", "ITEM_LOGIN_REQUIRED");
 
@@ -93,10 +118,27 @@ public class AlertGeneratorServiceTests
     }
 
     [Fact]
+    public async Task GenerateSyncFailure_RecentDismissed_SkipsCreation()
+    {
+        _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.SyncFailure, _accountId, default))
+            .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.SyncFailure, _accountId, "Chase", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(true);
+
+        await _service.GenerateSyncFailureAlertAsync(_userId, "plaid", _accountId, "Chase", "ITEM_LOGIN_REQUIRED");
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<Alert>(), default), Times.Never);
+    }
+
+    [Fact]
     public async Task GenerateUnusualSpend_NoExisting_AddsInfoAlert()
     {
         _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.UnusualSpend, null, default))
             .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.UnusualSpend, null, "Restaurants", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(false);
 
         await _service.GenerateUnusualSpendAlertAsync(_userId, "Restaurants", 1200m, 400m);
 
@@ -104,5 +146,19 @@ public class AlertGeneratorServiceTests
             a.Type == AlertType.UnusualSpend &&
             a.Severity == AlertSeverity.Info &&
             a.ReferenceLabel == "Restaurants"), default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateUnusualSpend_RecentDismissed_SkipsCreation()
+    {
+        _repo.Setup(r => r.FindActiveAsync(_userId, AlertType.UnusualSpend, null, default))
+            .ReturnsAsync((Alert?)null);
+        _repo.Setup(r => r.HasRecentAsync(
+                _userId, AlertType.UnusualSpend, null, "Restaurants", It.IsAny<DateTimeOffset>(), default))
+            .ReturnsAsync(true);
+
+        await _service.GenerateUnusualSpendAlertAsync(_userId, "Restaurants", 1200m, 400m);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<Alert>(), default), Times.Never);
     }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotBackfillServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotBackfillServiceTests.cs
@@ -1,0 +1,107 @@
+namespace FinanceSentry.Tests.Unit.Wealth;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Wealth.Domain;
+using FinanceSentry.Modules.Wealth.Domain.Repositories;
+using FinanceSentry.Modules.Wealth.Infrastructure.Jobs;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+public class NetWorthSnapshotBackfillServiceTests
+{
+    private static readonly Guid UserId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    private static NetWorthSnapshotJob BuildJob(List<DateOnly> capturedDates)
+    {
+        var bankingTotalsMock = new Mock<IBankingTotalsReader>();
+        bankingTotalsMock.Setup(r => r.GetActiveUserIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([UserId]);
+        bankingTotalsMock.Setup(r => r.GetTotalUsdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1000m);
+
+        var cryptoMock = new Mock<ICryptoHoldingsReader>();
+        cryptoMock.Setup(r => r.GetHoldingsAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var brokerageMock = new Mock<IBrokerageHoldingsReader>();
+        brokerageMock.Setup(r => r.GetHoldingsAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var snapshotServiceMock = new Mock<INetWorthSnapshotService>();
+        snapshotServiceMock
+            .Setup(s => s.PersistSnapshotAsync(UserId, It.IsAny<NetWorthSnapshotData>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, NetWorthSnapshotData, CancellationToken>((_, data, _) => capturedDates.Add(data.SnapshotDate))
+            .Returns(Task.CompletedTask);
+
+        return new NetWorthSnapshotJob(
+            bankingTotalsMock.Object,
+            cryptoMock.Object,
+            brokerageMock.Object,
+            snapshotServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task BackfillAsync_FillsMissingDates_AndRefreshesStaleTodaySnapshot()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var capturedDates = new List<DateOnly>();
+        var job = BuildJob(capturedDates);
+        var snapshotRepositoryMock = new Mock<INetWorthSnapshotRepository>();
+        snapshotRepositoryMock
+            .Setup(r => r.GetLatestByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NetWorthSnapshot
+            {
+                Id = Guid.NewGuid(),
+                UserId = UserId,
+                SnapshotDate = today.AddDays(-3),
+                TakenAt = DateTimeOffset.UtcNow.AddHours(-48),
+            });
+
+        var bankingTotalsMock = new Mock<IBankingTotalsReader>();
+        bankingTotalsMock.Setup(r => r.GetActiveUserIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([UserId]);
+
+        var sut = new NetWorthSnapshotBackfillService(
+            bankingTotalsMock.Object,
+            snapshotRepositoryMock.Object,
+            job);
+
+        await sut.BackfillAsync();
+
+        capturedDates.Should().Equal(
+            today.AddDays(-2),
+            today.AddDays(-1),
+            today);
+    }
+
+    [Fact]
+    public async Task BackfillAsync_DoesNothingForFreshSnapshot()
+    {
+        var capturedDates = new List<DateOnly>();
+        var job = BuildJob(capturedDates);
+        var snapshotRepositoryMock = new Mock<INetWorthSnapshotRepository>();
+        snapshotRepositoryMock
+            .Setup(r => r.GetLatestByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new NetWorthSnapshot
+            {
+                Id = Guid.NewGuid(),
+                UserId = UserId,
+                SnapshotDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                TakenAt = DateTimeOffset.UtcNow,
+            });
+
+        var bankingTotalsMock = new Mock<IBankingTotalsReader>();
+        bankingTotalsMock.Setup(r => r.GetActiveUserIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([UserId]);
+
+        var sut = new NetWorthSnapshotBackfillService(
+            bankingTotalsMock.Object,
+            snapshotRepositoryMock.Object,
+            job);
+
+        await sut.BackfillAsync();
+
+        capturedDates.Should().BeEmpty();
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotJobTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotJobTests.cs
@@ -64,10 +64,16 @@ public class NetWorthSnapshotJobTests
     public async Task ExecuteForUserAsync_PersistsSnapshotForSpecificUser()
     {
         Guid? capturedUserId = null;
+        DateOnly? capturedSnapshotDate = null;
+        var expectedDate = DateOnly.FromDateTime(DateTime.UtcNow);
         var snapshotServiceMock = new Mock<INetWorthSnapshotService>();
         snapshotServiceMock
             .Setup(s => s.PersistSnapshotAsync(It.IsAny<Guid>(), It.IsAny<NetWorthSnapshotData>(), It.IsAny<CancellationToken>()))
-            .Callback<Guid, NetWorthSnapshotData, CancellationToken>((uid, _, _) => capturedUserId = uid)
+            .Callback<Guid, NetWorthSnapshotData, CancellationToken>((uid, data, _) =>
+            {
+                capturedUserId = uid;
+                capturedSnapshotDate = data.SnapshotDate;
+            })
             .Returns(Task.CompletedTask);
 
         var bankingMock = new Mock<IBankingTotalsReader>();
@@ -83,5 +89,30 @@ public class NetWorthSnapshotJobTests
         await sut.ExecuteForUserAsync(UserId);
 
         capturedUserId.Should().Be(UserId);
+        capturedSnapshotDate.Should().Be(expectedDate);
+    }
+
+    [Fact]
+    public async Task CaptureForUserAsync_UsesProvidedSnapshotDate()
+    {
+        NetWorthSnapshotData? captured = null;
+        var snapshotServiceMock = new Mock<INetWorthSnapshotService>();
+        snapshotServiceMock
+            .Setup(s => s.PersistSnapshotAsync(UserId, It.IsAny<NetWorthSnapshotData>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, NetWorthSnapshotData, CancellationToken>((_, data, _) => captured = data)
+            .Returns(Task.CompletedTask);
+
+        var sut = new NetWorthSnapshotJob(
+            BankingMock(total: 2000m).Object,
+            CryptoMock(usdValue: 500m).Object,
+            BrokerageMock(usdValue: 1000m).Object,
+            snapshotServiceMock.Object);
+
+        var snapshotDate = new DateOnly(2026, 6, 29);
+
+        await sut.CaptureForUserAsync(UserId, snapshotDate);
+
+        captured.Should().NotBeNull();
+        captured!.SnapshotDate.Should().Be(snapshotDate);
     }
 }

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/alert-item/alert-item.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/alert-item/alert-item.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, computed, input, output} from '@angular/core';
 
-import {TagComponent} from '../tag/tag.component';
 import {IconComponent, type LucideIconName} from '../icon/icon.component';
+import {TagComponent} from '../tag/tag.component';
 
 export type AlertItemSeverity = 'error' | 'warning' | 'info';
 
@@ -87,6 +87,11 @@ function formatRelativeTime(value: Nullable<string | number | Date>): string {
             }}</span>
           }
         </div>
+        @if (description()) {
+          <p class="mb-cmn-1 text-[11px] font-medium uppercase tracking-wide text-text-secondary">
+            {{ description() }}
+          </p>
+        }
         <p class="mb-cmn-2 text-cmn-xs leading-relaxed text-text-secondary">
           {{ message() }}
         </p>
@@ -115,6 +120,7 @@ export class AlertItemComponent {
   public readonly icon = input<Nullable<LucideIconName>>(null);
   public readonly badgeLabel = input<Nullable<string>>(null);
   public readonly referenceLabel = input<Nullable<string>>(null);
+  public readonly description = input<Nullable<string>>(null);
   public readonly timestamp = input<Nullable<string | number | Date>>(null);
   public readonly isRead = input<boolean>(false);
   public readonly dismissible = input<boolean>(true);

--- a/frontend/src/app/modules/alerts/constants/alert-type-meta.constants.ts
+++ b/frontend/src/app/modules/alerts/constants/alert-type-meta.constants.ts
@@ -1,0 +1,27 @@
+import {type LucideIconName} from '@dsdevq-common/ui';
+
+import {type AlertType} from '../models/alert/alert.model';
+
+export interface AlertTypeMeta {
+  icon: LucideIconName;
+  label: string;
+  description: string;
+}
+
+export const ALERT_TYPE_META_REGISTRY = {
+  ['LowBalance']: {
+    icon: 'TriangleAlert',
+    label: 'low balance',
+    description: 'Balance dropped below your alert threshold.',
+  },
+  ['SyncFailure']: {
+    icon: 'CircleAlert',
+    label: 'sync error',
+    description: 'The provider failed to refresh this account.',
+  },
+  ['UnusualSpend']: {
+    icon: 'Zap',
+    label: 'unusual spend',
+    description: 'This category is spending faster than usual.',
+  },
+} satisfies Record<AlertType, AlertTypeMeta>;

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -66,6 +66,7 @@
               [severity]="severityFor(alert.severity)"
               [icon]="iconFor(alert.type)"
               [badgeLabel]="typeLabel(alert.type)"
+              [description]="typeDescription(alert.type)"
               [referenceLabel]="alert.referenceLabel"
               [timestamp]="alert.createdAt"
               [isRead]="alert.isRead"

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@dsdevq-common/ui';
 
 import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
+import {ALERT_TYPE_META_REGISTRY} from '../../constants/alert-type-meta.constants';
 import {
   type Alert,
   type AlertFilter,
@@ -18,28 +19,6 @@ import {
   type AlertType,
 } from '../../models/alert/alert.model';
 import {AlertsStore} from '../../store/alerts/alerts.store';
-
-function iconForType(type: AlertType): LucideIconName {
-  switch (type) {
-    case 'LowBalance':
-      return 'TriangleAlert';
-    case 'SyncFailure':
-      return 'CircleAlert';
-    case 'UnusualSpend':
-      return 'Zap';
-  }
-}
-
-function labelForType(type: AlertType): string {
-  switch (type) {
-    case 'LowBalance':
-      return 'low balance';
-    case 'SyncFailure':
-      return 'sync error';
-    case 'UnusualSpend':
-      return 'unusual spend';
-  }
-}
 
 function severityFor(severity: AlertSeverity): AlertItemSeverity {
   switch (severity) {
@@ -91,11 +70,15 @@ export class AlertsComponent {
   ];
 
   public iconFor(type: AlertType): LucideIconName {
-    return iconForType(type);
+    return ALERT_TYPE_META_REGISTRY[type].icon;
   }
 
   public typeLabel(type: AlertType): string {
-    return labelForType(type);
+    return ALERT_TYPE_META_REGISTRY[type].label;
+  }
+
+  public typeDescription(type: AlertType): string {
+    return ALERT_TYPE_META_REGISTRY[type].description;
   }
 
   public severityFor(severity: AlertSeverity): AlertItemSeverity {


### PR DESCRIPTION
## Summary\n- Added a quiet window to alert generation so dismissed low-balance, sync-failure, and unusual-spend alerts do not immediately reappear.\n- Surfaced plain-English alert type descriptions in the alerts UI via a shared registry.\n- Kept read and dismiss flows intact.\n\n## Verification\n- Backend build passed with 0 warnings.\n- AlertGeneratorService unit tests passed.\n- Frontend ESLint passed on the modified TypeScript files.\n\nNo auto-merge.