### PR TITLE
fix(bank-sync): make transfer debit/credit bucketing case-insensitive

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
@@ -77,8 +77,9 @@ public class TransferDetectionService : ITransferDetectionService
         foreach (var tx in transactions)
         {
             if (tx.IsPending || !tx.IsActive) continue;
-            if (tx.TransactionType == "debit") debits.Add(tx);
-            else if (tx.TransactionType == "credit") credits.Add(tx);
+            var txType = tx.TransactionType?.Trim();
+            if (txType?.Equals("debit", StringComparison.OrdinalIgnoreCase) == true) debits.Add(tx);
+            else if (txType?.Equals("credit", StringComparison.OrdinalIgnoreCase) == true) credits.Add(tx);
         }
 
         if (debits.Count == 0 || credits.Count == 0)

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
@@ -106,4 +106,52 @@ public class TransferDetectionTests
 
         result.Should().BeEmpty();
     }
+
+    [Theory]
+    [InlineData("Debit",  "Credit")]
+    [InlineData("DEBIT",  "CREDIT")]
+    [InlineData("debit",  "CREDIT")]
+    [InlineData("DEBIT",  "credit")]
+    [InlineData(" debit", " credit")]   // leading whitespace should be trimmed
+    [InlineData("debit ", "credit ")]   // trailing whitespace
+    public void DetectTransferTransactionIds_MixedCaseAndWhitespaceTypes_AreMatchedCorrectly(
+        string debitType, string creditType)
+    {
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit  = MakeTx(accountA, 500m, debitType,  date);
+        var credit = MakeTx(accountB, 500m, creditType, date);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit]);
+
+        result.Should().BeEquivalentTo(new[] { debit.Id, credit.Id },
+            because: $"debit type '{debitType}' and credit type '{creditType}' should be bucketed case-insensitively");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("unknown")]
+    [InlineData("transfer")]
+    public void DetectTransferTransactionIds_NonDebitCreditType_NotBucketed(string? txType)
+    {
+        // Rows with a type that is neither "debit" nor "credit" (regardless of case)
+        // must not end up in either bucket and therefore never produce a matched pair.
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        // Two rows with the same non-debit/credit type — no valid debit+credit pair exists.
+        var tx1 = MakeTx(accountA, 500m, txType!, date);
+        var tx2 = MakeTx(accountB, 500m, txType!, date);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([tx1, tx2]);
+
+        result.Should().BeEmpty(because: $"type '{txType}' is not a debit or credit bucket");
+    }
 }


### PR DESCRIPTION
## Changes
DetectTransferTransactionIds compared TransactionType with == "debit" / == "credit"
(ordinal case-sensitive), silently dropping rows typed "Debit", "CREDIT", etc.
Changed to OrdinalIgnoreCase + Trim(), consistent with IsLikelyTransfer's
treatment of "transfer". Added Theory tests covering mixed-case and
whitespace-padded type values; 14 unit tests pass, 0 warnings.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<details><summary>📋 Ticket (what was asked + why)</summary>

In `backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs`, `DetectTransferTransactionIds` buckets rows with case-sensitive ordinal `tx.TransactionType == "debit"` / `== "credit"`, whereas `IsLikelyTransfer` compares the type to "transfer" with `OrdinalIgnoreCase`. So a row typed "Debit"/"CREDIT" is silently dropped from batch detection. Make the debit/credit bucketing case-insensitive (and trim), consistent with `IsLikelyTransfer`. Add focused unit tests; do not weaken the suite.

</details>

## Verification
Gate `dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj -c Release` passed (exit 0).

## Files changed
```
.../Services/TransferDetectionService.cs           |  5 ++-
 .../BankSync/Application/TransferDetectionTests.cs | 48 ++++++++++++++++++++++
 2 files changed, 51 insertions(+), 2 deletions(-)
```

---
🤖 Delivered by devclaw (task `674f59fb-d852-4fdd-ba2d-39c74e412528`). Verify-gated, but **review before merging** — a green gate means the tests pass, not that the code is right.