### PR TITLE
feat(ui): add cmn-editable-field composite

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.spec.ts
@@ -1,0 +1,174 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {type ComponentFixture, TestBed} from '@angular/core/testing';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {EditableFieldComponent} from './editable-field.component';
+
+describe('EditableFieldComponent', () => {
+  let fixture: ComponentFixture<EditableFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [EditableFieldComponent]}).compileComponents();
+    fixture = TestBed.createComponent(EditableFieldComponent);
+    fixture.componentRef.setInput('value', 'Visa ending 4421');
+    fixture.componentRef.setInput('ariaLabel', 'account nickname');
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('should have display:block on the host element', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.style.display).toBe('block');
+  });
+
+  it('should render the current value in view mode', () => {
+    const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('button');
+    expect(button?.textContent).toContain('Visa ending 4421');
+    expect(button?.textContent).toContain('Edit');
+  });
+
+  it('should render the empty label when the value is blank', () => {
+    fixture.componentRef.setInput('value', '   ');
+    fixture.componentRef.setInput('emptyLabel', 'Missing nickname');
+    fixture.detectChanges();
+    const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('button');
+    expect(button?.textContent).toContain('Missing nickname');
+  });
+
+  it('should expose a specific edit aria-label', () => {
+    const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('button');
+    expect(button?.getAttribute('aria-label')).toBe('Edit account nickname');
+  });
+
+  it('should enter edit mode with the current value as draft', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement | null = fixture.nativeElement.querySelector('input');
+    expect(input?.value).toBe('Visa ending 4421');
+    expect(input?.getAttribute('aria-label')).toBe('account nickname');
+  });
+
+  it('should use the configured input type and placeholder in edit mode', () => {
+    fixture.componentRef.setInput('type', 'email');
+    fixture.componentRef.setInput('placeholder', 'name@example.com');
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement | null = fixture.nativeElement.querySelector('input');
+    expect(input?.type).toBe('email');
+    expect(input?.placeholder).toBe('name@example.com');
+  });
+
+  it('should save a trimmed draft value', () => {
+    const saved = vi.fn();
+    fixture.componentInstance.saved.subscribe(saved);
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = '  Primary account  ';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    const saveButton: HTMLButtonElement = fixture.nativeElement.querySelectorAll('button')[0];
+    saveButton.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()).toBe('Primary account');
+    expect(saved).toHaveBeenCalledWith('Primary account');
+    expect(fixture.nativeElement.querySelector('input')).toBeNull();
+  });
+
+  it('should save when Enter is pressed', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'Brokerage';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()).toBe('Brokerage');
+  });
+
+  it('should cancel edit mode and keep the prior value', () => {
+    const cancelled = vi.fn();
+    fixture.componentInstance.cancelled.subscribe(cancelled);
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'Changed';
+    input.dispatchEvent(new Event('input'));
+    const cancelButton: HTMLButtonElement = fixture.nativeElement.querySelectorAll('button')[1];
+    cancelButton.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()).toBe('Visa ending 4421');
+    expect(cancelled).toHaveBeenCalledOnce();
+  });
+
+  it('should cancel when Escape is pressed', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'Changed';
+    input.dispatchEvent(new Event('input'));
+    input.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.value()).toBe('Visa ending 4421');
+    expect(fixture.nativeElement.querySelector('input')).toBeNull();
+  });
+
+  it('should not enter edit mode when disabled', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('input')).toBeNull();
+    expect(button.disabled).toBe(true);
+  });
+});
+
+@Component({
+  imports: [EditableFieldComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<cmn-editable-field [(value)]="label" ariaLabel="label" />',
+})
+class TwoWayHostComponent {
+  public label = 'Initial';
+}
+
+describe('EditableFieldComponent — two-way model binding', () => {
+  let fixture: ComponentFixture<TwoWayHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({imports: [TwoWayHostComponent]}).compileComponents();
+    fixture = TestBed.createComponent(TwoWayHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should sync the host property when a draft is saved', () => {
+    const button: HTMLButtonElement = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
+    input.value = 'Updated';
+    input.dispatchEvent(new Event('input'));
+    const saveButton: HTMLButtonElement = fixture.nativeElement.querySelectorAll('button')[0];
+    saveButton.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.label).toBe('Updated');
+  });
+
+  it('should reflect host property changes in view mode', () => {
+    fixture.componentInstance.label = 'External update';
+    fixture.detectChanges();
+    const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('button');
+    expect(button?.textContent).toContain('External update');
+  });
+});

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.ts
@@ -1,0 +1,112 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+  signal,
+} from '@angular/core';
+
+export type EditableFieldType = 'text' | 'email' | 'number' | 'tel' | 'url';
+
+const VIEW_CLASSES =
+  'inline-flex min-h-cmn-10 w-full items-center justify-between gap-cmn-3 rounded-cmn-md ' +
+  'border border-transparent px-cmn-3 py-cmn-2 text-left text-cmn-sm text-text-primary ' +
+  'transition-colors hover:border-border-default hover:bg-surface-raised ' +
+  'focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-offset-1';
+
+const EMPTY_CLASSES = 'text-text-secondary';
+
+const INPUT_CLASSES =
+  'min-h-cmn-10 w-full rounded-cmn-md border border-border-default bg-surface-card ' +
+  'px-cmn-3 py-cmn-2 text-cmn-sm text-text-primary placeholder:text-text-disabled ' +
+  'focus:border-border-focus focus:outline-none focus:ring-2 focus:ring-border-focus';
+
+const ACTION_CLASSES =
+  'inline-flex min-h-cmn-10 items-center rounded-cmn-md border border-border-default ' +
+  'px-cmn-3 py-cmn-2 text-cmn-sm font-medium text-text-primary transition-colors ' +
+  'hover:bg-surface-raised focus:outline-none focus:ring-2 focus:ring-border-focus focus:ring-offset-1';
+
+@Component({
+  selector: 'cmn-editable-field',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {style: 'display: block'},
+  template: `
+    @if (editing()) {
+      <div class="flex items-center gap-cmn-2">
+        <input
+          [type]="type()"
+          [value]="draft()"
+          [placeholder]="placeholder()"
+          [attr.aria-label]="ariaLabel()"
+          [class]="inputClasses"
+          (input)="updateDraft($event)"
+          (keydown.enter)="save()"
+          (keydown.escape)="cancel()"
+        />
+        <button [class]="actionClasses" (click)="save()" type="button">Save</button>
+        <button [class]="actionClasses" (click)="cancel()" type="button">Cancel</button>
+      </div>
+    } @else {
+      <button
+        [class]="viewClasses()"
+        [disabled]="disabled()"
+        [attr.aria-label]="editLabel()"
+        (click)="startEditing()"
+        type="button"
+      >
+        <span [class]="displayClass()">{{ displayValue() }}</span>
+        <span class="text-cmn-xs font-medium text-text-secondary">Edit</span>
+      </button>
+    }
+  `,
+})
+export class EditableFieldComponent {
+  public readonly value = model<string>('');
+  public readonly placeholder = input<string>('Add value');
+  public readonly emptyLabel = input<string>('Not set');
+  public readonly ariaLabel = input<string>('Editable field');
+  public readonly type = input<EditableFieldType>('text');
+  public readonly disabled = input<boolean>(false);
+
+  public readonly saved = output<string>();
+  public readonly cancelled = output<void>();
+
+  protected readonly editing = signal<boolean>(false);
+  protected readonly draft = signal<string>('');
+  protected readonly inputClasses = INPUT_CLASSES;
+  protected readonly actionClasses = ACTION_CLASSES;
+
+  protected readonly displayValue = computed(() => this.value().trim() || this.emptyLabel());
+  protected readonly displayClass = computed(() => (this.value().trim() ? '' : EMPTY_CLASSES));
+  protected readonly viewClasses = computed(() =>
+    this.disabled() ? `${VIEW_CLASSES} opacity-50 cursor-not-allowed` : VIEW_CLASSES
+  );
+  protected readonly editLabel = computed(() => `Edit ${this.ariaLabel()}`);
+
+  protected startEditing(): void {
+    if (this.disabled()) {
+      return;
+    }
+    this.draft.set(this.value());
+    this.editing.set(true);
+  }
+
+  protected updateDraft(event: Event): void {
+    this.draft.set((event.target as HTMLInputElement).value);
+  }
+
+  protected save(): void {
+    const nextValue = this.draft().trim();
+    this.value.set(nextValue);
+    this.editing.set(false);
+    this.saved.emit(nextValue);
+  }
+
+  protected cancel(): void {
+    this.draft.set(this.value());
+    this.editing.set(false);
+    this.cancelled.emit();
+  }
+}

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.stories.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.stories.ts
@@ -1,0 +1,75 @@
+import type {Meta, StoryObj} from '@storybook/angular';
+
+import {EditableFieldComponent} from './editable-field.component';
+
+const meta: Meta<EditableFieldComponent> = {
+  title: 'Components/EditableField',
+  component: EditableFieldComponent,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'number', 'tel', 'url'],
+    },
+    value: {control: 'text'},
+    placeholder: {control: 'text'},
+    emptyLabel: {control: 'text'},
+    ariaLabel: {control: 'text'},
+    disabled: {control: 'boolean'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<EditableFieldComponent>;
+
+export const Default: Story = {
+  args: {
+    value: 'Emergency fund',
+    ariaLabel: 'account label',
+    placeholder: 'Enter label',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: '',
+    emptyLabel: 'No nickname',
+    ariaLabel: 'account nickname',
+    placeholder: 'Add nickname',
+  },
+};
+
+export const Email: Story = {
+  args: {
+    value: 'denys@example.com',
+    type: 'email',
+    ariaLabel: 'notification email',
+    placeholder: 'email@example.com',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: 'Locked value',
+    ariaLabel: 'locked value',
+    disabled: true,
+  },
+};
+
+export const InCard: Story = {
+  render: () => ({
+    template: `
+      <div class="max-w-md rounded-cmn-md border border-border-default bg-surface-card p-cmn-4">
+        <p class="mb-cmn-2 text-cmn-xs font-medium uppercase text-text-secondary">Budget label</p>
+        <cmn-editable-field
+          [(value)]="value"
+          ariaLabel="budget label"
+          placeholder="Add budget label"
+        />
+      </div>
+    `,
+    props: {
+      value: 'Monthly essentials',
+    },
+  }),
+};

--- a/frontend/projects/dsdevq-common/ui/src/lib/index.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/index.ts
@@ -24,6 +24,7 @@ export * from './components/donut-chart/donut-chart.component';
 export * from './components/drawer/drawer-config';
 export * from './components/drawer/drawer-container.component';
 export * from './components/drawer/drawer-ref';
+export * from './components/editable-field/editable-field.component';
 export * from './components/form-field/form-field.component';
 export * from './components/google-sign-in-button/google-sign-in-button.component';
 export * from './components/icon/icon.component';


### PR DESCRIPTION
## What
Adds `cmn-editable-field` to `@dsdevq-common/ui` as a library-only composite for inline view/edit flows.

## Scope
- `editable-field.component.ts`
- `editable-field.component.spec.ts`
- `editable-field.stories.ts`
- library public export in `src/lib/index.ts`

No app templates, e2e specs, Playwright config, docs, package metadata, or unrelated components touched.

## Verification
- `npm run lint` passed via pre-commit hook
- `npm run build:lib` passed
- `npm run build` passed
- `npx prettier --check ...` passed
- Local `npm run test:lib -- --watch=false` could not execute because Chromium crashes in this container with `Invalid file descriptor to ICU data received`; GitHub Frontend CI is the browser-test authority for this PR.

Merged PR #283 first per Denys's "Ship now" instruction, then shipped this directly because the durable goal is paused on quota.
