### PR TITLE
refactor(ui): adopt cmn-page-header in budgets and alerts pages

### DIFF
--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -1,24 +1,12 @@
 <div class="p-cmn-6">
   <div class="mx-auto max-w-[860px] space-y-cmn-5">
-    <div class="flex items-center justify-between">
-      <div>
-        <h1 class="font-headline text-2xl font-bold text-text-primary">Alerts</h1>
-        <p class="mt-1 text-cmn-sm text-text-secondary">
-          @if (store.unreadCount() > 0) {
-            {{ store.unreadCount() }} unread {{ store.unreadCount() === 1 ? 'alert' : 'alerts' }}
-          } @else {
-            All caught up
-          }
-        </p>
-      </div>
-      <div class="flex gap-cmn-2">
-        @if (store.unreadCount() > 0) {
-          <cmn-button (clicked)="markAllRead()" variant="secondary" size="sm" icon="CheckCheck">
-            Mark all read
-          </cmn-button>
-        }
-      </div>
-    </div>
+    <cmn-page-header
+      title="Alerts"
+      [subtitle]="alertsSubtitle()"
+      [actionLabel]="store.unreadCount() > 0 ? 'Mark all read' : null"
+      actionIcon="CheckCheck"
+      (actionClick)="markAllRead()"
+    />
 
     <div class="flex flex-wrap gap-cmn-2">
       @for (opt of filterOptions; track opt.id) {

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -3,10 +3,10 @@ import {Router} from '@angular/router';
 import {
   AlertItemComponent,
   type AlertItemSeverity,
-  ButtonComponent,
   CardComponent,
   IconComponent,
   type LucideIconName,
+  PageHeaderComponent,
   ToastService,
 } from '@dsdevq-common/ui';
 
@@ -33,7 +33,7 @@ function severityFor(severity: AlertSeverity): AlertItemSeverity {
 
 @Component({
   selector: 'fns-alerts',
-  imports: [AlertItemComponent, ButtonComponent, CardComponent, IconComponent],
+  imports: [AlertItemComponent, CardComponent, IconComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './alerts.component.html',
 })
@@ -42,6 +42,14 @@ export class AlertsComponent {
   private readonly router = inject(Router);
 
   public readonly store = inject(AlertsStore);
+
+  public readonly alertsSubtitle = computed(() => {
+    const count = this.store.unreadCount();
+    if (count > 0) {
+      return `${count} unread ${count === 1 ? 'alert' : 'alerts'}`;
+    }
+    return 'All caught up';
+  });
 
   public readonly filtered = computed(() => {
     const f = this.store.filter();

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.html
@@ -1,12 +1,9 @@
 <div class="p-cmn-6">
   <div class="mx-auto max-w-screen-lg space-y-cmn-5">
     <!-- Header -->
-    <div class="flex items-center justify-between">
-      <div>
-        <h1 class="font-headline text-2xl font-bold text-text-primary">Budgets</h1>
-        <p class="mt-1 text-cmn-sm text-text-secondary">Monthly spending limits</p>
-      </div>
-      <div class="text-right">
+    <div class="flex items-start justify-between gap-cmn-4">
+      <cmn-page-header title="Budgets" subtitle="Monthly spending limits" class="flex-1" />
+      <div class="shrink-0 text-right">
         <div
           class="font-label text-cmn-xs font-semibold uppercase tracking-widest text-text-secondary"
         >

--- a/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
+++ b/frontend/src/app/modules/budgets/pages/budgets/budgets.component.ts
@@ -1,7 +1,13 @@
 import {ChangeDetectionStrategy, Component, computed, inject, signal} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {Router} from '@angular/router';
-import {AlertComponent, CardComponent, SelectComponent, TagComponent} from '@dsdevq-common/ui';
+import {
+  AlertComponent,
+  CardComponent,
+  PageHeaderComponent,
+  SelectComponent,
+  TagComponent,
+} from '@dsdevq-common/ui';
 
 import {AppCurrencyPipe} from '../../../../core/pipes/app-currency.pipe';
 import {AppDecimalPipe} from '../../../../core/pipes/app-decimal.pipe';
@@ -22,6 +28,7 @@ const PCT_WARNING_THRESHOLD = 80;
     AppDecimalPipe,
     CardComponent,
     FormsModule,
+    PageHeaderComponent,
     SelectComponent,
     TagComponent,
   ],


### PR DESCRIPTION
## Changes
Replaces hand-rolled h1+subtitle+action-button markup in both
feature modules with the library's <cmn-page-header> component.

- budgets: static title/subtitle; Total Spent vs Budget stat widget
  kept alongside cmn-page-header in a flex row (no action button)
- alerts: dynamic subtitle computed from unreadCount(); conditional
  actionLabel bound to show 'Mark all read' only when unread > 0

ButtonComponent removed from AlertsComponent imports (now handled
internally by PageHeaderComponent).

Verified: ng build --configuration=production passes, eslint clean,
no changes to @dsdevq-common/ui library.

<details><summary>📋 Ticket (what was asked + why)</summary>

cmn-page-header (frontend/projects/dsdevq-common/ui/src/lib) is merged to origin/main. Adopt it in exactly two more feature modules this slice: budgets and alerts. Replace their hand-rolled title+subtitle+primary-action-button header markup with the library's <cmn-page-header> component and its title/subtitle/actions inputs/slots. Do NOT touch bank-sync, subscriptions (already converted in PR #271), holdings, or settings in this action — those are separate batches.

Acceptance criteria:
- budgets and alerts feature pages both render their header via <cmn-page-header> instead of inline markup.
- A grep for the old inline title+subtitle+action-button header shape in these two modules' templates turns up zero remaining matches.
- Full app build and the full test suite pass.
- No changes anywhere under the @dsdevq-common/ui library itself (component already shipped) — this slice is consumption-only.

Constraints:
- Touch only budgets and alerts feature-module files; bank-sync, subscriptions, holdings, settings are out of scope for this action.
- Do not touch ConfirmDialogComponent, DialogService, or CmnDialogService — closed scope (PR #269).
- Do not modify package.json/lockfile, rename the library package, or start the ng-zorro-antd primitive-adoption decision.
- Branch fresh off the current origin/main tip (which already has cmn-page-header merged) rather than resuming any prior branch.
- If the review gate crashes for a genuinely unreviewable reason (not a specific finding), do not auto-retry and do not page the owner — report the branch/commit plus local build+test evidence instead; this two-module diff is expected to be small enough to be reviewable.

</details>

## Files changed
```
.../alerts/pages/alerts/alerts.component.html      | 26 ++++++----------------
 .../alerts/pages/alerts/alerts.component.ts        | 12 ++++++++--
 .../budgets/pages/budgets/budgets.component.html   |  9 +++-----
 .../budgets/pages/budgets/budgets.component.ts     |  9 +++++++-
 4 files changed, 28 insertions(+), 28 deletions(-)
```

---
🤖 Delivered by devclaw (task `4044e8cb-4cf1-458f-82ed-f6103bd506e7`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.