### PR TITLE
feat(budgets): enforce invariants in Budget domain entity

### DIFF
--- a/backend/src/FinanceSentry.Modules.Budgets/Domain/Budget.cs
+++ b/backend/src/FinanceSentry.Modules.Budgets/Domain/Budget.cs
@@ -1,5 +1,7 @@
 namespace FinanceSentry.Modules.Budgets.Domain;
 
+using FinanceSentry.Modules.Budgets.Domain.Exceptions;
+
 public class Budget
 {
     public Guid Id { get; private set; }
@@ -14,6 +16,13 @@ public class Budget
 
     public static Budget Create(Guid userId, string category, decimal monthlyLimit, string currency)
     {
+        if (string.IsNullOrWhiteSpace(category))
+            throw new ArgumentException("Category must not be empty.", nameof(category));
+        if (string.IsNullOrWhiteSpace(currency))
+            throw new ArgumentException("Currency must not be empty.", nameof(currency));
+        if (monthlyLimit <= 0)
+            throw new BudgetInvalidLimitException();
+
         return new Budget
         {
             Id = Guid.NewGuid(),
@@ -28,6 +37,9 @@ public class Budget
 
     public void UpdateLimit(decimal newLimit)
     {
+        if (newLimit <= 0)
+            throw new BudgetInvalidLimitException();
+
         MonthlyLimit = newLimit;
         UpdatedAt = DateTimeOffset.UtcNow;
     }

--- a/backend/tests/FinanceSentry.Tests.Unit/Budgets/BudgetTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Budgets/BudgetTests.cs
@@ -1,0 +1,115 @@
+namespace FinanceSentry.Tests.Unit.Budgets;
+
+using FinanceSentry.Modules.Budgets.Domain;
+using FinanceSentry.Modules.Budgets.Domain.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+public class BudgetTests
+{
+    private static readonly Guid UserId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+
+    // ── Budget.Create — happy path ──────────────────────────────────────────
+
+    [Fact]
+    public void Create_ValidArgs_ReturnsBudgetWithCorrectProperties()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var budget = Budget.Create(UserId, "FOOD_AND_DRINK", 500m, "USD");
+        var after = DateTimeOffset.UtcNow;
+
+        budget.UserId.Should().Be(UserId);
+        budget.Category.Should().Be("FOOD_AND_DRINK");
+        budget.MonthlyLimit.Should().Be(500m);
+        budget.Currency.Should().Be("USD");
+        budget.Id.Should().NotBeEmpty();
+        budget.CreatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after);
+        budget.UpdatedAt.Should().BeCloseTo(budget.CreatedAt, TimeSpan.FromMilliseconds(100));
+    }
+
+    // ── Budget.Create — category guard ─────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_EmptyCategory_ThrowsArgumentException(string category)
+    {
+        var act = () => Budget.Create(UserId, category, 100m, "USD");
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*category*");
+    }
+
+    // ── Budget.Create — currency guard ─────────────────────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_EmptyCurrency_ThrowsArgumentException(string currency)
+    {
+        var act = () => Budget.Create(UserId, "FOOD_AND_DRINK", 100m, currency);
+
+        act.Should().Throw<ArgumentException>()
+           .WithMessage("*currency*");
+    }
+
+    // ── Budget.Create — limit guard ────────────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.01)]
+    [InlineData(-1000)]
+    public void Create_NonPositiveLimit_ThrowsBudgetInvalidLimitException(decimal limit)
+    {
+        var act = () => Budget.Create(UserId, "FOOD_AND_DRINK", limit, "USD");
+
+        act.Should().Throw<BudgetInvalidLimitException>();
+    }
+
+    [Fact]
+    public void Create_SmallestPositiveLimit_Succeeds()
+    {
+        var act = () => Budget.Create(UserId, "FOOD_AND_DRINK", 0.01m, "USD");
+
+        act.Should().NotThrow();
+    }
+
+    // ── Budget.UpdateLimit — happy path ────────────────────────────────────
+
+    [Fact]
+    public void UpdateLimit_ValidPositiveLimit_UpdatesMonthlyLimitAndUpdatedAt()
+    {
+        var budget = Budget.Create(UserId, "FOOD_AND_DRINK", 100m, "USD");
+        var createdAt = budget.UpdatedAt;
+
+        budget.UpdateLimit(250m);
+
+        budget.MonthlyLimit.Should().Be(250m);
+        budget.UpdatedAt.Should().BeOnOrAfter(createdAt);
+    }
+
+    // ── Budget.UpdateLimit — limit guard ───────────────────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-0.01)]
+    [InlineData(-500)]
+    public void UpdateLimit_NonPositiveLimit_ThrowsBudgetInvalidLimitException(decimal newLimit)
+    {
+        var budget = Budget.Create(UserId, "FOOD_AND_DRINK", 100m, "USD");
+
+        var act = () => budget.UpdateLimit(newLimit);
+
+        act.Should().Throw<BudgetInvalidLimitException>();
+    }
+
+    [Fact]
+    public void UpdateLimit_NonPositiveLimit_DoesNotMutateMonthlyLimit()
+    {
+        var budget = Budget.Create(UserId, "FOOD_AND_DRINK", 100m, "USD");
+
+        try { budget.UpdateLimit(0); } catch (BudgetInvalidLimitException) { }
+
+        budget.MonthlyLimit.Should().Be(100m);
+    }
+}


### PR DESCRIPTION
## Changes
Budget.Create now throws ArgumentException on empty category/currency
and BudgetInvalidLimitException on monthlyLimit <= 0. UpdateLimit
throws BudgetInvalidLimitException on newLimit <= 0, preventing any
caller from bypassing the guard that was previously only in
UpdateBudgetCommandHandler.

Verified: dotnet build (0 warnings), 281 unit tests pass.

<details><summary>📋 Ticket (what was asked + why)</summary>

In `backend/src/FinanceSentry.Modules.Budgets/Domain/Budget.cs`, enforce the budget invariants inside the domain entity. `Budget.UpdateLimit(decimal)` currently mutates with no validation, even though `UpdateBudgetCommandHandler` guards `MonthlyLimit <= 0` — so any other caller bypasses it. Make `Budget.UpdateLimit` throw `BudgetInvalidLimitException` (already defined in `Domain/Exceptions/`) when `newLimit <= 0`, and make `Budget.Create` throw the same on non-positive `monthlyLimit` and `ArgumentException` on empty `category`/`currency`. Do not change the command handlers' happy path. Add focused unit tests; do not weaken the suite.

</details>

## Verification
Gate `dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj -c Release` passed (exit 0).

## Files changed
```
.../FinanceSentry.Modules.Budgets/Domain/Budget.cs |  12 +++
 .../Budgets/BudgetTests.cs                         | 115 +++++++++++++++++++++
 2 files changed, 127 insertions(+)
```

---
🤖 Delivered by devclaw (task `cf3debfd-1d59-4aa7-a88a-4cd0d5c60797`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.