### PR TITLE
fix(dashboard): exclude internal transfers from flow and category stats

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/API/Controllers/DashboardController.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/API/Controllers/DashboardController.cs
@@ -32,26 +32,28 @@ public class DashboardController(
     public async Task<IActionResult> GetTransfers(CancellationToken ct)
     {
         var allTx = (await _transactions.GetByUserIdAsync(User.RequireUserId(), ct)).ToList();
+        var transferIds = _transferDetection.DetectTransferTransactionIds(allTx);
 
-        var debits = allTx.Where(t => t.TransactionType == "debit" && !t.IsPending).ToList();
-        var credits = allTx.Where(t => t.TransactionType == "credit" && !t.IsPending).ToList();
-
+        var byId = allTx.ToDictionary(t => t.Id);
+        var consumedCredits = new HashSet<Guid>();
         var pairs = new List<TransferPairDto>();
 
-        foreach (var debit in debits)
+        foreach (var debit in allTx.Where(t => t.TransactionType == "debit" && transferIds.Contains(t.Id)))
         {
-            foreach (var credit in credits)
+            foreach (var credit in allTx.Where(t => t.TransactionType == "credit" && transferIds.Contains(t.Id)))
             {
-                if (_transferDetection.IsLikelyTransfer(debit, credit))
-                {
-                    pairs.Add(new TransferPairDto(
-                        new TransferItemDto(
-                            debit.Id, debit.AccountId, debit.Amount,
-                            debit.PostedDate ?? debit.TransactionDate, debit.Description),
-                        new TransferItemDto(
-                            credit.Id, credit.AccountId, credit.Amount,
-                            credit.PostedDate ?? credit.TransactionDate, credit.Description)));
-                }
+                if (consumedCredits.Contains(credit.Id)) continue;
+                if (!_transferDetection.IsLikelyTransfer(debit, credit)) continue;
+
+                pairs.Add(new TransferPairDto(
+                    new TransferItemDto(
+                        debit.Id, debit.AccountId, debit.Amount,
+                        debit.PostedDate ?? debit.TransactionDate, debit.Description),
+                    new TransferItemDto(
+                        credit.Id, credit.AccountId, credit.Amount,
+                        credit.PostedDate ?? credit.TransactionDate, credit.Description)));
+                consumedCredits.Add(credit.Id);
+                break;
             }
         }
 

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
@@ -21,18 +21,22 @@ public interface IMerchantCategoryStatisticsService
 }
 
 /// <inheritdoc />
-public class MerchantCategoryStatisticsService(ITransactionRepository transactions) : IMerchantCategoryStatisticsService
+public class MerchantCategoryStatisticsService(
+    ITransactionRepository transactions,
+    ITransferDetectionService transferDetection) : IMerchantCategoryStatisticsService
 {
     private readonly ITransactionRepository _transactions = transactions ?? throw new ArgumentNullException(nameof(transactions));
+    private readonly ITransferDetectionService _transferDetection = transferDetection ?? throw new ArgumentNullException(nameof(transferDetection));
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<CategoryStat>> GetTopCategoriesAsync(
           Guid userId, int limit = 10, CancellationToken ct = default)
     {
         var txList = await _transactions.GetByUserIdAsync(userId, ct);
+        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList());
 
         var debits = txList
-            .Where(t => !t.IsPending && t.IsActive && t.TransactionType == "debit")
+            .Where(t => !t.IsPending && t.IsActive && t.TransactionType == "debit" && !transferIds.Contains(t.Id))
             .ToList();
 
         if (debits.Count == 0)

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
@@ -34,10 +34,12 @@ public interface IMoneyFlowStatisticsService
 /// <inheritdoc />
 public class MoneyFlowStatisticsService(
     ITransactionRepository transactions,
-    IBankAccountRepository accounts) : IMoneyFlowStatisticsService
+    IBankAccountRepository accounts,
+    ITransferDetectionService transferDetection) : IMoneyFlowStatisticsService
 {
     private readonly ITransactionRepository _transactions = transactions ?? throw new ArgumentNullException(nameof(transactions));
     private readonly IBankAccountRepository _accounts = accounts ?? throw new ArgumentNullException(nameof(accounts));
+    private readonly ITransferDetectionService _transferDetection = transferDetection ?? throw new ArgumentNullException(nameof(transferDetection));
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<MonthlyFlow>> GetMonthlyFlowAsync(
@@ -54,9 +56,12 @@ public class MoneyFlowStatisticsService(
         // 2. Fetch transactions in window
         var txList = await _transactions.GetByUserIdSinceAsync(userId, since, ct);
 
-        // 3. Group by (currency, year-month) and sum inflow/outflow
+        // 3. Detect internal transfer pairs so they don't inflate inflow / outflow
+        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList());
+
+        // 4. Group by (currency, year-month) and sum inflow/outflow
         var result = txList
-            .Where(t => !t.IsPending && t.IsActive)
+            .Where(t => !t.IsPending && t.IsActive && !transferIds.Contains(t.Id))
             .Select(t => new
             {
                 Transaction = t,

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
@@ -13,6 +13,14 @@ public interface ITransferDetectionService
     /// and at least one is type "transfer" or the descriptions share similarity.
     /// </summary>
     bool IsLikelyTransfer(Transaction debit, Transaction credit);
+
+    /// <summary>
+    /// Detects all likely internal transfers within a batch and returns the union of
+    /// matched debit + credit transaction Ids. Each credit is consumed by at most one
+    /// debit so an ambiguous credit is not double-counted. Pending / inactive rows are
+    /// ignored — the caller does not need to pre-filter.
+    /// </summary>
+    HashSet<Guid> DetectTransferTransactionIds(IReadOnlyCollection<Transaction> transactions);
 }
 
 /// <inheritdoc />
@@ -53,6 +61,45 @@ public class TransferDetectionService : ITransferDetectionService
 
         // Fallback: check description similarity (shared significant words)
         return HaveSimilarDescriptions(debit.Description, credit.Description);
+    }
+
+    /// <inheritdoc />
+    public HashSet<Guid> DetectTransferTransactionIds(IReadOnlyCollection<Transaction> transactions)
+    {
+        if (transactions == null) throw new ArgumentNullException(nameof(transactions));
+
+        var matched = new HashSet<Guid>();
+        if (transactions.Count == 0)
+            return matched;
+
+        var debits = new List<Transaction>();
+        var credits = new List<Transaction>();
+        foreach (var tx in transactions)
+        {
+            if (tx.IsPending || !tx.IsActive) continue;
+            if (tx.TransactionType == "debit") debits.Add(tx);
+            else if (tx.TransactionType == "credit") credits.Add(tx);
+        }
+
+        if (debits.Count == 0 || credits.Count == 0)
+            return matched;
+
+        var consumedCredits = new HashSet<Guid>();
+        foreach (var debit in debits)
+        {
+            foreach (var credit in credits)
+            {
+                if (consumedCredits.Contains(credit.Id)) continue;
+                if (!IsLikelyTransfer(debit, credit)) continue;
+
+                matched.Add(debit.Id);
+                matched.Add(credit.Id);
+                consumedCredits.Add(credit.Id);
+                break;
+            }
+        }
+
+        return matched;
     }
 
     private static bool HaveSimilarDescriptions(string a, string b)

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
@@ -1,0 +1,67 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Application;
+
+using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+public class MerchantCategoryStatisticsTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private static (BankAccount account, Guid accountId) MakeAccount(string currency = "USD")
+    {
+        var a = new BankAccount(UserId, $"item_{Guid.NewGuid():N}", "Bank", "checking", "1234", "Owner", currency, UserId);
+        return (a, a.Id);
+    }
+
+    private static Transaction MakeTx(
+        Guid accountId, decimal amount, string type, DateTime date, string? category = null, string description = "desc")
+    {
+        var hash = Guid.NewGuid().ToString("N");
+        var tx = new Transaction(accountId, UserId, amount, date, description, hash, isPending: false)
+        {
+            TransactionType = type,
+            PostedDate = date,
+            IsActive = true,
+            MerchantCategory = category,
+        };
+        return tx;
+    }
+
+    [Fact]
+    public async Task GetTopCategories_ExcludesInternalTransferDebit()
+    {
+        var (_, accountAId) = MakeAccount();
+        var (_, accountBId) = MakeAccount();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        // Internal transfer pair carrying a category. Must NOT appear in spending.
+        var transferDebit  = MakeTx(accountAId, 500m, "debit",  date, category: "Transfer", description: "Transfer to savings");
+        var transferCredit = MakeTx(accountBId, 500m, "credit", date, category: "Transfer", description: "Transfer to savings");
+
+        var transactions = new List<Transaction>
+        {
+            transferDebit,
+            transferCredit,
+            MakeTx(accountAId, 40m,  "debit", date, category: "Food"),
+            MakeTx(accountAId, 60m,  "debit", date, category: "Food"),
+            MakeTx(accountAId, 100m, "debit", date, category: "Travel"),
+        };
+
+        var txRepoMock = new Mock<ITransactionRepository>();
+        txRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(transactions);
+
+        var sut = new MerchantCategoryStatisticsService(txRepoMock.Object, new TransferDetectionService());
+
+        var result = await sut.GetTopCategoriesAsync(UserId, 10);
+
+        result.Should().NotContain(c => c.Category == "Transfer");
+        result.Sum(c => c.TotalSpend).Should().Be(200m);
+        var food = result.First(c => c.Category == "Food");
+        food.TotalSpend.Should().Be(100m);
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MoneyFlowStatisticsTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MoneyFlowStatisticsTests.cs
@@ -65,7 +65,7 @@ public class MoneyFlowStatisticsTests
         accountRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
                        .ReturnsAsync([account]);
 
-        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object);
+        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object, new TransferDetectionService());
 
         // Act
         var result = await sut.GetMonthlyFlowAsync(UserId, 6);
@@ -109,7 +109,7 @@ public class MoneyFlowStatisticsTests
         accountRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
                        .ReturnsAsync([account]);
 
-        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object);
+        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object, new TransferDetectionService());
 
         // Act
         var result = await sut.GetMonthlyFlowAsync(UserId, 6);
@@ -147,7 +147,7 @@ public class MoneyFlowStatisticsTests
         accountRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
                        .ReturnsAsync([eurAccount, usdAccount]);
 
-        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object);
+        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object, new TransferDetectionService());
 
         // Act
         var result = await sut.GetMonthlyFlowAsync(UserId, 6);
@@ -164,6 +164,46 @@ public class MoneyFlowStatisticsTests
         usdFlow.Inflow.Should().Be(800m);
         usdFlow.Outflow.Should().Be(300m);
         usdFlow.Net.Should().Be(500m);
+    }
+
+    // ── Transfer exclusion: internal transfer pair must not inflate inflow/outflow ─
+
+    [Fact]
+    public async Task GetMonthlyFlow_ExcludesInternalTransferPair()
+    {
+        var (accountA, accountAId) = MakeAccount("USD");
+        var (accountB, accountBId) = MakeAccount("USD");
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var transferDebit  = MakeTx(accountAId, 500m, "debit",  date);
+        var transferCredit = MakeTx(accountBId, 500m, "credit", date);
+        transferDebit.Description  = "Transfer to savings";
+        transferCredit.Description = "Transfer to savings";
+
+        var transactions = new List<Transaction>
+        {
+            transferDebit,
+            transferCredit,
+            MakeTx(accountAId, 100m, "debit",  date),  // real spending — kept
+            MakeTx(accountAId, 300m, "credit", date),  // real income   — kept
+        };
+
+        var txRepoMock = new Mock<ITransactionRepository>();
+        txRepoMock.Setup(r => r.GetByUserIdSinceAsync(UserId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(transactions);
+
+        var accountRepoMock = new Mock<IBankAccountRepository>();
+        accountRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync([accountA, accountB]);
+
+        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object, new TransferDetectionService());
+
+        var result = await sut.GetMonthlyFlowAsync(UserId, 6);
+
+        result.Should().HaveCount(1);
+        result[0].Inflow.Should().Be(300m);   // transfer credit excluded
+        result[0].Outflow.Should().Be(100m);  // transfer debit  excluded
+        result[0].Net.Should().Be(200m);
     }
 
     // ── T413 Test 4: Debit/credit classification ──────────────────────────────
@@ -190,7 +230,7 @@ public class MoneyFlowStatisticsTests
         accountRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
                        .ReturnsAsync([account]);
 
-        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object);
+        var sut = new MoneyFlowStatisticsService(txRepoMock.Object, accountRepoMock.Object, new TransferDetectionService());
 
         // Act
         var result = await sut.GetMonthlyFlowAsync(UserId, 6);

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
@@ -1,0 +1,109 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Application;
+
+using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Domain;
+using FluentAssertions;
+using Xunit;
+
+public class TransferDetectionTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private static Transaction MakeTx(
+        Guid accountId, decimal amount, string type, DateTime date,
+        string description = "Transfer to savings", bool isPending = false, bool isActive = true)
+    {
+        var hash = Guid.NewGuid().ToString("N");
+        var tx = new Transaction(accountId, UserId, amount, date, description, hash, isPending)
+        {
+            TransactionType = type,
+            PostedDate = isPending ? null : date,
+            IsActive = isActive,
+        };
+        return tx;
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_EmptyInput_ReturnsEmptySet()
+    {
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_PairMatchedByAmountAndDescription_ReturnsBothIds()
+    {
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit  = MakeTx(accountA, 500m, "debit",  date);
+        var credit = MakeTx(accountB, 500m, "credit", date);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit]);
+
+        result.Should().BeEquivalentTo(new[] { debit.Id, credit.Id });
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_UnrelatedDebitAndCredit_NotMatched()
+    {
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        // Different amounts + different descriptions → not a transfer
+        var debit  = MakeTx(accountA, 500m, "debit",  date, description: "Grocery Store");
+        var credit = MakeTx(accountB, 500m, "credit", date, description: "Employer Payroll");
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_AmbiguousCredit_ConsumedByFirstDebitOnly()
+    {
+        // Two debits both match the same credit. The credit must be consumed once, so
+        // the second debit stays unmatched (and is counted as real spending).
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit1 = MakeTx(accountA, 500m, "debit",  date);
+        var debit2 = MakeTx(accountA, 500m, "debit",  date);
+        var credit = MakeTx(accountB, 500m, "credit", date);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit1, debit2, credit]);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(credit.Id);
+        (result.Contains(debit1.Id) ^ result.Contains(debit2.Id)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_PendingAndInactive_Ignored()
+    {
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit  = MakeTx(accountA, 500m, "debit",  date, isPending: true);
+        var credit = MakeTx(accountB, 500m, "credit", date, isActive: false);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit]);
+
+        result.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Internal transfers between the user's own accounts were double-counted in monthly inflow/outflow and inflated **Top Spending Categories** when they carried a merchant category.
- Added `ITransferDetectionService.DetectTransferTransactionIds(transactions)` — a batch helper that runs the existing pairwise `IsLikelyTransfer` check once and returns the union of matched debit + credit IDs. Each credit is consumed by at most one debit so ambiguous credits are not double-counted.
- Wired the helper into `MoneyFlowStatisticsService` and `MerchantCategoryStatisticsService` so both exclude transfer IDs before aggregation.
- Refactored `DashboardController.GetTransfers` to use the same helper — all three consumers now share one definition of "transfer." Also fixes a pre-existing bug where an ambiguous credit could appear in multiple reported pairs.

## Not in scope
- **Net-worth history chart looking sparse** — separate issue. Diagnosed on the VPS: daily Hangfire job is running fine; the feature just started collecting on 2026-06-30, so there are only ~5 data points. Follow-up will be historical backfill from transactions + balances.
- Categories query still runs against all-time transactions (money-flow uses a 6-month window). Consistency between the two is a separate small task.
- Hardcoded FX rates in `CurrencyConverter` — not touched.

## Test plan
- [x] `dotnet build backend/` — 0 warnings, 0 errors
- [x] `dotnet test FinanceSentry.Tests.Unit` — 288/288 pass, including:
  - New `TransferDetectionTests` (5 cases: empty input, positive match, unrelated pair, ambiguous-credit-consumed-once, pending/inactive ignored)
  - New `MerchantCategoryStatisticsTests` covering transfer-debit exclusion
  - Extended `MoneyFlowStatisticsTests` with an internal-transfer-pair case
- [ ] Deploy to VPS and confirm `/dashboard/aggregated` monthly inflow/outflow no longer include obvious internal transfers
- [ ] Confirm `/dashboard/transfers` still returns matched pairs (used by the transfers view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)