### PR TITLE
fix(wealth): stop net-worth snapshots recording stale/$0 sync failures

### DIFF
--- a/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
+++ b/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <Version>0.11.0</Version> <!-- x-release-please-version -->
+    <Version>0.11.1</Version> <!-- x-release-please-version -->
     <AssemblyVersion>0.11.0</AssemblyVersion> <!-- x-release-please-version -->
     <FileVersion>0.11.0</FileVersion> <!-- x-release-please-version -->
   </PropertyGroup>

--- a/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
@@ -17,4 +17,6 @@ public record NetWorthSnapshotData(
     decimal BankingTotal,
     decimal BrokerageTotal,
     decimal CryptoTotal,
+    bool BrokerageFresh = true,
+    bool CryptoFresh = true,
     string Currency = "USD");

--- a/backend/src/FinanceSentry.Mcp/Tools/GetNetWorthHistoryTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/GetNetWorthHistoryTool.cs
@@ -18,7 +18,7 @@ public sealed class GetNetWorthHistoryTool(
     private readonly ILogger<GetNetWorthHistoryTool> _logger = logger;
 
     [McpServerTool(Name = "get_net_worth_history")]
-    [Description("Returns historical net worth snapshots (banking + brokerage + crypto totals per day), optionally bounded by from/to dates. Defaults to the authenticated MCP identity when userId is omitted.")]
+    [Description("Returns historical net worth snapshots (banking + brokerage + crypto totals per day), optionally bounded by from/to dates. Defaults to the authenticated MCP identity when userId is omitted. staleSleeves lists any sleeves whose value was carried forward from a prior day because that provider's feed was stale/disconnected/failed — treat a day with staleSleeves as a partially estimated net worth, not real movement.")]
     public async Task<IReadOnlyList<NetWorthHistoryEntry>> ExecuteAsync(
         [Description("Optional user GUID. Defaults to the authenticated MCP identity.")] Guid? userId = null,
         [Description("Optional inclusive start date (e.g. 2024-01-01).")] DateOnly? fromDate = null,
@@ -49,7 +49,8 @@ public sealed class GetNetWorthHistoryTool(
                 s.BrokerageTotal,
                 s.CryptoTotal,
                 s.TotalNetWorth,
-                s.Currency))
+                s.Currency,
+                s.StaleSleeves))
             .ToList();
     }
 }
@@ -60,4 +61,5 @@ public sealed record NetWorthHistoryEntry(
     decimal BrokerageTotal,
     decimal CryptoTotal,
     decimal TotalNetWorth,
-    string Currency);
+    string Currency,
+    string? StaleSleeves);

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetNetWorthHistoryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetNetWorthHistoryQuery.cs
@@ -9,7 +9,8 @@ public record NetWorthSnapshotDto(
     decimal BrokerageTotal,
     decimal CryptoTotal,
     decimal TotalNetWorth,
-    string Currency);
+    string Currency,
+    string? StaleSleeves);
 
 public record NetWorthHistoryResponse(
     IReadOnlyList<NetWorthSnapshotDto> Snapshots,
@@ -29,7 +30,7 @@ public class GetNetWorthHistoryQueryHandler(INetWorthSnapshotRepository reposito
         var dtos = snapshots
             .Select(s => new NetWorthSnapshotDto(
                 s.SnapshotDate, s.BankingTotal, s.BrokerageTotal,
-                s.CryptoTotal, s.TotalNetWorth, s.Currency))
+                s.CryptoTotal, s.TotalNetWorth, s.Currency, s.StaleSleeves))
             .ToList();
 
         return new NetWorthHistoryResponse(dtos, dtos.Count > 0);

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
@@ -13,20 +13,52 @@ public class NetWorthSnapshotService(INetWorthSnapshotRepository repository) : I
         if (await _repository.ExistsAsync(userId, data.SnapshotDate, ct))
             return;
 
+        // Never let a stale/missing/failed sync write a $0 or stale sleeve as if it were
+        // real movement. When a sleeve isn't trustworthy this run, carry forward its last
+        // known-good value and record which sleeves were estimated so trend analysis can
+        // tell a measured net worth from a partially carried-forward one.
+        var previous = await _repository.GetLatestByUserIdAsync(userId, ct);
+        var stale = new List<string>();
+
+        var banking = ResolveSleeve("banking", data.BankingTotal, isFresh: true, previous?.BankingTotal, stale);
+        var brokerage = ResolveSleeve("brokerage", data.BrokerageTotal, data.BrokerageFresh, previous?.BrokerageTotal, stale);
+        var crypto = ResolveSleeve("crypto", data.CryptoTotal, data.CryptoFresh, previous?.CryptoTotal, stale);
+
         var snapshot = new NetWorthSnapshot
         {
             Id = Guid.NewGuid(),
             UserId = userId,
             SnapshotDate = data.SnapshotDate,
-            BankingTotal = data.BankingTotal,
-            BrokerageTotal = data.BrokerageTotal,
-            CryptoTotal = data.CryptoTotal,
-            TotalNetWorth = data.BankingTotal + data.BrokerageTotal + data.CryptoTotal,
+            BankingTotal = banking,
+            BrokerageTotal = brokerage,
+            CryptoTotal = crypto,
+            TotalNetWorth = banking + brokerage + crypto,
             Currency = data.Currency,
             TakenAt = DateTimeOffset.UtcNow,
+            StaleSleeves = stale.Count > 0 ? string.Join(',', stale) : null,
         };
 
         await _repository.PersistAsync(snapshot, ct);
+    }
+
+    /// <summary>
+    /// Returns the value to record for a sleeve. Uses the fresh value when the feed is
+    /// trustworthy; otherwise carries forward the previous snapshot's value (and flags the
+    /// sleeve as stale). Treats a drop to exactly $0 when we previously held value as a
+    /// failed sync rather than a genuine liquidation.
+    /// </summary>
+    private static decimal ResolveSleeve(string name, decimal freshValue, bool isFresh, decimal? previousValue, List<string> stale)
+    {
+        var looksLikeFailedSync = freshValue == 0m && previousValue is > 0m;
+
+        if (isFresh && !looksLikeFailedSync)
+            return freshValue;
+
+        if (previousValue is null)
+            return freshValue; // no history to fall back on — best effort with what we have
+
+        stale.Add(name);
+        return previousValue.Value;
     }
 
     public async Task<bool> HasSnapshotForTodayAsync(Guid userId, CancellationToken ct = default)

--- a/backend/src/FinanceSentry.Modules.Wealth/Domain/NetWorthSnapshot.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Domain/NetWorthSnapshot.cs
@@ -11,4 +11,13 @@ public sealed class NetWorthSnapshot
     public decimal TotalNetWorth { get; init; }
     public string Currency { get; init; } = "USD";
     public DateTimeOffset TakenAt { get; init; }
+
+    /// <summary>
+    /// Comma-separated sleeve names whose value was carried forward from a prior
+    /// snapshot because the live feed was stale, missing, or a failed sync.
+    /// Empty/null = every sleeve was measured fresh this day. Lets consumers
+    /// distinguish a measured net worth from a partially estimated one instead of
+    /// treating carried-forward or $0 sync-failure days as real movement.
+    /// </summary>
+    public string? StaleSleeves { get; init; }
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
@@ -32,17 +32,28 @@ public class NetWorthSnapshotJob(
     public async Task CaptureForUserAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct = default)
         => await TakeSnapshotAsync(userId, snapshotDate, ct);
 
+    // A sleeve is only trusted if its freshest holding synced within this window; older
+    // than this (a disconnected provider, a stuck gateway, a failed sync) is treated as
+    // stale and carried forward rather than counted as the live number.
+    private static readonly TimeSpan StaleWindow = TimeSpan.FromHours(36);
+
     private async Task TakeSnapshotAsync(Guid userId, DateOnly snapshotDate, CancellationToken ct)
     {
+        var now = DateTime.UtcNow;
         var bankingTotal = await _bankingTotals.GetTotalUsdAsync(userId, ct);
 
         var cryptoHoldings = await _cryptoReader.GetHoldingsAsync(userId, ct);
         var cryptoTotal = cryptoHoldings.Sum(h => h.UsdValue);
+        var cryptoFresh = cryptoHoldings.Count > 0
+            && cryptoHoldings.Max(h => h.SyncedAt) >= now - StaleWindow;
 
         var brokerageHoldings = await _brokerageReader.GetHoldingsAsync(userId, ct);
         var brokerageTotal = brokerageHoldings.Sum(h => h.UsdValue);
+        var brokerageFresh = brokerageHoldings.Count > 0
+            && brokerageHoldings.Max(h => h.SyncedAt) >= now - StaleWindow;
 
         await _snapshotService.PersistSnapshotAsync(userId, new NetWorthSnapshotData(
-            snapshotDate, bankingTotal, brokerageTotal, cryptoTotal), ct);
+            snapshotDate, bankingTotal, brokerageTotal, cryptoTotal,
+            BrokerageFresh: brokerageFresh, CryptoFresh: cryptoFresh), ct);
     }
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Persistence/WealthDbContext.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Persistence/WealthDbContext.cs
@@ -23,6 +23,7 @@ public class WealthDbContext(DbContextOptions<WealthDbContext> options) : DbCont
         e.Property(s => s.TotalNetWorth).HasColumnType("numeric(18,2)").IsRequired();
         e.Property(s => s.Currency).IsRequired().HasMaxLength(3);
         e.Property(s => s.TakenAt).HasDefaultValueSql("now()");
+        e.Property(s => s.StaleSleeves).HasColumnName("stale_sleeves").HasMaxLength(64);
 
         e.HasIndex(s => new { s.UserId, s.SnapshotDate })
             .IsDescending(false, true)

--- a/backend/src/FinanceSentry.Modules.Wealth/Migrations/20260717115951_M002_AddStaleSleeves.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Migrations/20260717115951_M002_AddStaleSleeves.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.Wealth.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.Wealth.Migrations
 {
     [DbContext(typeof(WealthDbContext))]
-    partial class WealthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717115951_M002_AddStaleSleeves")]
+    partial class M002_AddStaleSleeves
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.Wealth/Migrations/20260717115951_M002_AddStaleSleeves.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Migrations/20260717115951_M002_AddStaleSleeves.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.Wealth.Migrations
+{
+    /// <inheritdoc />
+    public partial class M002_AddStaleSleeves : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "stale_sleeves",
+                table: "net_worth_snapshots",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "stale_sleeves",
+                table: "net_worth_snapshots");
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Mcp.Tests/GetNetWorthHistoryToolTests.cs
+++ b/backend/tests/FinanceSentry.Mcp.Tests/GetNetWorthHistoryToolTests.cs
@@ -44,8 +44,8 @@ public sealed class GetNetWorthHistoryToolTests
     [Fact]
     public async Task ExecuteAsync_MapsSnapshots_PreservingOrder()
     {
-        var snap1 = new NetWorthSnapshotDto(new DateOnly(2024, 1, 31), 1000m, 500m, 200m, 1700m, "USD");
-        var snap2 = new NetWorthSnapshotDto(new DateOnly(2024, 2, 29), 1100m, 600m, 250m, 1950m, "USD");
+        var snap1 = new NetWorthSnapshotDto(new DateOnly(2024, 1, 31), 1000m, 500m, 200m, 1700m, "USD", null);
+        var snap2 = new NetWorthSnapshotDto(new DateOnly(2024, 2, 29), 1100m, 600m, 250m, 1950m, "USD", "brokerage");
 
         _handler
             .Setup(h => h.Handle(It.IsAny<GetNetWorthHistoryQuery>(), It.IsAny<CancellationToken>()))
@@ -60,7 +60,9 @@ public sealed class GetNetWorthHistoryToolTests
         result[0].CryptoTotal.Should().Be(200m);
         result[0].TotalNetWorth.Should().Be(1700m);
         result[0].Currency.Should().Be("USD");
+        result[0].StaleSleeves.Should().BeNull();
         result[1].TotalNetWorth.Should().Be(1950m);
+        result[1].StaleSleeves.Should().Be("brokerage");
     }
 
     [Fact]

--- a/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotServiceTests.cs
@@ -58,5 +58,73 @@ public class NetWorthSnapshotServiceTests
         captured.CryptoTotal.Should().Be(250m);
         captured.TotalNetWorth.Should().Be(1750m);
         captured.Currency.Should().Be("USD");
+        captured.StaleSleeves.Should().BeNull();
+    }
+
+    private static (Mock<INetWorthSnapshotRepository> repo, Func<NetWorthSnapshot?> captured) SetupInsertCapture(
+        NetWorthSnapshot? previous)
+    {
+        NetWorthSnapshot? captured = null;
+        var repositoryMock = new Mock<INetWorthSnapshotRepository>();
+        repositoryMock
+            .Setup(r => r.ExistsAsync(UserId, SnapshotDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        repositoryMock
+            .Setup(r => r.GetLatestByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(previous);
+        repositoryMock
+            .Setup(r => r.PersistAsync(It.IsAny<NetWorthSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<NetWorthSnapshot, CancellationToken>((s, _) => captured = s)
+            .Returns(Task.CompletedTask);
+        return (repositoryMock, () => captured);
+    }
+
+    [Fact]
+    public async Task PersistSnapshotAsync_WhenBrokerageStale_CarriesForwardPreviousValueAndFlags()
+    {
+        var previous = new NetWorthSnapshot { BankingTotal = 900m, BrokerageTotal = 9912m, CryptoTotal = 240m };
+        var (repo, captured) = SetupInsertCapture(previous);
+        var data = new NetWorthSnapshotData(
+            SnapshotDate, BankingTotal: 1000m, BrokerageTotal: 9912m, CryptoTotal: 250m,
+            BrokerageFresh: false, CryptoFresh: true);
+
+        await new NetWorthSnapshotService(repo.Object).PersistSnapshotAsync(UserId, data, CancellationToken.None);
+
+        captured()!.BrokerageTotal.Should().Be(9912m); // carried forward, not re-counted as fresh
+        captured()!.BankingTotal.Should().Be(1000m);
+        captured()!.CryptoTotal.Should().Be(250m);
+        captured()!.StaleSleeves.Should().Be("brokerage");
+    }
+
+    [Fact]
+    public async Task PersistSnapshotAsync_WhenSleeveDropsToZeroButPreviouslyHeldValue_TreatsAsFailedSyncAndCarriesForward()
+    {
+        var previous = new NetWorthSnapshot { BankingTotal = 1000m, BrokerageTotal = 5000m, CryptoTotal = 300m };
+        var (repo, captured) = SetupInsertCapture(previous);
+        // Brokerage sync failed and returned $0 while reporting "fresh".
+        var data = new NetWorthSnapshotData(
+            SnapshotDate, BankingTotal: 1000m, BrokerageTotal: 0m, CryptoTotal: 300m,
+            BrokerageFresh: true, CryptoFresh: true);
+
+        await new NetWorthSnapshotService(repo.Object).PersistSnapshotAsync(UserId, data, CancellationToken.None);
+
+        captured()!.BrokerageTotal.Should().Be(5000m);
+        captured()!.TotalNetWorth.Should().Be(6300m);
+        captured()!.StaleSleeves.Should().Be("brokerage");
+    }
+
+    [Fact]
+    public async Task PersistSnapshotAsync_WhenStaleButNoHistory_UsesBestEffortValueWithoutFlag()
+    {
+        var (repo, captured) = SetupInsertCapture(previous: null);
+        var data = new NetWorthSnapshotData(
+            SnapshotDate, BankingTotal: 1000m, BrokerageTotal: 500m, CryptoTotal: 250m,
+            BrokerageFresh: false, CryptoFresh: false);
+
+        await new NetWorthSnapshotService(repo.Object).PersistSnapshotAsync(UserId, data, CancellationToken.None);
+
+        captured()!.BrokerageTotal.Should().Be(500m);
+        captured()!.CryptoTotal.Should().Be(250m);
+        captured()!.StaleSleeves.Should().BeNull();
     }
 }


### PR DESCRIPTION
## Problem
The daily net-worth snapshot recorded whatever the sleeve readers returned. A failed or stale provider sync wrote **\$0** (or a frozen stale value) as if it were real movement — producing `\$0.00` cliffs and phantom history. This is the root of Ledger reading a "demonstrably lying" dashboard (18-day history with sync-failure zeros, phantom values) and being unable to do trend/YTD analysis.

## Fix
- **Age-based freshness:** crypto/brokerage sleeves are trusted only if their newest holding synced within **36h** (uses the `SyncedAt` each holding already carries). A disconnected provider ages out instead of masquerading as the live number.
- **Zero-drop guard:** a sleeve that drops to exactly `\$0` while it previously held value is treated as a failed sync, not a liquidation.
- **Carry-forward + provenance:** when a sleeve isn't trustworthy this run, its last known-good value is carried forward and the sleeve is recorded in a new `stale_sleeves` column (migration **M002**). Surfaced through the `get_net_worth_history` MCP tool so the advisor can distinguish a measured net worth from a partially estimated one.

## Safety
- Migration is **additive, non-destructive** (nullable `varchar(64)`); existing rows untouched.
- Only changes how *future* snapshots are written.
- Build: 0 warnings / 0 errors. 43 tests pass, incl. new carry-forward, zero-drop, and no-history cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)