### PR TITLE
refactor(frontend): use cmn-chip for alerts and subscriptions controls

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finance-sentry",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -10,17 +10,9 @@
 
     <div class="flex flex-wrap gap-cmn-2">
       @for (opt of filterOptions; track opt.id) {
-        <button
-          [class.border-accent-default]="store.filter() === opt.id"
-          [class.bg-accent-subtle]="store.filter() === opt.id"
-          [class.text-accent-default]="store.filter() === opt.id"
-          [class.border-border-default]="store.filter() !== opt.id"
-          [class.text-text-secondary]="store.filter() !== opt.id"
-          (click)="store.setFilter(opt.id)"
-          class="rounded-full border px-cmn-3 py-cmn-1 font-label text-cmn-xs font-medium transition-colors"
-        >
+        <cmn-chip [selected]="store.filter() === opt.id" (clicked)="store.setFilter(opt.id)">
           {{ opt.label() }}
-        </button>
+        </cmn-chip>
       }
     </div>
 

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -4,6 +4,7 @@ import {
   AlertItemComponent,
   type AlertItemSeverity,
   CardComponent,
+  ChipComponent,
   IconComponent,
   type LucideIconName,
   PageHeaderComponent,
@@ -33,7 +34,7 @@ function severityFor(severity: AlertSeverity): AlertItemSeverity {
 
 @Component({
   selector: 'fns-alerts',
-  imports: [AlertItemComponent, CardComponent, IconComponent, PageHeaderComponent],
+  imports: [AlertItemComponent, CardComponent, ChipComponent, IconComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './alerts.component.html',
 })

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -52,17 +52,9 @@
         </span>
         <div class="flex gap-cmn-1">
           @for (opt of sortOptions; track opt.value) {
-            <button
-              [class.border-accent-default]="store.sort() === opt.value"
-              [class.bg-accent-subtle]="store.sort() === opt.value"
-              [class.text-accent-default]="store.sort() === opt.value"
-              [class.border-border-default]="store.sort() !== opt.value"
-              [class.text-text-secondary]="store.sort() !== opt.value"
-              (click)="setSort(opt.value)"
-              class="rounded-cmn-md border px-cmn-2 py-cmn-1 font-label text-cmn-xs font-medium transition-colors"
-            >
+            <cmn-chip [selected]="store.sort() === opt.value" (clicked)="setSort(opt.value)">
               {{ opt.label }}
-            </button>
+            </cmn-chip>
           }
         </div>
       </div>

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
@@ -3,6 +3,7 @@ import {ChangeDetectionStrategy, Component, inject, ViewContainerRef} from '@ang
 import {
   ButtonComponent,
   CardComponent,
+  ChipComponent,
   CmnDialogService,
   ConfirmDialogComponent,
   PageHeaderComponent,
@@ -32,6 +33,7 @@ const SORT_OPTIONS: {value: SubscriptionSort; label: string}[] = [
     AppCurrencyPipe,
     ButtonComponent,
     CardComponent,
+    ChipComponent,
     DatePipe,
     MerchantColorPipe,
     PageHeaderComponent,


### PR DESCRIPTION
## Changes
- Replace hand-rolled alerts filter buttons with `cmn-chip`.
- Replace hand-rolled subscriptions sort buttons with `cmn-chip`.
- Import `ChipComponent` in the two feature components.
- Bump `frontend/package.json` version from `0.11.2` to `0.11.3` per pre-commit policy.

## Scope
Only these files changed:
```text
frontend/package.json
frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
```

Old conditional raw-button class pattern grep result:
```text
(no matches)
```

## Verification
Passed:
- `npx eslint src/app/modules/alerts/pages/alerts/alerts.component.ts src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts`
- `npx prettier --check src/app/modules/alerts/pages/alerts/alerts.component.html src/app/modules/alerts/pages/alerts/alerts.component.ts src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts package.json`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run build:lib`
- `git commit` pre-commit hook passed: lint-staged, full lint, format check, version bump check

Known existing test blocker:
- `npm test -- --watch=false` fails before this diff's tests can run because Playwright Chromium is not installed in this container and existing `cmn-select` specs access protected members (`value`, `onValueChange`, `onBlur`, `disabled`). Same pre-existing test harness issue seen on prior UI-library work.

## Notes
This is the manual recovery for the timed-out DevClaw task `755d831e-4497-4119-ad59-5f6b34371e5b`. The durable goal loop stalled; this PR was produced directly from a fresh checkout of current `main`.
