### PR TITLE
fix(lint): resolve attributes-order violations in accounts-list and…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-sentry",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -1,11 +1,11 @@
 <div class="p-cmn-6">
   <div class="mx-auto max-w-[860px] space-y-cmn-5">
     <cmn-page-header
-      title="Alerts"
       [subtitle]="alertsSubtitle()"
       [actionLabel]="store.unreadCount() > 0 ? 'Mark all read' : null"
-      actionIcon="CheckCheck"
       (actionClick)="markAllRead()"
+      title="Alerts"
+      actionIcon="CheckCheck"
     />
 
     <div class="flex flex-wrap gap-cmn-2">

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -1,10 +1,10 @@
 <div class="p-cmn-8 max-w-[1200px] mx-auto">
   <div class="mb-cmn-8">
     <cmn-page-header
+      (actionClick)="connectAccount()"
       title="Account Inventory"
       subtitle="All connected financial accounts"
       actionLabel="Connect Account"
-      (actionClick)="connectAccount()"
     />
     @if (!store.isLoading() && store.totalNetWorth() !== 0) {
       <div class="mt-cmn-3 text-right">


### PR DESCRIPTION
## Changes
The @angular-eslint/template/attributes-order rule requires output bindings
to precede plain attribute bindings. Two violations existed on origin/main:
- accounts-list.component.html: (actionClick) was after title/subtitle/actionLabel
- alerts.component.html: (actionClick) was after title/[subtitle]/[actionLabel]/actionIcon

Reordered both tags; npm run lint passes with zero violations.

<details><summary>📋 Ticket (what was asked + why)</summary>

Fix the two pre-existing @angular-eslint/template/attributes-order violations on origin/main identified by diagnostic ea8b3a63: accounts-list.component.html (frontend/src/app/modules/bank-sync/pages/accounts-list/) and alerts.component.html both have output binding (actionClick) placed AFTER attribute bindings (title/subtitle/actionLabel/actionIcon) on their <cmn-page-header> tags. The repo's custom eslint rule requires order: structural directive -> template reference -> input binding -> two-way binding -> output binding -> attribute binding, so (actionClick) must move BEFORE the plain attributes on both tags. Hand-fix just these two tags, then bump frontend/package.json's version as the pre-commit hook requires for any frontend/src change, and commit deliberately (do not use --no-verify — let the hook pass because the violations are actually gone).

Acceptance criteria:
- `npm run lint` (or `ng lint`) passes with zero attributes-order violations anywhere in the two touched files.
- Both <cmn-page-header> tags show (actionClick) ordered before their plain attribute bindings (title, subtitle, actionLabel/actionIcon).
- `git diff --stat` against origin/main lists ONLY accounts-list.component.html, alerts.component.html, and frontend/package.json (version bump) — paste that output. Any other file means stop and re-scope.
- Full app build and full test suite pass, and the pre-commit hook itself passes cleanly on the commit (not bypassed with --no-verify).

Constraints:
- Do not touch holdings or settings cmn-page-header markup — that work already shipped in PR #274.
- Do not touch ConfirmDialogComponent, DialogService, or CmnDialogService — closed scope (PR #269).
- Do not run a repo-wide format/lint/fix pass beyond what's needed to correct these two specific tags — hand-edit the attribute order rather than invoking `eslint --fix`/`ng lint --fix` across the whole project, to avoid reformatting unrelated files.
- Do not start the ng-zorro-antd primitive-adoption work or rename the library package — those are separate, still-open decisions.
- Actually create a real feature branch (`git checkout -b <name> origin/main` after `git fetch origin`) rather than resetting local main to origin/main and committing there — the diagnostic found prior attempts never branched, which is a contributing factor to the confusion.
- If the review gate crashes for a genuinely unreviewable reason with no specific finding, do not auto-retry and do not page the owner — report the branch/commit plus local build+test evidence instead. If it names a specific, concrete finding, fix that finding before resubmitting.

</details>

## Files changed
```
frontend/package.json                                                 | 2 +-
 frontend/src/app/modules/alerts/pages/alerts/alerts.component.html    | 4 ++--
 .../bank-sync/pages/accounts-list/accounts-list.component.html        | 2 +-
 3 files changed, 4 insertions(+), 4 deletions(-)
```

---
🤖 Delivered by devclaw (task `75dae49b-1025-4655-baf7-d8c6ae94a87f`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.