### PR TITLE
feat(ui-library): add cmn-select primitive

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.spec.ts
@@ -1,0 +1,78 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {SelectComponent, SelectValue} from './select.component';
+
+describe('SelectComponent', () => {
+  let fixture: ComponentFixture<SelectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [SelectComponent]}).compileComponents();
+    fixture = TestBed.createComponent(SelectComponent);
+  });
+
+  function selectElement(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('nz-select');
+  }
+
+  it('renders the configured select options', () => {
+    fixture.componentRef.setInput('options', [
+      {label: 'Euro', value: 'eur'},
+      {label: 'US Dollar', value: 'usd', disabled: true},
+    ]);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.options()).toHaveLength(2);
+    expect(selectElement()).not.toBeNull();
+  });
+
+  it('applies size classes', () => {
+    fixture.componentRef.setInput('size', 'lg');
+    fixture.detectChanges();
+
+    expect(selectElement()?.className).toContain('cmn-select--lg');
+  });
+
+  it('writes external form values', () => {
+    fixture.componentInstance.writeValue('eur');
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['value']()).toBe('eur');
+  });
+
+  it('normalizes undefined form values to null', () => {
+    fixture.componentInstance.writeValue(undefined);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['value']()).toBeNull();
+  });
+
+  it('emits form changes when selection changes', () => {
+    let emitted: SelectValue = null;
+    fixture.componentInstance.registerOnChange(value => {
+      emitted = value;
+    });
+
+    fixture.componentInstance['onValueChange']('usd');
+
+    expect(emitted).toBe('usd');
+    expect(fixture.componentInstance['value']()).toBe('usd');
+  });
+
+  it('marks the control as touched on blur', () => {
+    let touched = false;
+    fixture.componentInstance.registerOnTouched(() => {
+      touched = true;
+    });
+
+    fixture.componentInstance['onBlur']();
+
+    expect(touched).toBe(true);
+  });
+
+  it('updates disabled state from forms API', () => {
+    fixture.componentInstance.setDisabledState(true);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance['disabled']()).toBe(true);
+  });
+});

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts
@@ -1,0 +1,115 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  forwardRef,
+  input,
+  signal,
+} from '@angular/core';
+import {ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {NzSelectModule} from 'ng-zorro-antd/select';
+
+export type SelectSize = 'sm' | 'md' | 'lg';
+export type SelectMode = 'default' | 'multiple';
+export type SelectOptionValue = string | number;
+export type SelectValue = SelectOptionValue | SelectOptionValue[] | null;
+
+export interface SelectOption {
+  label: string;
+  value: SelectOptionValue;
+  disabled?: boolean;
+}
+
+const BASE_CLASSES = 'cmn-select block w-full';
+
+const SIZE_CLASSES: Record<SelectSize, string> = {
+  sm: 'cmn-select--sm',
+  md: 'cmn-select--md',
+  lg: 'cmn-select--lg',
+};
+
+const NZ_SIZE: Record<SelectSize, 'small' | 'default' | 'large'> = {
+  sm: 'small',
+  md: 'default',
+  lg: 'large',
+};
+
+@Component({
+  selector: 'cmn-select',
+  imports: [FormsModule, NzSelectModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SelectComponent),
+      multi: true,
+    },
+  ],
+  template: `
+    <nz-select
+      [ngModel]="value()"
+      [nzAllowClear]="allowClear()"
+      [nzDisabled]="disabled()"
+      [nzMode]="mode()"
+      [nzPlaceHolder]="placeholder()"
+      [nzShowSearch]="showSearch()"
+      [nzSize]="nzSize()"
+      [nzStatus]="hasError() ? 'error' : ''"
+      [class]="classes()"
+      (ngModelChange)="onValueChange($event)"
+      (nzBlur)="onBlur()"
+    >
+      @for (option of options(); track option.value) {
+        <nz-option
+          [nzDisabled]="option.disabled ?? false"
+          [nzLabel]="option.label"
+          [nzValue]="option.value"
+        />
+      }
+    </nz-select>
+  `,
+})
+export class SelectComponent implements ControlValueAccessor {
+  public readonly options = input<readonly SelectOption[]>([]);
+  public readonly placeholder = input<string>('');
+  public readonly size = input<SelectSize>('md');
+  public readonly mode = input<SelectMode>('default');
+  public readonly allowClear = input<boolean>(false);
+  public readonly showSearch = input<boolean>(false);
+  public readonly hasError = input<boolean>(false);
+
+  public readonly classes = computed(() => [BASE_CLASSES, SIZE_CLASSES[this.size()]].join(' '));
+  public readonly nzSize = computed(() => NZ_SIZE[this.size()]);
+
+  protected readonly value = signal<SelectValue>(null);
+  protected readonly disabled = signal<boolean>(false);
+
+  private onChange: (value: SelectValue) => void = (_: SelectValue) => void 0;
+
+  private onTouched: () => void = () => void 0;
+
+  public writeValue(value: SelectValue | undefined): void {
+    this.value.set(value ?? null);
+  }
+
+  public registerOnChange(fn: (value: SelectValue) => void): void {
+    this.onChange = fn;
+  }
+
+  public registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+
+  protected onValueChange(value: SelectValue): void {
+    this.value.set(value);
+    this.onChange(value);
+  }
+
+  protected onBlur(): void {
+    this.onTouched();
+  }
+}

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.stories.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.stories.ts
@@ -1,0 +1,86 @@
+import type {Meta, StoryObj} from '@storybook/angular';
+
+import type {SelectMode, SelectOption, SelectSize} from './select.component';
+import {SelectComponent} from './select.component';
+
+interface SelectStoryArgs {
+  options: SelectOption[];
+  placeholder: string;
+  size: SelectSize;
+  mode: SelectMode;
+  allowClear: boolean;
+  showSearch: boolean;
+  hasError: boolean;
+}
+
+const accountOptions: SelectOption[] = [
+  {label: 'Main current account', value: 'main-current'},
+  {label: 'Savings vault', value: 'savings-vault'},
+  {label: 'Brokerage cash', value: 'brokerage-cash'},
+];
+
+const meta: Meta<SelectStoryArgs> = {
+  title: 'Components/Select',
+  component: SelectComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {control: 'select', options: ['sm', 'md', 'lg']},
+    mode: {control: 'select', options: ['default', 'multiple']},
+    allowClear: {control: 'boolean'},
+    showSearch: {control: 'boolean'},
+    hasError: {control: 'boolean'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<SelectStoryArgs>;
+
+export const Default: Story = {
+  render: args => ({
+    props: args,
+    template: `
+      <div class="w-80">
+        <cmn-select
+          [options]="options"
+          [placeholder]="placeholder"
+          [size]="size"
+          [mode]="mode"
+          [allowClear]="allowClear"
+          [showSearch]="showSearch"
+          [hasError]="hasError"
+        />
+      </div>
+    `,
+  }),
+  args: {
+    options: accountOptions,
+    placeholder: 'Choose account',
+    size: 'md',
+    mode: 'default',
+    allowClear: true,
+    showSearch: false,
+    hasError: false,
+  },
+};
+
+export const Multiple: Story = {
+  render: () => ({
+    props: {options: accountOptions},
+    template: `
+      <div class="w-80">
+        <cmn-select [options]="options" mode="multiple" placeholder="Choose accounts" />
+      </div>
+    `,
+  }),
+};
+
+export const Error: Story = {
+  render: () => ({
+    props: {options: accountOptions},
+    template: `
+      <div class="w-80">
+        <cmn-select [options]="options" [hasError]="true" placeholder="Required field" />
+      </div>
+    `,
+  }),
+};

--- a/frontend/projects/dsdevq-common/ui/src/lib/index.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/index.ts
@@ -31,6 +31,7 @@ export * from './components/institution-avatar/institution-avatar.component';
 export * from './components/line-chart/line-chart.component';
 export * from './components/menu/menu.component';
 export * from './components/password-strength/password-strength.component';
+export * from './components/select/select.component';
 export * from './components/selectable-card/selectable-card.component';
 export * from './components/sidebar-nav/sidebar-nav.component';
 export * from './components/skeleton/skeleton.component';


### PR DESCRIPTION
Summary
- add cmn-select, a ControlValueAccessor primitive wrapping ng-zorro select/options
- add Storybook stories and Vitest spec coverage for the new primitive
- export the component from @dsdevq-common/ui

Review notes
- scoped to the new select component files plus the public API export
- does not migrate app feature templates yet; raw select replacement remains the next phase

Verification
- git diff --check passed
- npm run build:lib passed
- npm run build passed
- npm run test:lib -- --watch=false compiled the test bundle, then failed before tests ran because Playwright Chromium crashed in this runner with Invalid file descriptor to ICU data
- npx ng lint @dsdevq-common/ui hung for several minutes with no output and was killed