### PR TITLE
feat: add cmn-disclosure-row component (no spec/story yet)

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/disclosure-row/disclosure-row.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/disclosure-row/disclosure-row.component.ts
@@ -1,0 +1,63 @@
+import {DecimalPipe} from '@angular/common';
+import {ChangeDetectionStrategy, Component, input} from '@angular/core';
+
+import {InstitutionAvatarComponent} from '../institution-avatar/institution-avatar.component';
+
+@Component({
+  selector: 'cmn-disclosure-row',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [InstitutionAvatarComponent, DecimalPipe],
+  host: {style: 'display: block'},
+  template: `
+    <details [open]="open()" class="group border-b border-border-default last:border-0">
+      <summary
+        class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
+      >
+        <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
+          @if (avatarName()) {
+            <cmn-institution-avatar [name]="avatarName()!" />
+          }
+          <div class="min-w-0">
+            <p class="font-medium text-text-primary">{{ label() }}</p>
+            @if (sublabel()) {
+              <p class="text-cmn-xs text-text-secondary">{{ sublabel() }}</p>
+            }
+          </div>
+        </div>
+        <ng-content select="[status]" />
+        @if (amount() !== null) {
+          <div class="font-mono tabular-nums font-medium text-text-primary text-right min-w-[7rem]">
+            @if (currency()) {
+              {{ currency() }}
+            }
+            {{ amount() | number: '1.2-2' }}
+          </div>
+        }
+        <ng-content select="[actions]" />
+        <svg
+          class="w-4 h-4 text-text-secondary transition-transform group-open:rotate-180 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </summary>
+      <ng-content />
+    </details>
+  `,
+})
+export class DisclosureRowComponent {
+  public readonly label = input.required<string>();
+  public readonly sublabel = input<string | null>(null);
+  public readonly amount = input<number | null>(null);
+  public readonly currency = input<string | null>(null);
+  public readonly avatarName = input<string | null>(null);
+  public readonly open = input<boolean>(true);
+}

--- a/frontend/projects/dsdevq-common/ui/src/lib/index.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/index.ts
@@ -19,6 +19,7 @@ export * from './components/dialog/dialog-bare-container.component';
 export * from './components/dialog/dialog-config';
 export * from './components/dialog/dialog-container.component';
 export * from './components/dialog/dialog-ref';
+export * from './components/disclosure-row/disclosure-row.component';
 export * from './components/donut-chart/donut-chart.component';
 export * from './components/drawer/drawer-config';
 export * from './components/drawer/drawer-container.component';


### PR DESCRIPTION
## Changes
Encapsulates the repeated <details>/<summary> collapsible institution-row
pattern used in accounts-list (3×) and holdings (1×). Inputs cover label,
sublabel, amount, currency, avatarName, and open state; content-projection
slots ([status], [actions], default) handle the status indicator, action
buttons, and child rows respectively.

Library build confirmed clean; ESLint passes with library config.
Vitest spec and Storybook story deferred per task scope to keep diff small.

<details><summary>📋 Ticket (what was asked + why)</summary>

Add the cmn-disclosure-row component to the @dsdevq-common/ui library (frontend/projects/dsdevq-common/ui/src/lib), modeled on cmn-page-header (PR #270) and cmn-page-container (PR #278) — standalone, OnPush, signal-based input()/output() APIs, its own ng-packagr build entry. It encapsulates the repeated collapsible institution-row pattern duplicated 3x in frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html (lines ~68-148, ~167-242, ~260-336 — `<details class="group" open>`/`<summary>` row: avatar, name/sublabel, a status indicator, a right-aligned amount, action button(s), rotating chevron SVG, followed by a `<table>` of child rows) and once in frontend/src/app/modules/holdings/pages/holdings/holdings.component.html (lines ~86-130, same shape with `cmn-tag` instead of a status indicator). This is a deliberately SMALLER retry of failed task f993e538: that attempt bundled component + spec + story + public-api export in one diff and the review gate crashed on a 180s timeout with no specific finding (fails closed, not auto-retried per the hardening rule — an unreviewable diff must be split, not resubmitted whole). This slice ships ONLY the component implementation + its public-api export — the Vitest spec and Storybook story are deferred to a tight follow-up action once this smaller diff clears the gate. Do NOT touch accounts-list.component.html or holdings.component.html.

Acceptance criteria:
- cmn-disclosure-row exists under dsdevq-common/ui with its own build target, inputs covering label/sublabel/amount/currency/status (or a projected status slot) and a chevron/expand affordance, plus a projected content area for child rows and an actions slot — flexible enough to match both accounts-list and holdings variations.
- Component is exported from the library's public API (index/ng-package entry).
- No Vitest spec or Storybook story in this slice — those are a deliberate follow-up to keep this diff small enough for the gate to review within its timeout.
- `git diff --stat` against origin/main lists ONLY the new disclosure-row component file(s) plus the public-api export file — paste that output; accounts-list.component.html, holdings.component.html, or any other pre-existing file must show zero changes.
- Full library build passes and the pre-commit hook passes cleanly (not bypassed with --no-verify).

Constraints:
- Do not touch accounts-list.component.html or holdings.component.html in this action.
- Do not touch cmn-chip, cmn-page-header, cmn-page-container, ConfirmDialogComponent/DialogService/CmnDialogService, cmn-select, or select.component.ts.
- Do not add a Vitest spec or Storybook story in this slice — deferred on purpose to keep the diff small.
- Owner decision (2026-07-16): keep the bespoke Tailwind primitive layer, do NOT adopt ng-zorro-antd, do NOT rename the library package, do NOT touch package.json's name field.
- Do not run any repository-wide format/lint/fix command — hand-edit only the files this slice requires.
- If the review gate again crashes/times out with no specific finding, do not retry within this action — stop and report the branch/commit plus local build evidence instead; do not page the owner.

</details>

## Files changed
```
.../disclosure-row/disclosure-row.component.ts     | 63 ++++++++++++++++++++++
 .../projects/dsdevq-common/ui/src/lib/index.ts     |  1 +
 2 files changed, 64 insertions(+)
```

---
🤖 Delivered by devclaw (task `6fc4293a-9bd0-4619-95db-cf89df1623d6`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.