### PR TITLE
refactor(frontend): replace raw <select> elements with cmn-select

### DIFF
--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
@@ -112,6 +112,7 @@
             Category
           </label>
           <cmn-select
+            id="budget-category"
             [ngModel]="newCategory()"
             (ngModelChange)="newCategory.set($event)"
             [options]="categorySelectOptions()"

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
@@ -111,17 +111,12 @@
           >
             Category
           </label>
-          <select
+          <cmn-select
             [ngModel]="newCategory()"
             (ngModelChange)="newCategory.set($event)"
-            id="budget-category"
-            class="w-full rounded border border-surface-raised bg-surface-bg px-cmn-2 py-1.5 text-cmn-sm text-text-primary outline-none focus:border-accent-default"
-          >
-            <option value="">Select category…</option>
-            @for (cat of categories(); track cat.key) {
-              <option [value]="cat.key">{{ cat.label }}</option>
-            }
-          </select>
+            [options]="categorySelectOptions()"
+            placeholder="Select category…"
+          />
         </div>
         <div class="w-36">
           <label

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
@@ -41,7 +41,7 @@ export class BudgetsComponent {
 
   public readonly categories = this.categoryStore.categories;
   public readonly categorySelectOptions = computed(() =>
-    this.categories().map(c => ({value: c.key, label: c.label})),
+    this.categories().map(c => ({value: c.key, label: c.label}))
   );
 
   public categoryColor(category: string): string {

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Router} from '@angular/router';
-import {AlertComponent, CardComponent, TagComponent} from '@dsdevq-common/ui';
+import {AlertComponent, CardComponent, SelectComponent, TagComponent} from '@dsdevq-common/ui';
 
 import {AppCurrencyPipe} from '../../../../core/pipes/app-currency.pipe';
 import {AppDecimalPipe} from '../../../../core/pipes/app-decimal.pipe';
@@ -20,9 +20,10 @@ const PCT_WARNING_THRESHOLD = 80;
     AlertComponent,
     AppCurrencyPipe,
     AppDecimalPipe,
-    TagComponent,
     CardComponent,
     FormsModule,
+    SelectComponent,
+    TagComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [BudgetsStore],
@@ -39,6 +40,7 @@ export class BudgetsComponent {
   public readonly newLimit = signal('');
 
   public readonly categories = this.categoryStore.categories;
+  public readonly categorySelectOptions = this.categoryStore.filterOptions;
 
   public categoryColor(category: string): string {
     return this.categoryStore.colorMap()[category] ?? CATEGORY_COLOR_FALLBACK;

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, inject, signal} from '@angular/core';
+import {ChangeDetectionStrategy, Component, computed, inject, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Router} from '@angular/router';
 import {AlertComponent, CardComponent, SelectComponent, TagComponent} from '@dsdevq-common/ui';
@@ -40,7 +40,9 @@ export class BudgetsComponent {
   public readonly newLimit = signal('');
 
   public readonly categories = this.categoryStore.categories;
-  public readonly categorySelectOptions = this.categoryStore.filterOptions;
+  public readonly categorySelectOptions = computed(() =>
+    this.categories().map(c => ({value: c.key, label: c.label})),
+  );
 
   public categoryColor(category: string): string {
     return this.categoryStore.colorMap()[category] ?? CATEGORY_COLOR_FALLBACK;

--- a/frontend/src/app/modules/settings/pages/settings/settings.component.html
+++ b/frontend/src/app/modules/settings/pages/settings/settings.component.html
@@ -76,6 +76,7 @@
               Base Currency
             </label>
             <cmn-select
+              id="s-currency"
               [ngModel]="profile.baseCurrency"
               (ngModelChange)="store.updateProfile({baseCurrency: $event})"
               [options]="currencyOptions"
@@ -89,6 +90,7 @@
               Theme
             </label>
             <cmn-select
+              id="s-theme"
               [ngModel]="profile.theme"
               (ngModelChange)="store.updateProfile({theme: $event})"
               [options]="themeOptions"

--- a/frontend/src/app/modules/settings/pages/settings/settings.component.html
+++ b/frontend/src/app/modules/settings/pages/settings/settings.component.html
@@ -75,16 +75,11 @@
             >
               Base Currency
             </label>
-            <select
+            <cmn-select
               [ngModel]="profile.baseCurrency"
               (ngModelChange)="store.updateProfile({baseCurrency: $event})"
-              id="s-currency"
-              class="w-full rounded-cmn-md border border-border-default bg-surface-card px-cmn-3 py-cmn-2 text-cmn-sm text-text-primary focus:border-border-focus focus:outline-none focus:ring-2 focus:ring-border-focus"
-            >
-              @for (opt of currencyOptions; track opt.value) {
-                <option [value]="opt.value">{{ opt.label }}</option>
-              }
-            </select>
+              [options]="currencyOptions"
+            />
           </div>
           <div>
             <label
@@ -93,16 +88,11 @@
             >
               Theme
             </label>
-            <select
+            <cmn-select
               [ngModel]="profile.theme"
               (ngModelChange)="store.updateProfile({theme: $event})"
-              id="s-theme"
-              class="w-full rounded-cmn-md border border-border-default bg-surface-card px-cmn-3 py-cmn-2 text-cmn-sm text-text-primary focus:border-border-focus focus:outline-none focus:ring-2 focus:ring-border-focus"
-            >
-              @for (opt of themeOptions; track opt.value) {
-                <option [value]="opt.value">{{ opt.label }}</option>
-              }
-            </select>
+              [options]="themeOptions"
+            />
           </div>
         </div>
       </div>

--- a/frontend/src/app/modules/settings/pages/settings/settings.component.ts
+++ b/frontend/src/app/modules/settings/pages/settings/settings.component.ts
@@ -6,6 +6,7 @@ import {
   ConfirmDialogComponent,
   FormFieldComponent,
   InputComponent,
+  SelectComponent,
   ToastService,
   ToggleComponent,
 } from '@dsdevq-common/ui';
@@ -33,7 +34,14 @@ const MIN_PASSWORD_LENGTH = 8;
 
 @Component({
   selector: 'fns-settings',
-  imports: [ButtonComponent, FormFieldComponent, FormsModule, InputComponent, ToggleComponent],
+  imports: [
+    ButtonComponent,
+    FormFieldComponent,
+    FormsModule,
+    InputComponent,
+    SelectComponent,
+    ToggleComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [SettingsStore],
   templateUrl: './settings.component.html',


### PR DESCRIPTION
## Changes
- budgets: categorySelectOptions was incorrectly aliased to
  categoryStore.filterOptions (a differently-scoped signal that could
  carry filter-only pseudo-options). Now computed() directly from
  categories() with the same {value,label} mapping, guaranteeing the
  add-budget category picker uses the identical data source as the
  original <option> loop.
- budgets + settings: all three converted <cmn-select> elements had
  their id attributes silently dropped, breaking <label for=...>
  association. Restored id="budget-category", id="s-currency", and
  id="s-theme" as HTML attributes on the host element (Angular sets
  them on the DOM node; cmn-select needs no dedicated [id] input for
  this to work at the host level).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<details><summary>📋 Ticket (what was asked + why)</summary>

On a branch created fresh off current origin/main (git_head 82d7c6d 'feat(ui-library): add cmn-select primitive wrapping ng-zorro nz-select' — cmn-select was merged via PR #267 and must already exist). Step 0: confirm you are on a clean branch off origin/main; grep for 'cmn-select' under frontend/projects/dsdevq-common/ui/ and confirm the component already exists and is exported from the library's public API (src/lib/index.ts) — do NOT recreate it or modify it. Step 1: grep the feature module templates under frontend/src/app (bank-sync, budgets, alerts, subscriptions, holdings, settings) for raw unstyled `<select>` elements. Step 2: replace every raw `<select>`/`<option>` usage with `<cmn-select>`, preserving existing form-binding (ngModel / formControl / reactive forms) and validation behavior exactly — only swap the markup/component, do not change form logic or validators. Import CmnSelectComponent (or the relevant standalone import) into each feature component that needs it. Step 3: do NOT touch cmn-button, cmn-input, cmn-icon, cmn-badge, cmn-select, or any other library component's internals — this change is feature-module templates/TS only, plus the new imports. Step 4: before finishing, run `git diff --stat` against origin/main and confirm the diff touches ONLY feature-module files that had raw `<select>` elements (template + minimal TS wiring/imports) — no library changes, no unrelated files. Step 5: full app build + library build (`npm run build:lib`) + full test suite (frontend + @dsdevq-common/ui, Storybook included) must stay green.

</details>

## Files changed
```
.../budgets/pages/budgets/budgets.component.html   | 14 +++++--------
 .../budgets/pages/budgets/budgets.component.ts     | 10 ++++++---
 .../pages/settings/settings.component.html         | 24 ++++++++--------------
 .../settings/pages/settings/settings.component.ts  |  2 ++
 4 files changed, 22 insertions(+), 28 deletions(-)
```

---
🤖 Delivered by devclaw (task `6035ecd5-ef34-4599-b2d5-6d201f67c024`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.