### PR TITLE
Fix portfolio data quality for crypto basis and quotes

### DIFF
--- a/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/SyncBinanceHoldingsCommand.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/SyncBinanceHoldingsCommand.cs
@@ -15,6 +15,9 @@ public sealed record SyncBinanceHoldingsResult(int HoldingsCount, DateTime Synce
 
 public sealed class SyncBinanceHoldingsCommandHandler : ICommandHandler<SyncBinanceHoldingsCommand, SyncBinanceHoldingsResult>
 {
+    private const decimal QuantityTolerance = 0.01m;
+    private const decimal MaximumTrustedCostToValueRatio = 20m;
+
     private readonly IBinanceCredentialRepository _credentialRepository;
     private readonly ICryptoHoldingRepository _holdingRepository;
     private readonly ICryptoExchangeAdapter _adapter;
@@ -130,6 +133,9 @@ public sealed class SyncBinanceHoldingsCommandHandler : ICommandHandler<SyncBina
                 ? new CostBasisResult(
                     CostBasisUsd: holding.CostBasisUsd ?? 0m,
                     AverageBuyPriceUsd: holding.AverageBuyPriceUsd ?? 0m,
+                    RemainingQuantity: holding.AverageBuyPriceUsd is > 0m && holding.CostBasisUsd is not null
+                        ? holding.CostBasisUsd.Value / holding.AverageBuyPriceUsd.Value
+                        : 0m,
                     RealizedPnlUsd: holding.RealizedPnlUsd ?? 0m,
                     LastTradeAt: holding.LastTradeAt,
                     LastTradeId: holding.LastTradeId,
@@ -143,9 +149,12 @@ public sealed class SyncBinanceHoldingsCommandHandler : ICommandHandler<SyncBina
                 continue;
             }
 
+            var currentQuantity = holding.FreeQuantity + holding.LockedQuantity;
+            var costBasis = TrustCostBasisForCurrentPosition(result, currentQuantity, holding.UsdValue);
+
             holding.SetCostBasis(
-                result.CostBasisUsd,
-                result.AverageBuyPriceUsd,
+                costBasis,
+                costBasis is null ? null : result.AverageBuyPriceUsd,
                 result.RealizedPnlUsd,
                 result.LastTradeAt,
                 result.LastTradeId,
@@ -153,5 +162,45 @@ public sealed class SyncBinanceHoldingsCommandHandler : ICommandHandler<SyncBina
         }
 
         await _holdingRepository.SaveChangesAsync(ct);
+    }
+
+    private static decimal? TrustCostBasisForCurrentPosition(
+        CostBasisResult result,
+        decimal currentQuantity,
+        decimal currentValueUsd)
+    {
+        if (currentQuantity <= 0m)
+        {
+            return 0m;
+        }
+
+        if (result.AverageBuyPriceUsd <= 0m || result.RemainingQuantity <= 0m)
+        {
+            return null;
+        }
+
+        var quantityDelta = Math.Abs(result.RemainingQuantity - currentQuantity);
+        var tolerance = Math.Max(currentQuantity, result.RemainingQuantity) * QuantityTolerance;
+
+        decimal costBasis;
+        if (quantityDelta <= tolerance)
+        {
+            costBasis = result.CostBasisUsd;
+        }
+        else if (result.RemainingQuantity > currentQuantity)
+        {
+            costBasis = result.AverageBuyPriceUsd * currentQuantity;
+        }
+        else
+        {
+            return null;
+        }
+
+        if (currentValueUsd > 0m && costBasis / currentValueUsd > MaximumTrustedCostToValueRatio)
+        {
+            return null;
+        }
+
+        return Math.Round(costBasis, 4);
     }
 }

--- a/backend/src/FinanceSentry.Modules.CryptoSync/Application/Services/CostBasisCalculator.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Application/Services/CostBasisCalculator.cs
@@ -5,6 +5,7 @@ namespace FinanceSentry.Modules.CryptoSync.Application.Services;
 public sealed record CostBasisResult(
     decimal CostBasisUsd,
     decimal AverageBuyPriceUsd,
+    decimal RemainingQuantity,
     decimal RealizedPnlUsd,
     DateTime? LastTradeAt,
     long LastTradeId,
@@ -66,6 +67,7 @@ public sealed class CostBasisCalculator
         return new CostBasisResult(
             CostBasisUsd: Math.Round(runningCostUsd, 4),
             AverageBuyPriceUsd: Math.Round(avgBuyPrice, 8),
+            RemainingQuantity: Math.Round(runningQty, 12),
             RealizedPnlUsd: Math.Round(realizedPnl, 4),
             LastTradeAt: lastAt,
             LastTradeId: lastId,

--- a/backend/src/FinanceSentry.Modules.Research/API/Responses/QuoteDto.cs
+++ b/backend/src/FinanceSentry.Modules.Research/API/Responses/QuoteDto.cs
@@ -2,8 +2,14 @@ namespace FinanceSentry.Modules.Research.API.Responses;
 
 public record QuoteDto(
     string Ticker,
+    string? ResolvedTicker,
     decimal Price,
     decimal? PreviousClose,
     decimal? ChangePct,
     string Currency,
-    DateTimeOffset FetchedAt);
+    DateTimeOffset FetchedAt,
+    string MarketState,
+    string Session,
+    bool IsStale,
+    DateTimeOffset? SourcePriceTime,
+    DateTimeOffset? RegularMarketTime);

--- a/backend/src/FinanceSentry.Modules.Research/Application/Queries/GetQuotesQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Queries/GetQuotesQuery.cs
@@ -18,7 +18,19 @@ public class GetQuotesQueryHandler(IMarketDataService market)
                 var changePct = q.PreviousClose is > 0
                     ? (q.Price - q.PreviousClose.Value) / q.PreviousClose.Value * 100m
                     : (decimal?)null;
-                return new QuoteDto(q.Ticker, q.Price, q.PreviousClose, changePct, q.Currency, q.FetchedAt);
+                return new QuoteDto(
+                    q.Ticker,
+                    q.ResolvedTicker,
+                    q.Price,
+                    q.PreviousClose,
+                    changePct,
+                    q.Currency,
+                    q.FetchedAt,
+                    q.MarketState,
+                    q.Session,
+                    q.IsStale,
+                    q.SourcePriceTime,
+                    q.RegularMarketTime);
             })
             .ToList();
     }

--- a/backend/src/FinanceSentry.Modules.Research/Application/Services/YahooMarketDataService.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Services/YahooMarketDataService.cs
@@ -13,8 +13,18 @@ public class YahooMarketDataService(
     public const string HttpClientName = "yahoo-finance";
 
     private const int MaxConcurrentFetches = 6;
+    private const string RegularSession = "regular";
+    private const string PreMarketSession = "pre_market";
+    private const string PostMarketSession = "post_market";
+    private const string ClosedSession = "closed";
+    private const string UnknownSession = "unknown";
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+    private static readonly IReadOnlyDictionary<string, string> YahooTickerAliases =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MHPC"] = "MHPC.IL",
+        };
 
     public async Task<IReadOnlyDictionary<string, QuoteCacheEntry>> GetQuotesAsync(
         IReadOnlyCollection<string> tickers, CancellationToken ct = default)
@@ -87,7 +97,8 @@ public class YahooMarketDataService(
     private async Task<QuoteCacheEntry?> FetchOneAsync(string ticker, CancellationToken ct)
     {
         var client = httpFactory.CreateClient(HttpClientName);
-        var url = $"/v8/finance/chart/{Uri.EscapeDataString(ticker)}?interval=1d&range=5d";
+        var yahooTicker = ResolveYahooTicker(ticker);
+        var url = $"/v8/finance/chart/{Uri.EscapeDataString(yahooTicker)}?interval=1d&range=5d";
 
         try
         {
@@ -113,8 +124,19 @@ public class YahooMarketDataService(
             var symbol = meta.TryGetProperty("symbol", out var symbolProp)
                 ? symbolProp.GetString() ?? ticker
                 : ticker;
-            var price = ReadDecimal(meta, "regularMarketPrice");
-            if (price is null)
+            if (!IsExpectedYahooSymbol(ticker, yahooTicker, symbol))
+            {
+                return null;
+            }
+
+            var marketState = meta.TryGetProperty("marketState", out var marketStateProp)
+                ? marketStateProp.GetString() ?? "unknown"
+                : "unknown";
+            var regularMarketPrice = ReadDecimal(meta, "regularMarketPrice");
+            var preMarketPrice = ReadDecimal(meta, "preMarketPrice");
+            var postMarketPrice = ReadDecimal(meta, "postMarketPrice");
+            var selected = SelectSessionPrice(marketState, regularMarketPrice, preMarketPrice, postMarketPrice);
+            if (selected.Price is null)
             {
                 return null;
             }
@@ -123,14 +145,27 @@ public class YahooMarketDataService(
             var currency = meta.TryGetProperty("currency", out var currencyProp)
                 ? currencyProp.GetString() ?? "USD"
                 : "USD";
+            var regularMarketTime = ReadUnixTime(meta, "regularMarketTime");
+            var sourcePriceTime = selected.Session switch
+            {
+                PreMarketSession => ReadUnixTime(meta, "preMarketTime") ?? regularMarketTime,
+                PostMarketSession => ReadUnixTime(meta, "postMarketTime") ?? regularMarketTime,
+                _ => regularMarketTime,
+            };
 
             return new QuoteCacheEntry
             {
-                Ticker = symbol.ToUpperInvariant(),
-                Price = price.Value,
+                Ticker = ticker.ToUpperInvariant(),
+                ResolvedTicker = symbol.ToUpperInvariant(),
+                Price = selected.Price.Value,
                 PreviousClose = prev,
                 Currency = currency,
                 FetchedAt = DateTimeOffset.UtcNow,
+                MarketState = marketState,
+                Session = selected.Session,
+                IsStale = selected.IsStale,
+                SourcePriceTime = sourcePriceTime,
+                RegularMarketTime = regularMarketTime,
             };
         }
         catch (Exception ex)
@@ -240,5 +275,47 @@ public class YahooMarketDataService(
             JsonValueKind.Number => prop.TryGetDecimal(out var value) ? value : null,
             _ => null,
         };
+    }
+
+    private static string ResolveYahooTicker(string ticker)
+    {
+        return YahooTickerAliases.TryGetValue(ticker, out var alias)
+            ? alias
+            : ticker;
+    }
+
+    private static bool IsExpectedYahooSymbol(string requestedTicker, string yahooTicker, string resolvedSymbol)
+    {
+        return string.Equals(resolvedSymbol, yahooTicker, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(resolvedSymbol, requestedTicker, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static (decimal? Price, string Session, bool IsStale) SelectSessionPrice(
+        string marketState,
+        decimal? regularMarketPrice,
+        decimal? preMarketPrice,
+        decimal? postMarketPrice)
+    {
+        return marketState.ToUpperInvariant() switch
+        {
+            "PRE" or "PREPRE" when preMarketPrice is not null => (preMarketPrice, PreMarketSession, false),
+            "POST" or "POSTPOST" when postMarketPrice is not null => (postMarketPrice, PostMarketSession, false),
+            "REGULAR" when regularMarketPrice is not null => (regularMarketPrice, RegularSession, false),
+            "CLOSED" when regularMarketPrice is not null => (regularMarketPrice, ClosedSession, true),
+            _ when regularMarketPrice is not null => (regularMarketPrice, UnknownSession, true),
+            _ => (null, UnknownSession, true),
+        };
+    }
+
+    private static DateTimeOffset? ReadUnixTime(JsonElement element, string property)
+    {
+        if (!element.TryGetProperty(property, out var prop) ||
+            prop.ValueKind is not JsonValueKind.Number ||
+            !prop.TryGetInt64(out var value))
+        {
+            return null;
+        }
+
+        return DateTimeOffset.FromUnixTimeSeconds(value);
     }
 }

--- a/backend/src/FinanceSentry.Modules.Research/Domain/QuoteCacheEntry.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Domain/QuoteCacheEntry.cs
@@ -3,8 +3,14 @@ namespace FinanceSentry.Modules.Research.Domain;
 public class QuoteCacheEntry
 {
     public string Ticker { get; set; } = string.Empty;
+    public string? ResolvedTicker { get; set; }
     public decimal Price { get; set; }
     public decimal? PreviousClose { get; set; }
     public string Currency { get; set; } = "USD";
     public DateTimeOffset FetchedAt { get; set; } = DateTimeOffset.UtcNow;
+    public string MarketState { get; set; } = "unknown";
+    public string Session { get; set; } = "unknown";
+    public bool IsStale { get; set; }
+    public DateTimeOffset? SourcePriceTime { get; set; }
+    public DateTimeOffset? RegularMarketTime { get; set; }
 }

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/ResearchDbContext.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/ResearchDbContext.cs
@@ -112,10 +112,16 @@ public class ResearchDbContext(DbContextOptions<ResearchDbContext> options) : Db
         qb.ToTable("quote_cache");
         qb.HasKey(x => x.Ticker);
         qb.Property(x => x.Ticker).HasMaxLength(20);
+        qb.Property(x => x.ResolvedTicker).HasMaxLength(20);
         qb.Property(x => x.Price).HasColumnType("numeric(18,6)");
         qb.Property(x => x.PreviousClose).HasColumnType("numeric(18,6)");
         qb.Property(x => x.Currency).HasMaxLength(6).HasDefaultValue("USD");
         qb.Property(x => x.FetchedAt).HasDefaultValueSql("CURRENT_TIMESTAMP");
+        qb.Property(x => x.MarketState).HasMaxLength(20).HasDefaultValue("unknown");
+        qb.Property(x => x.Session).HasMaxLength(20).HasDefaultValue("unknown");
+        qb.Property(x => x.IsStale).HasDefaultValue(false);
+        qb.Property(x => x.SourcePriceTime);
+        qb.Property(x => x.RegularMarketTime);
 
         var ib = modelBuilder.Entity<InvestmentPolicyStatement>();
         ib.ToTable("investment_policy_statements");

--- a/backend/src/FinanceSentry.Modules.Research/Migrations/20260714090000_M007_QuoteSessionMetadata.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Migrations/20260714090000_M007_QuoteSessionMetadata.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.Research.Migrations
+{
+    /// <inheritdoc />
+    public partial class M007_QuoteSessionMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsStale",
+                schema: "research",
+                table: "quote_cache",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MarketState",
+                schema: "research",
+                table: "quote_cache",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "unknown");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RegularMarketTime",
+                schema: "research",
+                table: "quote_cache",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ResolvedTicker",
+                schema: "research",
+                table: "quote_cache",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Session",
+                schema: "research",
+                table: "quote_cache",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "unknown");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SourcePriceTime",
+                schema: "research",
+                table: "quote_cache",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsStale",
+                schema: "research",
+                table: "quote_cache");
+
+            migrationBuilder.DropColumn(
+                name: "MarketState",
+                schema: "research",
+                table: "quote_cache");
+
+            migrationBuilder.DropColumn(
+                name: "RegularMarketTime",
+                schema: "research",
+                table: "quote_cache");
+
+            migrationBuilder.DropColumn(
+                name: "ResolvedTicker",
+                schema: "research",
+                table: "quote_cache");
+
+            migrationBuilder.DropColumn(
+                name: "Session",
+                schema: "research",
+                table: "quote_cache");
+
+            migrationBuilder.DropColumn(
+                name: "SourcePriceTime",
+                schema: "research",
+                table: "quote_cache");
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Research/Migrations/ResearchDbContextModelSnapshot.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Migrations/ResearchDbContextModelSnapshot.cs
@@ -398,11 +398,40 @@ namespace FinanceSentry.Modules.Research.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasDefaultValueSql("CURRENT_TIMESTAMP");
 
+                    b.Property<bool>("IsStale")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false);
+
+                    b.Property<string>("MarketState")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)")
+                        .HasDefaultValue("unknown");
+
                     b.Property<decimal?>("PreviousClose")
                         .HasColumnType("numeric(18,6)");
 
                     b.Property<decimal>("Price")
                         .HasColumnType("numeric(18,6)");
+
+                    b.Property<DateTimeOffset?>("RegularMarketTime")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ResolvedTicker")
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)");
+
+                    b.Property<string>("Session")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(20)
+                        .HasColumnType("character varying(20)")
+                        .HasDefaultValue("unknown");
+
+                    b.Property<DateTimeOffset?>("SourcePriceTime")
+                        .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Ticker");
 

--- a/backend/tests/FinanceSentry.Mcp.Tests/CostBasisCalculatorTests.cs
+++ b/backend/tests/FinanceSentry.Mcp.Tests/CostBasisCalculatorTests.cs
@@ -24,6 +24,7 @@ public sealed class CostBasisCalculatorTests
 
         result.CostBasisUsd.Should().Be(0m);
         result.AverageBuyPriceUsd.Should().Be(0m);
+        result.RemainingQuantity.Should().Be(0m);
         result.RealizedPnlUsd.Should().Be(0m);
         result.LastTradeAt.Should().BeNull();
         result.TradeCount.Should().Be(0);
@@ -36,6 +37,7 @@ public sealed class CostBasisCalculatorTests
 
         result.CostBasisUsd.Should().Be(20_000m);
         result.AverageBuyPriceUsd.Should().Be(20_000m);
+        result.RemainingQuantity.Should().Be(1m);
         result.RealizedPnlUsd.Should().Be(0m);
         result.LastTradeId.Should().Be(1);
         result.TradeCount.Should().Be(1);
@@ -65,7 +67,23 @@ public sealed class CostBasisCalculatorTests
         result.RealizedPnlUsd.Should().Be(5_000m);
         result.CostBasisUsd.Should().Be(10_000m);
         result.AverageBuyPriceUsd.Should().Be(10_000m);
+        result.RemainingQuantity.Should().Be(1m);
         result.TradeCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_PartialSell_DoesNotReturnHistoricalBuyNotionalAsRemainingCostBasis()
+    {
+        var result = _sut.Compute([
+            Buy(qty: 100m, price: 10m, id: 1),
+            Buy(qty: 100m, price: 20m, id: 2),
+            Sell(qty: 170m, price: 25m, id: 3),
+        ]);
+
+        result.RemainingQuantity.Should().Be(30m);
+        result.AverageBuyPriceUsd.Should().Be(15m);
+        result.CostBasisUsd.Should().Be(450m);
+        result.CostBasisUsd.Should().NotBe(3_000m);
     }
 
     [Fact]
@@ -98,6 +116,7 @@ public sealed class CostBasisCalculatorTests
         var seed = new CostBasisResult(
             CostBasisUsd: 10_000m,
             AverageBuyPriceUsd: 10_000m,
+            RemainingQuantity: 1m,
             RealizedPnlUsd: 0m,
             LastTradeAt: new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             LastTradeId: 1,

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Unit/YahooMarketDataServiceTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Unit/YahooMarketDataServiceTests.cs
@@ -1,0 +1,138 @@
+namespace FinanceSentry.Modules.Research.Tests.Unit;
+
+using System.Net;
+using FinanceSentry.Modules.Research.Application.Services;
+using FinanceSentry.Modules.Research.Domain;
+using FinanceSentry.Modules.Research.Domain.Repositories;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+public sealed class YahooMarketDataServiceTests
+{
+    [Fact]
+    public async Task GetQuotesAsync_UsesMhpcYahooAlias_AndKeepsRequestedTicker()
+    {
+        var handler = new StubHttpMessageHandler(_ => QuoteJson(
+            symbol: "MHPC.IL",
+            marketState: "REGULAR",
+            regularMarketPrice: 8.30m,
+            chartPreviousClose: 8.32m));
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetQuotesAsync(["MHPC"]);
+
+        handler.RequestedPath.Should().Contain("/v8/finance/chart/MHPC.IL");
+        result.Should().ContainKey("MHPC");
+        result["MHPC"].Ticker.Should().Be("MHPC");
+        result["MHPC"].ResolvedTicker.Should().Be("MHPC.IL");
+        result["MHPC"].Price.Should().Be(8.30m);
+    }
+
+    [Fact]
+    public async Task GetQuotesAsync_UsesPreMarketPrice_WhenYahooMarketStateIsPre()
+    {
+        var handler = new StubHttpMessageHandler(_ => QuoteJson(
+            symbol: "DRAM",
+            marketState: "PRE",
+            regularMarketPrice: 63.04m,
+            chartPreviousClose: 63.04m,
+            preMarketPrice: 56m));
+        var sut = CreateSut(handler);
+
+        var result = await sut.GetQuotesAsync(["DRAM"]);
+
+        result["DRAM"].Price.Should().Be(56m);
+        result["DRAM"].Session.Should().Be("pre_market");
+        result["DRAM"].IsStale.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetQuotesAsync_RefusesUnexpectedYahooSymbol()
+    {
+        var handler = new StubHttpMessageHandler(_ => QuoteJson(
+            symbol: "WRONG",
+            marketState: "REGULAR",
+            regularMarketPrice: 0.0004m,
+            chartPreviousClose: 0.0004m));
+        var cache = new Mock<IQuoteCacheRepository>();
+        cache.Setup(c => c.GetFreshAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, QuoteCacheEntry>());
+        var sut = CreateSut(handler, cache);
+
+        var result = await sut.GetQuotesAsync(["MHPCX"]);
+
+        result.Should().BeEmpty();
+        cache.Verify(c => c.UpsertManyAsync(It.IsAny<IReadOnlyCollection<QuoteCacheEntry>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static YahooMarketDataService CreateSut(
+        HttpMessageHandler handler,
+        Mock<IQuoteCacheRepository>? cacheMock = null)
+    {
+        var http = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://query1.finance.yahoo.com"),
+        };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(YahooMarketDataService.HttpClientName)).Returns(http);
+
+        var cache = cacheMock ?? new Mock<IQuoteCacheRepository>();
+        cache.Setup(c => c.GetFreshAsync(It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, QuoteCacheEntry>());
+        cache.Setup(c => c.UpsertManyAsync(It.IsAny<IReadOnlyCollection<QuoteCacheEntry>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        return new YahooMarketDataService(factory.Object, cache.Object, NullLogger<YahooMarketDataService>.Instance);
+    }
+
+    private static string QuoteJson(
+        string symbol,
+        string marketState,
+        decimal regularMarketPrice,
+        decimal chartPreviousClose,
+        decimal? preMarketPrice = null,
+        decimal? postMarketPrice = null)
+    {
+        var preMarket = preMarketPrice is null ? string.Empty : $@",""preMarketPrice"":{preMarketPrice}";
+        var postMarket = postMarketPrice is null ? string.Empty : $@",""postMarketPrice"":{postMarketPrice}";
+        return $$"""
+        {
+          "chart": {
+            "result": [
+              {
+                "meta": {
+                  "symbol": "{{symbol}}",
+                  "currency": "USD",
+                  "marketState": "{{marketState}}",
+                  "regularMarketPrice": {{regularMarketPrice}},
+                  "chartPreviousClose": {{chartPreviousClose}},
+                  "regularMarketTime": 1783958400,
+                  "preMarketTime": 1783947600,
+                  "postMarketTime": 1783976400
+                  {{preMarket}}
+                  {{postMarket}}
+                }
+              }
+            ]
+          }
+        }
+        """;
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, string> responseFactory) : HttpMessageHandler
+    {
+        public string? RequestedPath { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestedPath = request.RequestUri?.PathAndQuery;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseFactory(request)),
+            });
+        }
+    }
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -37,7 +37,7 @@ The current runtime surface contains 21 tools: 17 read-only and 4 mutating. Ther
 | `get_net_worth_history` | Read | Wealth | `userId?`, `fromDate?`, `toDate?` | Historical net worth snapshots |
 | `get_macro_calendar` | Read | Research | `from?`, `to?`, `regions?`, `minImportance?` | Scheduled macro events |
 | `get_news_for_ticker` | Read | Research | `ticker`, `since?`, `limit` | Recent ticker-specific news |
-| `get_quotes` | Read | Research | `tickers` | Current quotes for one or more tickers |
+| `get_quotes` | Read | Research | `tickers` | Current quotes for one or more tickers, including requested/resolved ticker identity and market-session freshness metadata |
 | `search_market_news` | Read | Research | `query?`, `tickers?`, `since?`, `limit` | Search ingested market news |
 | `list_watchlist` | Read | Research | `userId?` | Stored watchlist entries |
 | `list_theses` | Read | Research | `userId?` | Stored investment theses |


### PR DESCRIPTION
## Summary
- Reconcile Binance weighted-average cost basis to the actual current holding quantity before exposing it through portfolio snapshots.
- Fail closed when crypto basis cannot be reconciled or implies an absurd cost/value ratio, returning null instead of poisoning P&L math.
- Add Yahoo quote identity/session metadata, map MHPC to the Yahoo/LSE line `MHPC.IL`, and refuse unexpected Yahoo symbol resolutions.
- Prefer Yahoo pre/post-market prices when the market state says they are available; otherwise expose stale/session metadata so Ledger can avoid treating a regular close as live tape.

## Notes
- `get_quotes` keeps `Ticker` as the requested symbol for compatibility and adds `ResolvedTicker`, `MarketState`, `Session`, `IsStale`, `SourcePriceTime`, and `RegularMarketTime`.
- Added migration `M007_QuoteSessionMetadata` for quote-cache metadata.

## Verification
- `dotnet restore backend/FinanceSentry.sln`
- `dotnet build backend/FinanceSentry.sln --no-restore` -> 0 warnings
- `dotnet build backend/FinanceSentry.sln --no-restore -c Release` -> 0 warnings
- `DOTNET_ROLL_FORWARD=Major dotnet test backend/tests/FinanceSentry.Mcp.Tests/FinanceSentry.Mcp.Tests.csproj --no-build --filter "CostBasisCalculatorTests"` -> 8 passed
- `DOTNET_ROLL_FORWARD=Major dotnet test backend/tests/FinanceSentry.Modules.Research.Tests/FinanceSentry.Modules.Research.Tests.csproj --no-build --filter "YahooMarketDataServiceTests"` -> 3 passed

## Known Test Environment Failures
`DOTNET_ROLL_FORWARD=Major dotnet test backend/FinanceSentry.sln --no-build --filter "Category!=Integration"` still has unrelated failures in IBKR adapter contract tests, Radar ingestion idempotency tests, and existing connect contract tests under the local no-Postgres/background-job harness. The changed targeted test projects pass.
