### PR TITLE
feat(holdings): add position-level view alongside allocation

### DIFF
--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -2,10 +2,28 @@
   <div class="mx-auto max-w-screen-lg space-y-cmn-5">
     <!-- Header -->
     <div>
-      <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Asset Allocation</h1>
+      <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Holdings</h1>
       <p class="text-cmn-sm text-text-secondary mt-cmn-1">
-        Portfolio breakdown across all connected accounts
+        Allocation across institutions, or a flat position-level view for brokerage + crypto.
       </p>
+    </div>
+
+    <!-- Tab bar -->
+    <div class="flex gap-cmn-2 border-b border-border-default">
+      <button
+        [class]="tabClass('holdings')"
+        (click)="switchTab('holdings')"
+        type="button"
+      >
+        Allocation
+      </button>
+      <button
+        [class]="tabClass('positions')"
+        (click)="switchTab('positions')"
+        type="button"
+      >
+        Positions
+      </button>
     </div>
 
     <!-- Error state -->
@@ -23,7 +41,7 @@
       <div class="h-64 bg-neutral-100 dark:bg-neutral-800 rounded-xl animate-pulse"></div>
     }
 
-    @if (!store.isLoading() && !store.errorMessage()) {
+    @if (activeTab() === 'holdings' && !store.isLoading() && !store.errorMessage()) {
       <!-- KPI cards -->
       <div class="grid grid-cols-3 gap-4">
         <cmn-stat-card [value]="store.totalNetWorth() | currencyAmount" label="Net Asset Value" />
@@ -162,6 +180,84 @@
           </div>
         }
       </cmn-card>
+    }
+
+    @if (activeTab() === 'positions') {
+      @if (store.isPositionsLoading()) {
+        <div class="h-64 bg-neutral-100 dark:bg-neutral-800 rounded-xl animate-pulse"></div>
+      } @else if (store.positionsErrorMessage()) {
+        <cmn-alert variant="error">{{ store.positionsErrorMessage() }}</cmn-alert>
+      } @else {
+        <cmn-stat-card
+          [value]="store.totalPositionsValue() | currencyAmount"
+          label="Total position value"
+        />
+
+        @if (store.positionsByAssetClass().length === 0) {
+          <cmn-card>
+            <div class="py-cmn-8 text-center text-text-secondary text-cmn-sm">
+              No positions yet. Connect a brokerage or crypto account to see holdings.
+            </div>
+          </cmn-card>
+        } @else {
+          @for (group of store.positionsByAssetClass(); track group.assetClass) {
+            <cmn-card class="grid gap-cmn-4">
+              <div class="flex items-baseline justify-between">
+                <h2 class="font-headline text-cmn-lg font-semibold text-text-primary">
+                  {{ group.label }}
+                </h2>
+                <span class="font-mono tabular-nums text-cmn-sm text-text-secondary">
+                  {{ group.totalValue | currencyAmount }}
+                </span>
+              </div>
+
+              <div class="overflow-x-auto -mx-cmn-4">
+                <table class="w-full text-cmn-sm">
+                  <thead>
+                    <tr class="text-left text-text-secondary uppercase text-cmn-xs tracking-wide">
+                      <th class="py-cmn-2 pl-cmn-4 pr-cmn-3">Symbol</th>
+                      <th class="py-cmn-2 pr-cmn-3">Provider</th>
+                      <th class="py-cmn-2 pr-cmn-3 text-right">Quantity</th>
+                      <th class="py-cmn-2 pr-cmn-3 text-right">Price</th>
+                      <th class="py-cmn-2 pr-cmn-3 text-right">Value</th>
+                      <th class="py-cmn-2 pr-cmn-3 text-right">P&amp;L %</th>
+                      <th class="py-cmn-2 pr-cmn-4 text-right">Weight</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    @for (row of group.rows; track row.symbol + row.provider) {
+                      <tr class="border-t border-border-default">
+                        <td class="py-cmn-2 pl-cmn-4 pr-cmn-3 font-semibold text-text-primary">
+                          {{ row.symbol }}
+                        </td>
+                        <td class="py-cmn-2 pr-cmn-3 text-text-secondary">{{ row.provider }}</td>
+                        <td class="py-cmn-2 pr-cmn-3 text-right font-mono tabular-nums">
+                          {{ row.quantity | number: '1.0-8' }}
+                        </td>
+                        <td class="py-cmn-2 pr-cmn-3 text-right font-mono tabular-nums">
+                          {{ row.currentPrice | currencyAmount }}
+                        </td>
+                        <td class="py-cmn-2 pr-cmn-3 text-right font-mono tabular-nums font-semibold">
+                          {{ row.currentValue | currencyAmount }}
+                        </td>
+                        <td
+                          [class]="row.pnlPercent >= 0 ? pnlPositiveClass : pnlNegativeClass"
+                          class="py-cmn-2 pr-cmn-3 text-right font-mono tabular-nums"
+                        >
+                          {{ row.pnlPercent | number: '1.2-2' }}%
+                        </td>
+                        <td class="py-cmn-2 pr-cmn-4 text-right font-mono tabular-nums text-text-secondary">
+                          {{ row.weightPercent | number: '1.1-1' }}%
+                        </td>
+                      </tr>
+                    }
+                  </tbody>
+                </table>
+              </div>
+            </cmn-card>
+          }
+        }
+      }
     }
   </div>
 </div>

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
@@ -21,6 +21,10 @@ import {HoldingsStore} from '../../store/holdings.store';
 
 const DISCONNECTABLE_PROVIDERS = new Set<Provider>(['binance', 'ibkr']);
 
+const TAB_BASE_CLASSES = 'px-cmn-4 py-cmn-2 text-cmn-sm font-medium transition-colors border-b-2';
+const TAB_ACTIVE_CLASSES = 'text-text-primary border-accent-default';
+const TAB_INACTIVE_CLASSES = 'text-text-secondary border-transparent hover:text-text-primary';
+
 export type HoldingsTab = 'holdings' | 'positions';
 
 @Component({
@@ -48,6 +52,12 @@ export class HoldingsComponent {
 
   public readonly store = inject(HoldingsStore);
   public readonly activeTab = signal<HoldingsTab>('holdings');
+  public readonly pnlPositiveClass = 'text-status-success';
+  public readonly pnlNegativeClass = 'text-status-error';
+
+  public tabClass(tab: HoldingsTab): string {
+    return `${TAB_BASE_CLASSES} ${this.activeTab() === tab ? TAB_ACTIVE_CLASSES : TAB_INACTIVE_CLASSES}`;
+  }
 
   public switchTab(tab: HoldingsTab): void {
     this.activeTab.set(tab);

--- a/frontend/src/app/modules/holdings/store/holdings.computed.ts
+++ b/frontend/src/app/modules/holdings/store/holdings.computed.ts
@@ -16,6 +16,39 @@ interface StateSignals {
 
 const DEFAULT_ERROR = 'Failed to load holdings. Please try again.';
 const DEFAULT_POSITIONS_ERROR = 'Failed to load positions.';
+const WEIGHT_TO_PERCENT = 100;
+
+export type AssetClass = 'equity' | 'crypto';
+
+export interface PositionRow {
+  symbol: string;
+  provider: string;
+  quantity: number;
+  currentPrice: number;
+  currentValue: number;
+  pnlPercent: number;
+  weightPercent: number;
+}
+
+export interface PositionAssetGroup {
+  assetClass: AssetClass;
+  label: string;
+  rows: PositionRow[];
+  totalValue: number;
+}
+
+const ASSET_CLASS_ORDER: readonly AssetClass[] = ['equity', 'crypto'];
+
+const ASSET_CLASS_LABEL: Record<AssetClass, string> = {
+  equity: 'Equities',
+  crypto: 'Crypto',
+};
+
+const CRYPTO_PROVIDERS = new Set<string>(['binance']);
+
+function resolveAssetClass(provider: string): AssetClass {
+  return CRYPTO_PROVIDERS.has(provider) ? 'crypto' : 'equity';
+}
 
 export function holdingsComputed(store: StateSignals) {
   const errorMessages = inject(ErrorMessageService);
@@ -55,6 +88,40 @@ export function holdingsComputed(store: StateSignals) {
         return '';
       }
       return errorMessages.resolve(store.positionsErrorCode()) ?? DEFAULT_POSITIONS_ERROR;
+    }),
+    totalPositionsValue: computed(() =>
+      store.positions().reduce((sum, p) => sum + p.currentValue, 0)
+    ),
+    positionsByAssetClass: computed(() => {
+      const positions = store.positions();
+      const totalValue = positions.reduce((sum, p) => sum + p.currentValue, 0);
+      const groups = new Map<AssetClass, PositionRow[]>();
+
+      for (const p of positions) {
+        const assetClass = resolveAssetClass(p.provider);
+        const row: PositionRow = {
+          symbol: p.symbol,
+          provider: p.provider,
+          quantity: p.quantity,
+          currentPrice: p.currentPrice,
+          currentValue: p.currentValue,
+          pnlPercent: p.mockPnlPercent,
+          weightPercent: totalValue > 0 ? (p.currentValue / totalValue) * WEIGHT_TO_PERCENT : 0,
+        };
+        const bucket = groups.get(assetClass);
+        if (bucket) {
+          bucket.push(row);
+        } else {
+          groups.set(assetClass, [row]);
+        }
+      }
+
+      return ASSET_CLASS_ORDER.filter(cls => groups.has(cls)).map(cls => ({
+        assetClass: cls,
+        label: ASSET_CLASS_LABEL[cls],
+        rows: (groups.get(cls) ?? []).sort((a, b) => b.currentValue - a.currentValue),
+        totalValue: (groups.get(cls) ?? []).reduce((sum, r) => sum + r.currentValue, 0),
+      }));
     }),
   };
 }


### PR DESCRIPTION
## Summary
- Adds a **Positions** tab to `/holdings` that renders a flat position-level table (symbol, provider, quantity, price, value, P&L %, weight) grouped by asset class (Equities / Crypto).
- Renames the existing Institution/account view to an **Allocation** tab under the same page.
- Store gains two new computed signals: `totalPositionsValue`, `positionsByAssetClass`.

## Why
Denys pointed out that `/holdings` was ~90% the same as `/accounts` — institution-grouped account rows. The new Positions tab answers "what am I actually holding" instead of "where is it held".

## What is not in this PR (follow-ups)
- **Real avg cost + P&L**. P&L % is still the pre-existing symbol-hash mock. Wiring true avg cost requires IBKR cost-basis lookups + a fallback strategy for Binance (they don't expose entry price). This is intentionally left for a follow-up so Denys can review the shape first.
- **Live prices via `get_quotes` MCP / `YahooMarketDataService`**. Current view uses the cached `usdValue` from the holdings sync (which is close-to-real-time on the sync cadence). Wiring live quotes is another follow-up.
- **Top gainers / top losers chips**. Suggested in the original brief; deferred until real P&L lands.

## Verification
- `docker exec finance-sentry-frontend npx eslint <changed files>` → clean.
- Angular dev server rebuilt the `holdings-component` chunk without errors.

## Test plan
- [ ] Load `/holdings`, confirm two tabs render (Allocation, Positions).
- [ ] Allocation tab looks identical to before.
- [ ] Positions tab shows Equities section (IBKR positions) and Crypto section (Binance holdings), each sorted by value descending.
- [ ] Positions weight column adds up to ~100% within rounding.