### PR TITLE
feat: add cmn-tab-group library composite (spans 5 files, 360 lines)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-sentry",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-sentry",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "workspaces": [
         "projects/dsdevq-common/*"
       ],

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.spec.ts
@@ -1,0 +1,201 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {type ComponentFixture, TestBed} from '@angular/core/testing';
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {type CmnTab, TabGroupComponent} from './tab-group.component';
+
+const SAMPLE_TABS: CmnTab[] = [
+  {id: 'overview', label: 'Overview'},
+  {id: 'details', label: 'Details'},
+  {id: 'history', label: 'History'},
+];
+
+describe('TabGroupComponent', () => {
+  let fixture: ComponentFixture<TabGroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [TabGroupComponent]}).compileComponents();
+    fixture = TestBed.createComponent(TabGroupComponent);
+    fixture.componentRef.setInput('tabs', SAMPLE_TABS);
+    fixture.componentRef.setInput('activeTab', 'overview');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should have display:block on the host element', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.style.display).toBe('block');
+  });
+
+  it('should render a button for each tab', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons.length).toBe(SAMPLE_TABS.length);
+    expect(buttons[0].textContent?.trim()).toBe('Overview');
+    expect(buttons[1].textContent?.trim()).toBe('Details');
+    expect(buttons[2].textContent?.trim()).toBe('History');
+  });
+
+  it('should render the tablist container with role="tablist"', () => {
+    const tablist: HTMLElement | null = fixture.nativeElement.querySelector('[role="tablist"]');
+    expect(tablist).toBeTruthy();
+  });
+
+  it('should apply active classes to the selected tab', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons[0].classList).toContain('border-accent-default');
+    expect(buttons[0].classList).toContain('text-text-primary');
+  });
+
+  it('should apply inactive classes to non-selected tabs', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons[1].classList).toContain('border-transparent');
+    expect(buttons[1].classList).toContain('text-text-secondary');
+    expect(buttons[2].classList).toContain('border-transparent');
+    expect(buttons[2].classList).toContain('text-text-secondary');
+  });
+
+  it('should set aria-selected="true" on the active tab', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons[0].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('should set aria-selected="false" on inactive tabs', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons[1].getAttribute('aria-selected')).toBe('false');
+    expect(buttons[2].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('should update the active tab signal when a tab button is clicked', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    buttons[1].click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.activeTab()).toBe('details');
+  });
+
+  it('should swap active/inactive classes after a tab click', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    buttons[1].click();
+    fixture.detectChanges();
+    expect(buttons[1].classList).toContain('border-accent-default');
+    expect(buttons[0].classList).toContain('border-transparent');
+  });
+
+  it('should not apply active class to any tab when activeTab is empty', () => {
+    fixture.componentRef.setInput('activeTab', '');
+    fixture.detectChanges();
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    buttons.forEach(btn => {
+      expect(btn.classList).not.toContain('border-accent-default');
+    });
+  });
+
+  it('should apply shared base classes to every tab button', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    buttons.forEach(btn => {
+      expect(btn.classList).toContain('px-cmn-4');
+      expect(btn.classList).toContain('py-cmn-2');
+      expect(btn.classList).toContain('text-cmn-sm');
+      expect(btn.classList).toContain('font-medium');
+      expect(btn.classList).toContain('border-b-2');
+    });
+  });
+
+  it('should re-render when tabs input changes', () => {
+    fixture.componentRef.setInput('tabs', [{id: 'a', label: 'Alpha'}]);
+    fixture.detectChanges();
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].textContent?.trim()).toBe('Alpha');
+  });
+});
+
+@Component({
+  imports: [TabGroupComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<cmn-tab-group [tabs]="tabs" [(activeTab)]="current" />',
+})
+class TwoWayHostComponent {
+  public tabs: CmnTab[] = SAMPLE_TABS;
+  public current = 'overview';
+}
+
+describe('TabGroupComponent — two-way model binding', () => {
+  let fixture: ComponentFixture<TwoWayHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [TwoWayHostComponent]}).compileComponents();
+    fixture = TestBed.createComponent(TwoWayHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should sync the host property when a tab is clicked', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    buttons[2].click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.current).toBe('history');
+  });
+
+  it('should reflect host property change in the rendered active tab', () => {
+    fixture.componentInstance.current = 'details';
+    fixture.detectChanges();
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('[role="tab"]');
+    expect(buttons[1].classList).toContain('border-accent-default');
+    expect(buttons[0].classList).toContain('border-transparent');
+  });
+});
+
+@Component({
+  imports: [TabGroupComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <cmn-tab-group [tabs]="tabs" activeTab="overview">
+      <p data-testid="panel">Panel content</p>
+    </cmn-tab-group>
+  `,
+})
+class ContentProjectionHostComponent {
+  public readonly tabs: CmnTab[] = SAMPLE_TABS;
+}
+
+describe('TabGroupComponent — content projection', () => {
+  let fixture: ComponentFixture<ContentProjectionHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ContentProjectionHostComponent],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ContentProjectionHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should project default slot content below the tab bar', () => {
+    const panel: HTMLElement | null = fixture.nativeElement.querySelector('[data-testid="panel"]');
+    expect(panel).toBeTruthy();
+    expect(panel?.textContent?.trim()).toBe('Panel content');
+  });
+
+  it('should render the tab bar above the projected content', () => {
+    const host: HTMLElement = fixture.nativeElement.querySelector('cmn-tab-group');
+    const allChildren = Array.from(host.children);
+    const tablistIdx = allChildren.findIndex(el => el.getAttribute('role') === 'tablist');
+    const panelIdx = allChildren.findIndex(el => el.querySelector('[data-testid="panel"]'));
+    expect(tablistIdx).toBeGreaterThanOrEqual(0);
+    expect(panelIdx).toBeGreaterThanOrEqual(0);
+    expect(tablistIdx).toBeLessThan(panelIdx);
+  });
+});

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.ts
@@ -1,0 +1,44 @@
+import {ChangeDetectionStrategy, Component, input, model} from '@angular/core';
+
+export interface CmnTab {
+  id: string;
+  label: string;
+}
+
+const TAB_BASE = 'px-cmn-4 py-cmn-2 text-cmn-sm font-medium transition-colors border-b-2';
+const TAB_ACTIVE = 'text-text-primary border-accent-default';
+const TAB_INACTIVE = 'text-text-secondary border-transparent hover:text-text-primary';
+
+@Component({
+  selector: 'cmn-tab-group',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {style: 'display: block'},
+  template: `
+    <div class="flex gap-cmn-2 border-b border-border-default" role="tablist">
+      @for (tab of tabs(); track tab.id) {
+        <button
+          [attr.aria-selected]="tab.id === activeTab()"
+          [class]="tabClass(tab.id)"
+          (click)="selectTab(tab.id)"
+          type="button"
+          role="tab"
+        >
+          {{ tab.label }}
+        </button>
+      }
+    </div>
+    <ng-content />
+  `,
+})
+export class TabGroupComponent {
+  public readonly tabs = input.required<CmnTab[]>();
+  public readonly activeTab = model<string>('');
+
+  protected tabClass(id: string): string {
+    return id === this.activeTab() ? `${TAB_BASE} ${TAB_ACTIVE}` : `${TAB_BASE} ${TAB_INACTIVE}`;
+  }
+
+  protected selectTab(id: string): void {
+    this.activeTab.set(id);
+  }
+}

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.stories.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.stories.ts
@@ -1,0 +1,110 @@
+import type {Meta, StoryObj} from '@storybook/angular';
+
+import {TabGroupComponent} from './tab-group.component';
+
+const meta: Meta<TabGroupComponent> = {
+  title: 'Components/TabGroup',
+  component: TabGroupComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    activeTab: {control: 'text'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<TabGroupComponent>;
+
+export const Default: Story = {
+  args: {
+    tabs: [
+      {id: 'overview', label: 'Overview'},
+      {id: 'details', label: 'Details'},
+      {id: 'history', label: 'History'},
+    ],
+    activeTab: 'overview',
+  },
+};
+
+export const SecondTabActive: Story = {
+  args: {
+    tabs: [
+      {id: 'overview', label: 'Overview'},
+      {id: 'details', label: 'Details'},
+      {id: 'history', label: 'History'},
+    ],
+    activeTab: 'details',
+  },
+};
+
+export const TwoTabs: Story = {
+  args: {
+    tabs: [
+      {id: 'holdings', label: 'Allocation'},
+      {id: 'positions', label: 'Positions'},
+    ],
+    activeTab: 'holdings',
+  },
+};
+
+export const NoActiveTab: Story = {
+  args: {
+    tabs: [
+      {id: 'a', label: 'Alpha'},
+      {id: 'b', label: 'Beta'},
+      {id: 'c', label: 'Gamma'},
+    ],
+    activeTab: '',
+  },
+};
+
+export const WithPanelContent: Story = {
+  render: () => ({
+    template: `
+      <cmn-tab-group [tabs]="tabs" [(activeTab)]="active">
+        @if (active === 'overview') {
+          <div class="p-cmn-4 text-cmn-sm text-text-secondary">Overview panel — summary information.</div>
+        }
+        @if (active === 'details') {
+          <div class="p-cmn-4 text-cmn-sm text-text-secondary">Details panel — line-by-line breakdown.</div>
+        }
+        @if (active === 'history') {
+          <div class="p-cmn-4 text-cmn-sm text-text-secondary">History panel — past events listed here.</div>
+        }
+      </cmn-tab-group>
+    `,
+    props: {
+      tabs: [
+        {id: 'overview', label: 'Overview'},
+        {id: 'details', label: 'Details'},
+        {id: 'history', label: 'History'},
+      ],
+      active: 'overview',
+    },
+  }),
+};
+
+export const HoldingsStyle: Story = {
+  render: () => ({
+    template: `
+      <div class="rounded-cmn-md border border-border-default overflow-hidden">
+        <cmn-tab-group [tabs]="tabs" [(activeTab)]="active">
+          <div class="p-cmn-4">
+            @if (active === 'holdings') {
+              <p class="text-cmn-sm text-text-secondary">Allocation breakdown by institution.</p>
+            }
+            @if (active === 'positions') {
+              <p class="text-cmn-sm text-text-secondary">Flat position-level view for brokerage + crypto.</p>
+            }
+          </div>
+        </cmn-tab-group>
+      </div>
+    `,
+    props: {
+      tabs: [
+        {id: 'holdings', label: 'Allocation'},
+        {id: 'positions', label: 'Positions'},
+      ],
+      active: 'holdings',
+    },
+  }),
+};

--- a/frontend/projects/dsdevq-common/ui/src/lib/index.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/index.ts
@@ -41,6 +41,7 @@ export * from './components/sidebar-nav/sidebar-nav.component';
 export * from './components/skeleton/skeleton.component';
 export * from './components/stat-card/stat-card.component';
 export * from './components/status-indicator/status-indicator.component';
+export * from './components/tab-group/tab-group.component';
 export * from './components/tag/tag.component';
 export * from './components/toast/toast.component';
 export * from './components/toast/toast.service';


### PR DESCRIPTION
## What
Extract the tab-group pattern into a new library composite `cmn-tab-group` under frontend/projects/dsdevq-common/ui/src/lib/components/tab-group, following the same shape as cmn-list-item-row/cmn-disclosure-row/cmn-page-header/cmn-page-container: standalone, OnPush, signal-based input()/output() APIs. This is a LIBRARY-ONLY slice — exactly 4 files: tab-group.component.ts, tab-group.component.spec.ts, tab-group.stories.ts, and an added export line in src/lib/index.ts. Fetch origin and verify the TRUE current origin/main tip before branching — do NOT branch from the stale local `feat/cmn-tab-group` branch at 6e9c0b0 (that belongs to the previous failed attempt); branch fresh from confirmed origin/main.

This is the fifth dispatch of this exact composite. Per owner steering (2026-07-18), the browser/Playwright review gate should now be scoped to skip when a diff touches only frontend/projects/dsdevq-common/ui/ plus the library's public export/story/spec — no running app route or template is wired, so no browser run is expected for this class of change. The owner has since resumed the goal, indicating this scoping should now be in effect.

Acceptance criteria:
- cmn-tab-group exists in the library (standalone, OnPush, signal-based inputs/outputs) and is exported from lib/index.ts.
- A Vitest spec exists for cmn-tab-group at the same quality bar as the cmn-list-item-row/cmn-disclosure-row precedents.
- A Storybook story exists for cmn-tab-group demonstrating tab switching.
- Full library build and full test suite pass, and the pre-commit hook passes cleanly (not bypassed with --no-verify).

Constraints:
- Do NOT create, modify, or touch anything under any `e2e/` directory, `playwright.config.ts`, any Playwright spec, any feature-module template/usage, AGENTS.md, or any other doc/guide file in this task — in-app adoption and e2e coverage are separate follow-up slices.
- Do not touch cmn-chip, cmn-page-header, cmn-page-container, cmn-disclosure-row, cmn-list-item-row, ConfirmDialogComponent/DialogService/CmnDialogService, cmn-select, or select.component.ts — already shipped, out of scope.
- Owner decision (2026-07-16, reconfirmed 2026-07-17): keep the bespoke Tailwind primitive layer, do NOT adopt ng-zorro-antd, do NOT rename the library package, do NOT touch package.json's name field.
- Do not run any repository-wide format/lint/fix command — hand-edit only the files this slice requires.
- CIRCUIT BREAKER: if the review gate fails closed again with the SAME browser/Playwright-gate error on a diff that genuinely touches only the 4 named library files, do NOT retry within this action — stop immediately and report the branch name, commit SHA, and local build+test+story evidence. Do not attempt a sixth dispatch of this composite under the same assumption; this will be treated as confirmation the gate fix is not actually deployed despite the steering, and escalated as a hard blocker rather than repeating the same question. If the gate instead names a different, concrete finding about the actual component/spec/story files, fix that finding before resubmitting.

## Files changed
```
frontend/package-lock.json                         |   4 +-
 .../tab-group/tab-group.component.spec.ts          | 201 +++++++++++++++++++++
 .../components/tab-group/tab-group.component.ts    |  44 +++++
 .../lib/components/tab-group/tab-group.stories.ts  | 110 +++++++++++
 .../projects/dsdevq-common/ui/src/lib/index.ts     |   1 +
 5 files changed, 358 insertions(+), 2 deletions(-)
```

---
🤖 Delivered by devclaw (task `6b617733-15d8-4c25-a9cb-7eef3227b807`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.