### PR TITLE
chore(frontend): resync package-lock.json to match package.json

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-sentry",
-  "version": "0.6.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-sentry",
-      "version": "0.6.0",
+      "version": "0.11.0",
       "workspaces": [
         "projects/dsdevq-common/*"
       ],
@@ -4433,6 +4433,10 @@
     },
     "node_modules/@dsdevq-common/config": {
       "resolved": "projects/dsdevq-common/config",
+      "link": true
+    },
+    "node_modules/@dsdevq-common/core": {
+      "resolved": "projects/dsdevq-common/core",
       "link": true
     },
     "node_modules/@dsdevq-common/ui": {
@@ -22983,9 +22987,23 @@
         "typescript-eslint": "*"
       }
     },
+    "projects/dsdevq-common/core": {
+      "name": "@dsdevq-common/core",
+      "version": "0.1.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.2.0",
+        "@angular/core": "^21.2.0",
+        "@angular/router": "^21.2.0",
+        "@ngrx/signals": "^21.0.0",
+        "rxjs": "^7.8.0"
+      }
+    },
     "projects/dsdevq-common/ui": {
       "name": "@dsdevq-common/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },


### PR DESCRIPTION
## Changes
Lockfile had pre-existing drift on main: root version was stuck at
0.6.0 (package.json is 0.11.0), the @dsdevq-common/core workspace link
was missing from node_modules/, and projects/dsdevq-common/ui was
pinned to 0.1.0 instead of 0.2.0.

Fix: ran `npm install --package-lock-only --ignore-scripts` in
frontend/ (--ignore-scripts because husky is absent in CI/sandbox).
Only frontend/package-lock.json changed — no dependency additions,
no source or template changes. App build and @dsdevq-common/ui library
build both pass green after resync.

This is a lockfile-only resync unrelated to any feature work;
it is a prerequisite for subsequent ng-zorro-antd dependency additions
which all failed due to this same pre-existing drift.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<details><summary>📋 Ticket (what was asked + why)</summary>

Fix the pre-existing stale frontend lockfile on finance-sentry main so dependency changes stop carrying unrelated lockfile drift. Work from a clean branch based on current origin/main. Do ONLY the standalone lockfile resync: run npm install/package-lock reconciliation in frontend so frontend/package-lock.json matches frontend/package.json and current workspaces. Expected intentional lockfile-only effects include root version 0.6.0 -> 0.11.0, adding the missing @dsdevq-common/core workspace link, and updating @dsdevq-common/ui metadata from 0.1.0 -> 0.2.0. Do NOT add ng-zorro-antd. Do NOT migrate UI components. Do NOT change frontend/package.json unless npm proves it is required and explain why. The final diff should be limited to frontend/package-lock.json. Run the verification gate and open a PR with a concise title explaining this is a lockfile resync prerequisite for the UI library goal.

</details>

## Verification
Gate `cd frontend && npm ci --ignore-scripts` passed (exit 0).

## Files changed
```
frontend/package-lock.json | 24 +++++++++++++++++++++---
 1 file changed, 21 insertions(+), 3 deletions(-)
```

---
🤖 Delivered by devclaw (task `85fa73f1-a596-494e-9f9a-00b479e333d7`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.