### PR TITLE
chore(frontend): add ng-zorro dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "chart.js": "^4.5.1",
         "chroma-js": "^3.2.0",
         "lucide-angular": "^1.0.0",
+        "ng-zorro-antd": "21.2.2",
         "rxjs": "^7.8.0",
         "tslib": "^2.6.0",
         "zone.js": "^0.16.0"
@@ -2412,6 +2413,43 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
+    "node_modules/@ant-design/colors": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
+      "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^2.0.6"
+      }
+    },
+    "node_modules/@ant-design/fast-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
+      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=8.x"
+      }
+    },
+    "node_modules/@ant-design/icons-angular": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-angular/-/icons-angular-21.0.0.tgz",
+      "integrity": "sha512-Io1DSg0JyzsxQtF2T9LfQSZL22d7zSYyNz0RiUCOhtMoDnnGis1oU6mPs5JzZTRtVdgpuLUhS6GVTlT+dmP1nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
@@ -4078,7 +4116,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4419,6 +4456,15 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -11256,6 +11302,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -16030,6 +16092,26 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ng-zorro-antd": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/ng-zorro-antd/-/ng-zorro-antd-21.2.2.tgz",
+      "integrity": "sha512-mYgc5aDGkBLFwQwcuCW63ESM9oIaCAHCen0PkB77YSfe79f9SVunmUcSsiGPS4lFVmW8VWiL2TYeW53oc9yGOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@angular/cdk": "^21.0.0",
+        "@ant-design/icons-angular": "^21.0.0",
+        "@ctrl/tinycolor": "^3.6.0",
+        "date-fns": "^2.16.1",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/router": "^21.0.0"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -23009,7 +23091,11 @@
       },
       "peerDependencies": {
         "@angular/common": "^21.2.0",
-        "@angular/core": "^21.2.0"
+        "@angular/core": "^21.2.0",
+        "@angular/forms": "^21.2.0",
+        "@angular/platform-browser": "^21.2.0",
+        "@angular/router": "^21.2.0",
+        "ng-zorro-antd": "^21.2.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "chart.js": "^4.5.1",
     "chroma-js": "^3.2.0",
     "lucide-angular": "^1.0.0",
+    "ng-zorro-antd": "21.2.2",
     "rxjs": "^7.8.0",
     "tslib": "^2.6.0",
     "zone.js": "^0.16.0"

--- a/frontend/projects/dsdevq-common/ui/package.json
+++ b/frontend/projects/dsdevq-common/ui/package.json
@@ -3,7 +3,11 @@
   "version": "0.2.0",
   "peerDependencies": {
     "@angular/common": "^21.2.0",
-    "@angular/core": "^21.2.0"
+    "@angular/core": "^21.2.0",
+    "@angular/forms": "^21.2.0",
+    "@angular/platform-browser": "^21.2.0",
+    "@angular/router": "^21.2.0",
+    "ng-zorro-antd": "^21.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
## Summary
- add ng-zorro-antd 21.2.2 to the frontend host app
- declare ng-zorro and its required Angular packages as @dsdevq-common/ui peer dependencies
- update package-lock.json only for the dependency tree

## Manual approval context
Denys selected option B for the finance-sentry-ui-library goal: manually approve this dependency-add diff because DevClaw's review gate repeatedly fails closed on the mechanical lockfile diff with `No JSON object found in planner response`.

## Verification
- `git diff --check` passed
- `npm run build:lib` passed
- `npm run build` passed
- `npm run test:lib -- --watch=false` could not complete in this fresh runner because Playwright Chromium was missing; attempted `npx playwright install chromium`, but it hung after download and was terminated. The test bundle built before failing on missing browser executable.