### PR TITLE
docs: document ng-zorro-antd dependency in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,14 @@ Verified 2026-06-27 via `dotnet test FinanceSentry.sln --filter 'Category!=Integ
 
 Full tool catalogue (input parameters, return schemas, real/stub): [`docs/mcp.md`](docs/mcp.md).
 
+## Frontend UI primitives — ng-zorro-antd
+
+`ng-zorro-antd` **21.2.2** is a real, installed runtime dependency (`frontend/package.json` line 52; resolved entry in `frontend/package-lock.json`). It serves as the low-level widget primitive layer for `@dsdevq-common/ui` — library components wrap `nz-*` elements rather than building raw HTML widgets from scratch.
+
+**Reference usage:** `SelectComponent` (`frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts`) imports `NzSelectModule` from `ng-zorro-antd/select` and renders `<nz-select>` / `<nz-option>` in its template. This component has a passing Vitest spec that proves the dependency resolves and renders end-to-end in the test environment.
+
+Architecture direction: new `cmn-*` library components that need a complex interactive primitive (date-picker, tree-select, cascader, etc.) should prefer an `nz-*` base over hand-rolling the behaviour. Design token coexistence (`@dsdevq-common/config` Tailwind tokens vs `ng-zorro-antd` CSS vars) is a separate, deferred slice — do not resolve it implicitly when adding new components.
+
 ## Frontend test environment gotcha
 
 `ng test @dsdevq-common/ui` and `ng test finance-sentry` both require Chromium (Playwright browser runner).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-sentry",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-sentry",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "workspaces": [
         "projects/dsdevq-common/*"
       ],


### PR DESCRIPTION
## Changes
ng-zorro-antd 21.2.2 was already in package.json and package-lock.json but
undocumented. Added a dedicated section to AGENTS.md citing SelectComponent
as the grounded reference usage. Also synced the cosmetic version field in
package-lock.json (0.11.4 → 0.12.0) to match frontend/package.json.

<details><summary>📋 Ticket (what was asked + why)</summary>

Document ng-zorro-antd in AGENTS.md since the dependency is already genuinely installed and working on origin/main (confirmed by review: frontend/package.json line 52 lists `ng-zorro-antd: 21.2.2` under `dependencies`; frontend/package-lock.json line 16096 has a real resolved entry; `@angular/cdk` is present at package.json line 39; and frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts already imports `NzSelectModule` from `ng-zorro-antd/select` and has a passing spec, proving the dependency renders end-to-end). Do NOT cherry-pick, rebase, or recreate the orphaned `cmn-ng-zorro-probe` component/spec from commits 4b1ee2e/e4cab57 — they are on a dangling, unmerged branch and are redundant now that SelectComponent already satisfies the 'prove one component renders' bar. Add a concise section to AGENTS.md recording that ng-zorro-antd (version 21.2.2) is a real runtime dependency used as the primitive base per the current architecture direction, citing SelectComponent as the reference usage. Separately, inspect frontend/package-lock.json's top-level `version` field (currently 0.11.4, cosmetic mismatch vs frontend/package.json's 0.12.0) — fix it only if doing so is a trivial, isolated edit with no dependency-tree side effects; otherwise leave it untouched and just note in your PR description that it's cosmetic and non-blocking.

Acceptance criteria:
- AGENTS.md documents ng-zorro-antd as an installed dependency with its version, citing SelectComponent as an actual grounded rendering usage — not aspirational prose.
- frontend/package.json's ng-zorro-antd entry and package-lock.json's resolved `ng-zorro-antd` entry are unchanged (already correct) — this task only adds documentation and optionally the single cosmetic lockfile version-field line.
- Full app build and full test suite pass, and the pre-commit hook passes cleanly (not bypassed with --no-verify).
- No new components are added; the orphaned ng-zorro-probe component/spec is not cherry-picked or recreated; none of the 7 already-shipped composites are touched.

Constraints:
- Do NOT cherry-pick, rebase onto, or recreate commits 4b1ee2e/e4cab57 or the cmn-ng-zorro-probe component/spec.
- Do NOT touch cmn-chip, cmn-page-header, cmn-page-container, cmn-disclosure-row, cmn-list-item-row, cmn-tab-group, or cmn-editable-field.
- Do NOT touch the disclosure-row-in-accounts-list adoption in bank-sync/accounts-list — that circuit breaker stays tripped.
- Do NOT migrate or touch the existing @dsdevq-common/config/tailwind design tokens — that coexistence decision is a separate, later slice.
- Keep the diff small — AGENTS.md plus at most the single lockfile version-field line, nothing else.

</details>

## Files changed
```
AGENTS.md                  | 8 ++++++++
 frontend/package-lock.json | 4 ++--
 2 files changed, 10 insertions(+), 2 deletions(-)
```

---
🤖 Delivered by devclaw (task `5b3cf995-b8fa-4650-8428-a874df66cfa1`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.