### PR TITLE
chore: declare the .NET 9 SDK in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Declares the toolchain the backend already targets (net9.0 in `backend/Directory.Build.props`) as a machine-readable fact. devclaw's ADR 0005 sandbox provisions the SDK from this file via mise at task start; `rollForward: latestFeature` accepts any 9.0.x SDK so local setups are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)