### PR TITLE
feat(research): opportunity scan job — machine nomination from market structure (019 US2)

### DIFF
--- a/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
+++ b/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <Version>0.12.2</Version> <!-- x-release-please-version -->
+    <Version>0.13.0</Version> <!-- x-release-please-version -->
     <AssemblyVersion>0.11.0</AssemblyVersion> <!-- x-release-please-version -->
     <FileVersion>0.11.0</FileVersion> <!-- x-release-please-version -->
   </PropertyGroup>

--- a/backend/src/FinanceSentry.Core/Interfaces/IMarketStructureReader.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IMarketStructureReader.cs
@@ -14,9 +14,18 @@ public interface IMarketStructureReader
     /// </summary>
     Task<IReadOnlyList<PairwiseCorrelation>> GetPairwiseCorrelationsAsync(
         IReadOnlyCollection<string> tickers, CancellationToken ct = default);
+
+    /// <summary>
+    /// Structure snapshots for every active universe member (019 US2 scan input). Members whose
+    /// bars are missing are omitted. <see cref="UniverseStructureEntry.IsEtfLens"/> marks
+    /// benchmark/sector/industry ETFs — lenses, never auto-nominated as candidates.
+    /// </summary>
+    Task<IReadOnlyList<UniverseStructureEntry>> GetUniverseStructuresAsync(CancellationToken ct = default);
 }
 
 public sealed record PairwiseCorrelation(string TickerA, string TickerB, decimal Correlation);
+
+public sealed record UniverseStructureEntry(string Ticker, bool IsEtfLens, MarketStructureSnapshot Snapshot);
 
 /// <summary>
 /// Projection of Radar's <c>TickerStructure</c> across the module boundary, plus the 019 FR-003

--- a/backend/src/FinanceSentry.Modules.Radar/Application/Services/MarketStructureReader.cs
+++ b/backend/src/FinanceSentry.Modules.Radar/Application/Services/MarketStructureReader.cs
@@ -47,6 +47,23 @@ public sealed class MarketStructureReader(
             DistanceFrom63dHigh(series));
     }
 
+    public async Task<IReadOnlyList<UniverseStructureEntry>> GetUniverseStructuresAsync(CancellationToken ct = default)
+    {
+        var members = await universe.ListActiveAsync(ct);
+        var entries = new List<UniverseStructureEntry>(members.Count);
+        foreach (var member in members)
+        {
+            var snapshot = await GetStructureAsync(member.Ticker, ct);
+            if (snapshot is not null)
+            {
+                var isEtfLens = member.Kind is UniverseKind.Benchmark or UniverseKind.Sector or UniverseKind.Industry;
+                entries.Add(new UniverseStructureEntry(snapshot.Ticker, isEtfLens, snapshot));
+            }
+        }
+
+        return entries;
+    }
+
     public async Task<IReadOnlyList<PairwiseCorrelation>> GetPairwiseCorrelationsAsync(
         IReadOnlyCollection<string> tickers, CancellationToken ct = default)
     {

--- a/backend/src/FinanceSentry.Modules.Research/Application/Commands/ScoreCandidateCommand.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Commands/ScoreCandidateCommand.cs
@@ -9,7 +9,12 @@ using FinanceSentry.Modules.Research.Domain.Scoring;
 using FinanceSentry.Modules.Research.Domain;
 using Microsoft.Extensions.Options;
 
-public record ScoreCandidateCommand(Guid UserId, string Ticker, string? DecisionNote = null) : ICommand<ScoreCandidateResult>;
+public record ScoreCandidateCommand(
+    Guid UserId,
+    string Ticker,
+    string? DecisionNote = null,
+    CandidateSource Source = CandidateSource.User,
+    IReadOnlyList<string>? NominationReasons = null) : ICommand<ScoreCandidateResult>;
 
 public sealed record ScoreCandidateResult(
     Guid CandidateId,
@@ -45,11 +50,15 @@ public sealed class ScoreCandidateCommandHandler(
         var ticker = command.Ticker.Trim().ToUpperInvariant();
 
         var (candidate, isNew) = await candidateRepo.UpsertActiveAsync(
-            command.UserId, ticker, CandidateSource.User, TimeSpan.FromDays(_options.CandidateTtlDays), ct);
+            command.UserId, ticker, command.Source, TimeSpan.FromDays(_options.CandidateTtlDays), ct);
 
-        if (isNew)
+        IReadOnlyList<string> incomingReasons = command.NominationReasons is { Count: > 0 }
+            ? command.NominationReasons
+            : [DefaultNominationReason];
+        var newReasons = incomingReasons.Where(r => !candidate.NominationReasons.Contains(r, StringComparer.OrdinalIgnoreCase)).ToList();
+        if (newReasons.Count > 0)
         {
-            candidate.NominationReasons = [DefaultNominationReason];
+            candidate.NominationReasons.AddRange(newReasons);
             await candidateRepo.UpdateAsync(candidate, ct);
         }
 

--- a/backend/src/FinanceSentry.Modules.Research/Application/Services/OpportunityOptions.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Services/OpportunityOptions.cs
@@ -34,4 +34,22 @@ public sealed class OpportunityOptions
 
     /// <summary>Bumped whenever the scoring normalization rules change, so old scorecards stay honest (FR-002).</summary>
     public int FormulaVersion { get; set; } = 1;
+
+    /// <summary>Sector rotation ranks 1..N qualify as "top rotating" for scan rule (a) (FR-008a).</summary>
+    public int ScanTopRotatingSectors { get; set; } = 2;
+
+    /// <summary>Universe RS percentile at/above this is "top-quartile" for scan rule (a).</summary>
+    public int ScanTopQuartileRsPercentile { get; set; } = 75;
+
+    /// <summary>Universe RS percentile at/above this is "top-decile" for scan rule (b) (FR-008b).</summary>
+    public int ScanTopDecileRsPercentile { get; set; } = 90;
+
+    /// <summary>Volume ratio at/above this counts as above-average for the breakout rule (c) (FR-008c).</summary>
+    public decimal ScanBreakoutVolumeRatioMin { get; set; } = 1.2m;
+
+    /// <summary>Most nominations a single scan run may score; excess is logged and dropped (alert-flood guard).</summary>
+    public int ScanMaxNominationsPerRun { get; set; } = 5;
+
+    /// <summary>Hour (UTC) the daily opportunity scan runs — after Radar's 23:00 UTC compute job has refreshed structure.</summary>
+    public int ScanHourUtc { get; set; } = 0;
 }

--- a/backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IIpsRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IIpsRepository.cs
@@ -13,4 +13,7 @@ public interface IIpsRepository
 
     /// <summary>Persists a new IPS version, demoting any prior current version.</summary>
     Task AddVersionAsync(InvestmentPolicyStatement ips, CancellationToken ct = default);
+
+    /// <summary>Users with a current IPS on file — the books the opportunity scan nominates for.</summary>
+    Task<IReadOnlyList<Guid>> GetUserIdsWithCurrentIpsAsync(CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.Research/Domain/Scoring/ScanNominationRules.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Domain/Scoring/ScanNominationRules.cs
@@ -1,0 +1,101 @@
+namespace FinanceSentry.Modules.Research.Domain.Scoring;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Research.Application.Services;
+
+/// <summary>
+/// Pure, deterministic FR-008 nomination rules over the active universe (019 US2):
+/// (a) top-quartile RS members of top-N rotating sectors, (b) top-decile RS overall,
+/// (c) at the 63-day high on above-average volume. ETF lenses and stale snapshots are
+/// never nominated. Reason strings are stable so re-nominations dedup instead of
+/// accumulating near-duplicates on the candidate.
+/// </summary>
+public static class ScanNominationRules
+{
+    /// <summary>Window (bars) whose relative strength drives rules (a) and (b).</summary>
+    public const int RsWindowBars = 63;
+
+    public const string TopQuartileRotatingSectorReason = "scan: top-quartile RS in top rotating sector";
+    public const string TopDecileRsReason = "scan: top-decile RS";
+    public const string BreakoutReason = "scan: 63d-high breakout on above-average volume";
+
+    public static IReadOnlyList<ScanNomination> Evaluate(
+        IReadOnlyList<UniverseStructureEntry> universe, OpportunityOptions options)
+    {
+        var eligible = universe
+            .Where(e => !e.IsEtfLens && !e.Snapshot.Stale)
+            .ToList();
+        if (eligible.Count == 0)
+        {
+            return [];
+        }
+
+        var rsByTicker = eligible
+            .Select(e => (e.Ticker, Rs: RsAtWindow(e.Snapshot)))
+            .Where(x => x.Rs is not null)
+            .ToDictionary(x => x.Ticker, x => x.Rs!.Value, StringComparer.OrdinalIgnoreCase);
+        var percentiles = PercentileRanks(rsByTicker);
+
+        var nominations = new List<ScanNomination>();
+        foreach (var entry in eligible)
+        {
+            var reasons = new List<string>();
+            var percentile = percentiles.TryGetValue(entry.Ticker, out var p) ? p : (decimal?)null;
+
+            if (percentile >= options.ScanTopQuartileRsPercentile
+                && entry.Snapshot.SectorRank is { } rank
+                && rank <= options.ScanTopRotatingSectors)
+            {
+                reasons.Add(TopQuartileRotatingSectorReason);
+            }
+
+            if (percentile >= options.ScanTopDecileRsPercentile)
+            {
+                reasons.Add(TopDecileRsReason);
+            }
+
+            if (entry.Snapshot.DistanceFrom63dHigh == 0m
+                && entry.Snapshot.VolumeRatio >= options.ScanBreakoutVolumeRatioMin)
+            {
+                reasons.Add(BreakoutReason);
+            }
+
+            if (reasons.Count > 0)
+            {
+                nominations.Add(new ScanNomination(entry.Ticker, reasons, percentile));
+            }
+        }
+
+        return nominations
+            .OrderByDescending(n => n.RsPercentile ?? -1m)
+            .ThenBy(n => n.Ticker, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static decimal? RsAtWindow(MarketStructureSnapshot snapshot)
+        => snapshot.RsByWindow.TryGetValue(RsWindowBars, out var rs) ? rs : null;
+
+    /// <summary>
+    /// Inclusive percentile rank per ticker: share of universe values at or below the ticker's RS,
+    /// scaled 0-100. A one-member universe ranks 100 (trivially at the top of what exists).
+    /// </summary>
+    private static Dictionary<string, decimal> PercentileRanks(Dictionary<string, decimal> rsByTicker)
+    {
+        var result = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        if (rsByTicker.Count == 0)
+        {
+            return result;
+        }
+
+        var values = rsByTicker.Values.OrderBy(v => v).ToList();
+        foreach (var (ticker, rs) in rsByTicker)
+        {
+            var atOrBelow = values.Count(v => v <= rs);
+            result[ticker] = Math.Round(100m * atOrBelow / values.Count, 2);
+        }
+
+        return result;
+    }
+}
+
+public sealed record ScanNomination(string Ticker, IReadOnlyList<string> Reasons, decimal? RsPercentile);

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/OpportunityScanJob.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/OpportunityScanJob.cs
@@ -1,0 +1,89 @@
+namespace FinanceSentry.Modules.Research.Infrastructure.Jobs;
+
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Research.Application.Commands;
+using FinanceSentry.Modules.Research.Application.Services;
+using FinanceSentry.Modules.Research.Domain.Opportunity;
+using FinanceSentry.Modules.Research.Domain.Scoring;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Scheduled FR-008 machine scan (019 US2): nominates candidates from 018 market structure by the
+/// deterministic <see cref="ScanNominationRules"/> and scores each through the same pipeline as
+/// user nominations, so 020 can compare hit rates across the two sources. Runs after Radar's
+/// nightly compute. One ticker failing never aborts the run (FR-013); an empty 018 read aborts
+/// with a recorded error; zero nominations is a valid, silent outcome.
+/// </summary>
+public sealed class OpportunityScanJob(
+    IMarketStructureReader structureReader,
+    Domain.Repositories.IIpsRepository ipsRepo,
+    ICommandHandler<ScoreCandidateCommand, ScoreCandidateResult> scorer,
+    IOptions<OpportunityOptions> options,
+    ILogger<OpportunityScanJob> logger)
+{
+    private readonly OpportunityOptions _options = options.Value;
+
+    [AutomaticRetry(Attempts = 1)]
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        var universe = await structureReader.GetUniverseStructuresAsync(ct);
+        if (universe.Count == 0)
+        {
+            logger.LogError("Opportunity scan aborted: no 018 structure data (empty universe read — ingestion outage?)");
+            return;
+        }
+
+        var nominations = ScanNominationRules.Evaluate(universe, _options);
+        var capped = nominations.Take(_options.ScanMaxNominationsPerRun).ToList();
+        if (capped.Count < nominations.Count)
+        {
+            logger.LogWarning(
+                "Opportunity scan capped nominations at {Cap}; dropped {Dropped}: {DroppedTickers}",
+                _options.ScanMaxNominationsPerRun,
+                nominations.Count - capped.Count,
+                string.Join(", ", nominations.Skip(capped.Count).Select(n => n.Ticker)));
+        }
+
+        var userIds = await ipsRepo.GetUserIdsWithCurrentIpsAsync(ct);
+        var scored = 0;
+        var newCandidates = 0;
+        var errors = 0;
+
+        foreach (var userId in userIds)
+        {
+            foreach (var nomination in capped)
+            {
+                try
+                {
+                    var result = await scorer.Handle(
+                        new ScoreCandidateCommand(
+                            userId,
+                            nomination.Ticker,
+                            DecisionNote: null,
+                            Source: CandidateSource.Scan,
+                            NominationReasons: nomination.Reasons),
+                        ct);
+                    scored++;
+                    if (result.IsNewCandidate)
+                    {
+                        newCandidates++;
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    errors++;
+                    logger.LogError(ex,
+                        "Opportunity scan failed to score {Ticker} for user {UserId}", nomination.Ticker, userId);
+                }
+            }
+        }
+
+        logger.LogInformation(
+            "Opportunity scan run: universe {Universe}, nominated {Nominated} (capped {Capped}), " +
+            "users {Users}, scored {Scored}, new candidates {New}, errors {Errors}",
+            universe.Count, nominations.Count, capped.Count, userIds.Count, scored, newCandidates, errors);
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/IpsRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/IpsRepository.cs
@@ -16,6 +16,13 @@ public class IpsRepository(ResearchDbContext db) : IIpsRepository
             .OrderByDescending(x => x.Version)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<Guid>> GetUserIdsWithCurrentIpsAsync(CancellationToken ct = default)
+        => await db.PolicyStatements.AsNoTracking()
+            .Where(x => x.IsCurrent)
+            .Select(x => x.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+
     public async Task<int> GetMaxVersionAsync(Guid userId, CancellationToken ct = default)
         => await db.PolicyStatements
             .Where(x => x.UserId == userId)

--- a/backend/src/FinanceSentry.Modules.Research/ResearchModule.cs
+++ b/backend/src/FinanceSentry.Modules.Research/ResearchModule.cs
@@ -10,6 +10,7 @@ using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 public static class ResearchModule
 {
@@ -54,6 +55,12 @@ public static class ResearchModule
                 "opportunity-candidate-expiry",
                 job => job.ExecuteAsync(CancellationToken.None),
                 Cron.Daily());
+
+            var opportunity = sp.GetRequiredService<IOptions<OpportunityOptions>>().Value;
+            mgr.AddOrUpdate<OpportunityScanJob>(
+                "opportunity-scan",
+                job => job.ExecuteAsync(CancellationToken.None),
+                Cron.Daily(opportunity.ScanHourUtc));
         }
     }
 
@@ -142,6 +149,7 @@ public static class ResearchModule
         services.AddScoped<ThesisMonitorJob>();
         services.AddScoped<ThesisTrackRecordSnapshotJob>();
         services.AddScoped<CandidateExpiryJob>();
+        services.AddScoped<OpportunityScanJob>();
 
         services.AddSingleton<IJobRegistrar, JobRegistrar>();
 

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
@@ -90,6 +90,10 @@ internal sealed class FakeMarketStructureReader(MarketStructureSnapshot? snapsho
     public Task<IReadOnlyList<PairwiseCorrelation>> GetPairwiseCorrelationsAsync(
         IReadOnlyCollection<string> tickers, CancellationToken ct = default)
         => Task.FromResult<IReadOnlyList<PairwiseCorrelation>>([]);
+
+    public Task<IReadOnlyList<UniverseStructureEntry>> GetUniverseStructuresAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<UniverseStructureEntry>>(
+            snapshot is null ? [] : [new UniverseStructureEntry(snapshot.Ticker, false, snapshot)]);
 }
 
 internal sealed class FakeSecEdgarService(IReadOnlyList<FundamentalFact>? facts = null) : ISecEdgarService
@@ -116,6 +120,9 @@ internal sealed class FakeIpsRepository(InvestmentPolicyStatement? ips = null) :
 
     public Task AddVersionAsync(InvestmentPolicyStatement statement, CancellationToken ct = default)
         => Task.CompletedTask;
+
+    public Task<IReadOnlyList<Guid>> GetUserIdsWithCurrentIpsAsync(CancellationToken ct = default)
+        => Task.FromResult<IReadOnlyList<Guid>>(ips is null ? [] : [ips.UserId]);
 }
 
 internal sealed class FakeBrokerageHoldingsReader(IReadOnlyList<BrokerageHoldingSummary>? holdings = null)

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/ScanNominationRulesTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/ScanNominationRulesTests.cs
@@ -1,0 +1,183 @@
+namespace FinanceSentry.Modules.Research.Tests.Opportunity;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.Research.Application.Services;
+using FinanceSentry.Modules.Research.Domain.Scoring;
+using FluentAssertions;
+using Xunit;
+
+public sealed class ScanNominationRulesTests
+{
+    private static readonly OpportunityOptions Options = new();
+
+    private static UniverseStructureEntry Entry(
+        string ticker,
+        decimal? rs,
+        bool isEtfLens = false,
+        bool stale = false,
+        int? sectorRank = null,
+        decimal? distanceFrom63dHigh = -0.05m,
+        decimal? volumeRatio = 1m)
+        => new(
+            ticker,
+            isEtfLens,
+            new MarketStructureSnapshot(
+                ticker,
+                new Dictionary<int, decimal?> { [ScanNominationRules.RsWindowBars] = rs },
+                new Dictionary<int, decimal?>(),
+                ExtensionFromMa50: 0.05m,
+                TodayZScore: 0m,
+                VolumeRatio: volumeRatio,
+                Ma50: 50m,
+                Ma200: 48m,
+                Stale: stale,
+                SectorRank: sectorRank,
+                SectorRankDelta: null,
+                DistanceFrom63dHigh: distanceFrom63dHigh));
+
+    private static List<UniverseStructureEntry> TenTickerUniverse()
+    {
+        // RS 0.01..0.10 → percentiles 10..100. T10 is top-decile; T8-T10 top-quartile.
+        var entries = new List<UniverseStructureEntry>();
+        for (var i = 1; i <= 10; i++)
+        {
+            entries.Add(Entry($"T{i:00}", rs: 0.01m * i));
+        }
+
+        return entries;
+    }
+
+    [Fact]
+    public void Evaluate_EmptyUniverse_ReturnsEmpty()
+        => ScanNominationRules.Evaluate([], Options).Should().BeEmpty();
+
+    [Fact]
+    public void Evaluate_NothingQualifies_ReturnsEmpty_SilenceIsValid()
+    {
+        var universe = new List<UniverseStructureEntry>
+        {
+            Entry("AAA", rs: null),
+            Entry("BBB", rs: null),
+        };
+
+        ScanNominationRules.Evaluate(universe, Options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Evaluate_TopDecileRs_Nominated()
+    {
+        var nominations = ScanNominationRules.Evaluate(TenTickerUniverse(), Options);
+
+        nominations.Should().Contain(n => n.Ticker == "T10")
+            .Which.Reasons.Should().Contain(ScanNominationRules.TopDecileRsReason);
+        nominations.Should().NotContain(n => n.Ticker == "T08");
+    }
+
+    [Fact]
+    public void Evaluate_TopQuartileRsInTopRotatingSector_Nominated()
+    {
+        var universe = TenTickerUniverse();
+        // T09 (90th percentile) sits in the #1 rotating sector → rule (a) fires; decile rule also fires.
+        universe[8] = Entry("T09", rs: 0.09m, sectorRank: 1);
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        nominations.Should().Contain(n => n.Ticker == "T09")
+            .Which.Reasons.Should().Contain(ScanNominationRules.TopQuartileRotatingSectorReason);
+    }
+
+    [Fact]
+    public void Evaluate_TopQuartileRsOutsideTopSectors_NotNominatedByRuleA()
+    {
+        var universe = TenTickerUniverse();
+        universe[7] = Entry("T08", rs: 0.08m, sectorRank: Options.ScanTopRotatingSectors + 1);
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        nominations.Should().NotContain(n => n.Ticker == "T08");
+    }
+
+    [Fact]
+    public void Evaluate_BreakoutOnAboveAverageVolume_Nominated()
+    {
+        var universe = TenTickerUniverse();
+        universe[0] = Entry("T01", rs: 0.01m, distanceFrom63dHigh: 0m, volumeRatio: 1.5m);
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        nominations.Should().Contain(n => n.Ticker == "T01")
+            .Which.Reasons.Should().ContainSingle()
+            .Which.Should().Be(ScanNominationRules.BreakoutReason);
+    }
+
+    [Fact]
+    public void Evaluate_BreakoutOnWeakVolume_NotNominated()
+    {
+        var universe = TenTickerUniverse();
+        universe[0] = Entry("T01", rs: 0.01m, distanceFrom63dHigh: 0m, volumeRatio: 0.8m);
+
+        ScanNominationRules.Evaluate(universe, Options)
+            .Should().NotContain(n => n.Ticker == "T01");
+    }
+
+    [Fact]
+    public void Evaluate_TwoRulesOneTicker_SingleNominationWithBothReasons()
+    {
+        var universe = TenTickerUniverse();
+        universe[9] = Entry("T10", rs: 0.10m, sectorRank: 1, distanceFrom63dHigh: 0m, volumeRatio: 2m);
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        var t10 = nominations.Where(n => n.Ticker == "T10").ToList();
+        t10.Should().ContainSingle();
+        t10[0].Reasons.Should().BeEquivalentTo(
+        [
+            ScanNominationRules.TopQuartileRotatingSectorReason,
+            ScanNominationRules.TopDecileRsReason,
+            ScanNominationRules.BreakoutReason,
+        ]);
+    }
+
+    [Fact]
+    public void Evaluate_EtfLens_NeverNominated()
+    {
+        var universe = TenTickerUniverse();
+        universe[9] = Entry("XLK", rs: 0.10m, isEtfLens: true, sectorRank: 1, distanceFrom63dHigh: 0m, volumeRatio: 2m);
+
+        ScanNominationRules.Evaluate(universe, Options)
+            .Should().NotContain(n => n.Ticker == "XLK");
+    }
+
+    [Fact]
+    public void Evaluate_StaleSnapshot_NeverNominated()
+    {
+        var universe = TenTickerUniverse();
+        universe[9] = Entry("T10", rs: 0.10m, stale: true);
+
+        ScanNominationRules.Evaluate(universe, Options)
+            .Should().NotContain(n => n.Ticker == "T10");
+    }
+
+    [Fact]
+    public void Evaluate_OrdersByRsPercentileDescending()
+    {
+        var universe = TenTickerUniverse();
+        universe[0] = Entry("T01", rs: 0.01m, distanceFrom63dHigh: 0m, volumeRatio: 2m);
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        nominations.Select(n => n.Ticker).Should().ContainInOrder("T10", "T01");
+    }
+
+    [Fact]
+    public void Evaluate_MissingRs_ExcludedFromRsRules_ButBreakoutStillFires()
+    {
+        var universe = TenTickerUniverse();
+        universe.Add(Entry("NORS", rs: null, distanceFrom63dHigh: 0m, volumeRatio: 2m));
+
+        var nominations = ScanNominationRules.Evaluate(universe, Options);
+
+        nominations.Should().Contain(n => n.Ticker == "NORS")
+            .Which.Reasons.Should().BeEquivalentTo([ScanNominationRules.BreakoutReason]);
+    }
+}


### PR DESCRIPTION
## What

Implements 019's deferred **User Story 2**: the scheduled machine scan that nominates opportunity candidates from 018 market structure — the missing half that left `CandidateSource.Scan` unused and the candidate list frozen since Jul 9.

**Nomination rules (FR-008, pure + deterministic, `ScanNominationRules`):**
- (a) top-quartile RS member of a top-N rotating sector
- (b) top-decile RS overall
- (c) at the 63-day high on above-average volume

ETF lenses (benchmark/sector/industry) and stale snapshots are never nominated. Stable reason strings dedup on re-nomination. Two rules on one ticker → one candidate, both reasons (AC-2).

**`OpportunityScanJob`** (Hangfire, daily 00:00 UTC — after Radar's 23:00 compute): reads the universe once via the new Core seam, evaluates rules, caps at `ScanMaxNominationsPerRun` (logs what it drops), and scores each nomination for every user with a current IPS through the **same `ScoreCandidateCommand` pipeline** as user nominations — same scorecard, signals, and top-tier alerts, so 020 can compare user-vs-machine hit rates ([DECISION] in spec). Per-ticker failures never abort the run (FR-013); empty 018 read aborts with a recorded error; zero nominations is a valid silent outcome.

## Changes
- Core: `IMarketStructureReader.GetUniverseStructuresAsync()` + `UniverseStructureEntry(Ticker, IsEtfLens, Snapshot)`; Radar impl reuses the single-ticker enrichment path
- `ScoreCandidateCommand` gains `Source`/`NominationReasons` (defaults preserve the MCP `score_candidate` contract)
- `IIpsRepository.GetUserIdsWithCurrentIpsAsync`
- Scan thresholds in `OpportunityOptions` (section `Opportunity`) — no magic numbers
- Version 0.12.2 → 0.13.0

## Verification
- `dotnet build`: 0 warnings, 0 errors
- 11 new `ScanNominationRulesTests` — quartile/decile cutoffs, ETF/stale exclusion, reason merge, breakout volume gate, ordering, missing-RS handling
- Research suite 79/79, unit suite 276/276

🤖 Generated with [Claude Code](https://claude.com/claude-code)