### PR TITLE
chore(specs): make Status reflect reality; reconcile shipped task boxes

### DIFF
--- a/specs/001-bank-account-sync/spec.md
+++ b/specs/001-bank-account-sync/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `001-bank-account-sync`  
 **Created**: 2026-03-21  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "Bank account aggregation and sync - accumulate all bank accounts in one place with statistics for overall money flow"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/002-investment-tracking/spec.md
+++ b/specs/002-investment-tracking/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `002-investment-tracking`  
 **Created**: 2026-03-21  
-**Status**: Draft  
+**Status**: Superseded — delivered under 008 (wealth) / 009 (binance) / 010 (ibkr) + the research suite
 **Input**: User description: "Multi-source investment tracking for Binance and Interactive Brokers with AI-powered analytics"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/003-auth-flow/spec.md
+++ b/specs/003-auth-flow/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `003-auth-flow`  
 **Created**: 2026-04-11  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "Auth flow — login and register pages, JWT token storage, HTTP interceptor to attach Bearer token to all API requests, route guards to protect authenticated pages."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/004-adopt-oauth/spec.md
+++ b/specs/004-adopt-oauth/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `004-adopt-oauth`
 **Created**: 2026-04-15
 **Revised**: 2026-04-18
-**Status**: Draft
+**Status**: Implemented
 **Input**: Switch Google OAuth from server-side Authorization Code flow to Google Identity Services (GSI) client-side credential flow.
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/005-ui-component-library/spec.md
+++ b/specs/005-ui-component-library/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `005-ui-component-library`  
 **Created**: 2026-04-11  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "Create @dsdevq-common/ui — a standalone Angular component library..."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/006-ui-library-adoption/spec.md
+++ b/specs/006-ui-library-adoption/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-ui-library-adoption`
 **Created**: 2026-04-14
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "I want to adopt theme and ui library to my main frontend project"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/007-monobank-adapter/spec.md
+++ b/specs/007-monobank-adapter/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-monobank-adapter`  
 **Created**: 2026-04-19  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "I want to create a monobank adapter, since it is not available through plaid"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/008-wealth-aggregation-api/spec.md
+++ b/specs/008-wealth-aggregation-api/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-wealth-aggregation-api`  
 **Created**: 2026-04-19  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "Financial aggregation API that answers questions like what is my total net worth across all providers, what do I have across all banks, what have I spent this month, show me all crypto holdings. The API should support flexible grouping and filtering by provider category (bank, crypto, broker), by specific provider (monobank, plaid, binance), by currency, and by time window for transaction-based metrics like expenses and income. Users should be able to get a unified financial snapshot or drill down into a specific slice."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/009-binance-integration/spec.md
+++ b/specs/009-binance-integration/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `009-binance-integration`  
 **Created**: 2026-04-21  
-**Status**: Draft  
+**Status**: Implemented
 **Input**: User description: "integrate binance"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/010-ibkr-integration/spec.md
+++ b/specs/010-ibkr-integration/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `010-ibkr-integration`
 **Created**: 2026-04-22
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "make ibkr integration"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/011-connect-providers/spec.md
+++ b/specs/011-connect-providers/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `011-connect-providers`
 **Created**: 2026-04-25
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "I want you to implement connect feature of banks(plaid, monobank, etc), ibkr and binance. Design has been implemented by stitch"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/012-alerts-system/spec.md
+++ b/specs/012-alerts-system/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `012-alerts-system`
 **Created**: 2026-05-02
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Full new feature. Triggers: sync failure, low balance threshold breach, unusual spend pattern. DB schema, dismiss/read flow, event-driven or Hangfire generation."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/013-budgets/spec.md
+++ b/specs/013-budgets/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `013-budgets`
 **Created**: 2026-05-02
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Needs budget CRUD + spending-vs-budget calculation by joining transaction categories. Category data from Plaid/Monobank needs to be reliable enough to aggregate against."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/014-subscriptions/spec.md
+++ b/specs/014-subscriptions/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `014-subscriptions`
 **Created**: 2026-05-02
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Most complex. Requires recurring-transaction detection algorithm (same merchant, ~same amount, ~30-day cadence). Need to decide: run on-demand vs scheduled, how to handle edge cases (annual subscriptions, variable amounts), and confidence threshold."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/015-net-worth-history/spec.md
+++ b/specs/015-net-worth-history/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `015-net-worth-history`
 **Created**: 2026-05-02
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Dashboard net worth history chart. Currently 13 hardcoded monthly data points. Need to decide: periodic Hangfire snapshots vs on-demand aggregation from existing data. This decision shapes the schema entirely."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/017-thesis-monitor/spec.md
+++ b/specs/017-thesis-monitor/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `017-thesis-monitor`
 **Created**: 2026-07-06
-**Status**: Ready for implementation
+**Status**: Implemented
 **Input**: The deterministic **monitoring half** of Thesis Radar (`016-thesis-radar`), carved out as a bounded backend service. The discovery/candidate-generation half of the radar is explicitly **deferred** to a separate feature.
 
 ## Why this spec exists (design-pass reconciliation)

--- a/specs/017-thesis-monitor/tasks.md
+++ b/specs/017-thesis-monitor/tasks.md
@@ -12,8 +12,8 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 ## Phase 1: Setup
 
-- [ ] T001 Confirm the two open data-migration inputs before M004: exact GRAB thesis id and DRAM `price_drawdown` threshold (0.30?). Query `research.theses` (`SELECT id, ticker, invalidation_triggers FROM research.theses;`) on the running Postgres and record the real ids/current triggers in `specs/017-thesis-monitor/data-model.md` (replace the `e7b9af2c-…` placeholder).
-- [ ] T002 [P] Verify test projects exist: `backend/tests/FinanceSentry.Modules.Research.Tests/` and `backend/tests/FinanceSentry.Mcp.Tests/`. If the Research test project is missing, create it (xUnit, reference `FinanceSentry.Modules.Research`) and add to the solution.
+- [X] T001 Confirm the two open data-migration inputs before M004: exact GRAB thesis id and DRAM `price_drawdown` threshold (0.30?). Query `research.theses` (`SELECT id, ticker, invalidation_triggers FROM research.theses;`) on the running Postgres and record the real ids/current triggers in `specs/017-thesis-monitor/data-model.md` (replace the `e7b9af2c-…` placeholder).
+- [X] T002 [P] Verify test projects exist: `backend/tests/FinanceSentry.Modules.Research.Tests/` and `backend/tests/FinanceSentry.Mcp.Tests/`. If the Research test project is missing, create it (xUnit, reference `FinanceSentry.Modules.Research`) and add to the solution.
 
 ---
 
@@ -21,13 +21,13 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 **These block ALL user stories — the trigger shape, vocabulary, and price-history source must exist first.**
 
-- [ ] T003 Add `ThesisPeriodType` enum (`Quarter`, `Annual`) in `backend/src/FinanceSentry.Modules.Research/Domain/InvestmentThesis.cs` (or a sibling `Domain/ThesisPeriodType.cs`).
-- [ ] T004 Extend the `ThesisInvalidationTrigger` record in `backend/src/FinanceSentry.Modules.Research/Domain/InvestmentThesis.cs`: add `string? ProxyTicker`, `int ConsecutivePeriods = 1`, `ThesisPeriodType PeriodType = ThesisPeriodType.Quarter`. Keep it a positional record; ensure System.Text.Json (Web defaults) round-trips missing keys to defaults.
-- [ ] T005 [P] Create the closed metric vocabulary `ThesisMetric` in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/ThesisMetric.cs` — the 12 keys (`gross_margin`, `operating_margin`, `net_margin`, `revenue_yoy`, `net_income_yoy`, `operating_income_yoy`, `eps_yoy`, `revenue`, `net_income`, `diluted_eps`, `price_drawdown`, `price_return`), with a `Contains(string)` guard and a `IsPriceMetric(string)` helper.
-- [ ] T006 [P] Create `TriggerVerdict` result types in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/TriggerVerdict.cs`: `Breached(Metric, decimal[] ObservedValues, string[] Periods, decimal Threshold, string Direction)`, `Held`, `NonEvaluable(string Reason)` (reasons: `no_fundamentals`, `insufficient_periods`, `divide_by_zero`, `no_price_history`, `unsupported_metric`).
-- [ ] T007 [P] Add `DailyClose(DateOnly Date, decimal Close)` DTO and the `GetDailyClosesAsync(string ticker, DateOnly since, CancellationToken ct)` method signature to `backend/src/FinanceSentry.Modules.Research/Application/Services/IMarketDataService.cs`.
-- [ ] T008 Implement `GetDailyClosesAsync` in `backend/src/FinanceSentry.Modules.Research/Application/Services/YahooMarketDataService.cs` — reuse the existing `/v8/finance/chart/{ticker}?interval=1d` call, widen `range` to cover `since`, and retain the full close series (currently discarded). Return empty list on fetch failure (caller treats as non-evaluable).
-- [ ] T009 Add `ThesisTriggerVocabulary` static guard in `backend/src/FinanceSentry.Modules.Research/Application/Validation/ThesisTriggerVocabulary.cs` and invoke it from `SaveThesisCommandHandler` (`backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs`) — reject any trigger whose `Metric` ∉ vocabulary (FR-012), throwing a domain validation exception.
+- [X] T003 Add `ThesisPeriodType` enum (`Quarter`, `Annual`) in `backend/src/FinanceSentry.Modules.Research/Domain/InvestmentThesis.cs` (or a sibling `Domain/ThesisPeriodType.cs`).
+- [X] T004 Extend the `ThesisInvalidationTrigger` record in `backend/src/FinanceSentry.Modules.Research/Domain/InvestmentThesis.cs`: add `string? ProxyTicker`, `int ConsecutivePeriods = 1`, `ThesisPeriodType PeriodType = ThesisPeriodType.Quarter`. Keep it a positional record; ensure System.Text.Json (Web defaults) round-trips missing keys to defaults.
+- [X] T005 [P] Create the closed metric vocabulary `ThesisMetric` in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/ThesisMetric.cs` — the 12 keys (`gross_margin`, `operating_margin`, `net_margin`, `revenue_yoy`, `net_income_yoy`, `operating_income_yoy`, `eps_yoy`, `revenue`, `net_income`, `diluted_eps`, `price_drawdown`, `price_return`), with a `Contains(string)` guard and a `IsPriceMetric(string)` helper.
+- [X] T006 [P] Create `TriggerVerdict` result types in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/TriggerVerdict.cs`: `Breached(Metric, decimal[] ObservedValues, string[] Periods, decimal Threshold, string Direction)`, `Held`, `NonEvaluable(string Reason)` (reasons: `no_fundamentals`, `insufficient_periods`, `divide_by_zero`, `no_price_history`, `unsupported_metric`).
+- [X] T007 [P] Add `DailyClose(DateOnly Date, decimal Close)` DTO and the `GetDailyClosesAsync(string ticker, DateOnly since, CancellationToken ct)` method signature to `backend/src/FinanceSentry.Modules.Research/Application/Services/IMarketDataService.cs`.
+- [X] T008 Implement `GetDailyClosesAsync` in `backend/src/FinanceSentry.Modules.Research/Application/Services/YahooMarketDataService.cs` — reuse the existing `/v8/finance/chart/{ticker}?interval=1d` call, widen `range` to cover `since`, and retain the full close series (currently discarded). Return empty list on fetch failure (caller treats as non-evaluable).
+- [X] T009 Add `ThesisTriggerVocabulary` static guard in `backend/src/FinanceSentry.Modules.Research/Application/Validation/ThesisTriggerVocabulary.cs` and invoke it from `SaveThesisCommandHandler` (`backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs`) — reject any trigger whose `Metric` ∉ vocabulary (FR-012), throwing a domain validation exception.
 
 **Checkpoint**: trigger shape, vocabulary, price source, and save-guard all exist and build clean.
 
@@ -40,19 +40,19 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 ### Tests (write first — must fail before impl)
 
-- [ ] T010 [P] [US1] Evaluator unit tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/ThesisBreakEvaluatorTests.cs`: consecutive-period breach (holds all N periods → breach; holds N-1 → held), YoY using same fiscal period prior year, proxy-ticker substitution (evaluates proxy not thesis ticker), OR semantics (any trigger breaches → break; `BrokenReason` names first breaching trigger), no-triggers → skipped.
-- [ ] T011 [P] [US1] Non-evaluable unit tests in the same test dir: missing fundamentals → `NonEvaluable(no_fundamentals)`, insufficient periods → `insufficient_periods`, Revenue=0 denominator → `divide_by_zero`, unsupported metric → `unsupported_metric` — none produce a breach (SC-002).
+- [X] T010 [P] [US1] Evaluator unit tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/ThesisBreakEvaluatorTests.cs`: consecutive-period breach (holds all N periods → breach; holds N-1 → held), YoY using same fiscal period prior year, proxy-ticker substitution (evaluates proxy not thesis ticker), OR semantics (any trigger breaches → break; `BrokenReason` names first breaching trigger), no-triggers → skipped.
+- [X] T011 [P] [US1] Non-evaluable unit tests in the same test dir: missing fundamentals → `NonEvaluable(no_fundamentals)`, insufficient periods → `insufficient_periods`, Revenue=0 denominator → `divide_by_zero`, unsupported metric → `unsupported_metric` — none produce a breach (SC-002).
 
 ### Implementation
 
-- [ ] T012 [US1] Implement the pure deterministic `ThesisBreakEvaluator` in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/ThesisBreakEvaluator.cs`: given a trigger + `IReadOnlyList<FundamentalFact>` (target ticker) and/or `IReadOnlyList<DailyClose>`, compute the metric over the most recent `ConsecutivePeriods` periods and return a `TriggerVerdict`. Fundamentals metrics select by `PeriodType`/fiscal period; price metrics compute drawdown/return over trading days. No EF, no HTTP, no LLM.
-- [ ] T013 [US1] Add `AlertType.ThesisBroken` const to `backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs` and a silence-window `TimeSpan` for it in `AlertGeneratorService`.
-- [ ] T014 [US1] Add `GenerateThesisBreakAlertAsync(Guid userId, Guid thesisId, string ticker, string reason, CancellationToken)` to `backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs` and implement in `backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs` following `GenerateLowBalanceAlertAsync` (FindActive → HasRecent silence window → AddAsync; `ReferenceId`=thesisId, `ReferenceLabel`=ticker, Severity=Warning).
-- [ ] T015 [US1] Add `RunThesisMonitorCommand` + handler in `backend/src/FinanceSentry.Modules.Research/Application/Commands/RunThesisMonitorCommand.cs` (Core.Cqrs `ICommand<ThesisMonitorRunSummary>`): load active theses for the user via `IThesisRepository`, fetch fundamentals (`ISecEdgarService`, ≥8 periods) and price closes per target/proxy ticker, run `ThesisBreakEvaluator`, on unbroken→broken set `BrokenAt`/`BrokenReason` + call `GenerateThesisBreakAlertAsync`, persist via `UpsertAsync`, accumulate `ThesisMonitorRunSummary` counts. One thesis/ticker failure is caught, counted in `errors`, run continues (FR-014).
-- [ ] T016 [US1] Add `ThesisMonitorRunSummary` result record in `backend/src/FinanceSentry.Modules.Research/Application/Commands/` (or `Domain/ThesisMonitor/`): `ThesesEvaluated, TriggersEvaluated, BreaksRaised, BreaksCleared, Skipped, Errors` (FR-016).
-- [ ] T017 [US1] Create `ThesisMonitorJob` in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/ThesisMonitorJob.cs` (sealed, `[AutomaticRetry(Attempts = 2)]`, ILogger, primary ctor) with `ExecuteAsync(CancellationToken)` that resolves the command handler and runs it for all users; log the summary via Serilog.
-- [ ] T018 [US1] Register in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`: `services.AddScoped<ThesisMonitorJob>()` and add `mgr.AddOrUpdate<ThesisMonitorJob>("thesis-monitor", j => j.ExecuteAsync(CancellationToken.None), Cron.Daily())` to the existing `JobRegistrar`.
-- [ ] T019 [US1] Create migration `M004_ThesisTriggerV2` in `backend/src/FinanceSentry.Modules.Research/Migrations/` (`dotnet ef migrations add M004_ThesisTriggerV2 --context ResearchDbContext`): reshape `invalidation_triggers` jsonb and backfill the DRAM/GRAB triggers to the exact target state (per data-model.md, using ids confirmed in T001). Verify `dotnet ef database update` applies cleanly.
+- [X] T012 [US1] Implement the pure deterministic `ThesisBreakEvaluator` in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisMonitor/ThesisBreakEvaluator.cs`: given a trigger + `IReadOnlyList<FundamentalFact>` (target ticker) and/or `IReadOnlyList<DailyClose>`, compute the metric over the most recent `ConsecutivePeriods` periods and return a `TriggerVerdict`. Fundamentals metrics select by `PeriodType`/fiscal period; price metrics compute drawdown/return over trading days. No EF, no HTTP, no LLM.
+- [X] T013 [US1] Add `AlertType.ThesisBroken` const to `backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs` and a silence-window `TimeSpan` for it in `AlertGeneratorService`.
+- [X] T014 [US1] Add `GenerateThesisBreakAlertAsync(Guid userId, Guid thesisId, string ticker, string reason, CancellationToken)` to `backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs` and implement in `backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs` following `GenerateLowBalanceAlertAsync` (FindActive → HasRecent silence window → AddAsync; `ReferenceId`=thesisId, `ReferenceLabel`=ticker, Severity=Warning).
+- [X] T015 [US1] Add `RunThesisMonitorCommand` + handler in `backend/src/FinanceSentry.Modules.Research/Application/Commands/RunThesisMonitorCommand.cs` (Core.Cqrs `ICommand<ThesisMonitorRunSummary>`): load active theses for the user via `IThesisRepository`, fetch fundamentals (`ISecEdgarService`, ≥8 periods) and price closes per target/proxy ticker, run `ThesisBreakEvaluator`, on unbroken→broken set `BrokenAt`/`BrokenReason` + call `GenerateThesisBreakAlertAsync`, persist via `UpsertAsync`, accumulate `ThesisMonitorRunSummary` counts. One thesis/ticker failure is caught, counted in `errors`, run continues (FR-014).
+- [X] T016 [US1] Add `ThesisMonitorRunSummary` result record in `backend/src/FinanceSentry.Modules.Research/Application/Commands/` (or `Domain/ThesisMonitor/`): `ThesesEvaluated, TriggersEvaluated, BreaksRaised, BreaksCleared, Skipped, Errors` (FR-016).
+- [X] T017 [US1] Create `ThesisMonitorJob` in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/ThesisMonitorJob.cs` (sealed, `[AutomaticRetry(Attempts = 2)]`, ILogger, primary ctor) with `ExecuteAsync(CancellationToken)` that resolves the command handler and runs it for all users; log the summary via Serilog.
+- [X] T018 [US1] Register in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`: `services.AddScoped<ThesisMonitorJob>()` and add `mgr.AddOrUpdate<ThesisMonitorJob>("thesis-monitor", j => j.ExecuteAsync(CancellationToken.None), Cron.Daily())` to the existing `JobRegistrar`.
+- [X] T019 [US1] Create migration `M004_ThesisTriggerV2` in `backend/src/FinanceSentry.Modules.Research/Migrations/` (`dotnet ef migrations add M004_ThesisTriggerV2 --context ResearchDbContext`): reshape `invalidation_triggers` jsonb and backfill the DRAM/GRAB triggers to the exact target state (per data-model.md, using ids confirmed in T001). Verify `dotnet ef database update` applies cleanly.
 
 **Checkpoint**: US1 independently testable — scheduled/handler run marks a breached thesis broken with one alert.
 
@@ -65,13 +65,13 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 ### Tests (write first)
 
-- [ ] T020 [P] [US2] Add parity `[Fact]`s for `run_thesis_monitor` and `list_thesis_breaks` in `backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs` (invoke against seeded in-memory DB; assert run summary shape and that a broken thesis appears in the list; empty-list-not-error case).
+- [X] T020 [P] [US2] Add parity `[Fact]`s for `run_thesis_monitor` and `list_thesis_breaks` in `backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs` (invoke against seeded in-memory DB; assert run summary shape and that a broken thesis appears in the list; empty-list-not-error case).
 
 ### Implementation
 
-- [ ] T021 [US2] Add `ListThesisBreaksQuery` + handler in `backend/src/FinanceSentry.Modules.Research/Application/Queries/ListThesisBreaksQuery.cs` (Core.Cqrs `IQuery<IReadOnlyList<ThesisBreakView>>`): return every broken thesis for the user with metric, observed value(s), period(s), threshold, direction, reason (FR-015, SC-005). Add the `ThesisBreakView` record.
-- [ ] T022 [P] [US2] Create `RunThesisMonitorTool` in `backend/src/FinanceSentry.Mcp/Tools/RunThesisMonitorTool.cs` — `[McpServerToolType]`, `[McpServerTool(Name = "run_thesis_monitor")]`, primary-ctor DI of the command handler + `IIdentityResolver`, resolve `userId ?? identity.GetUserId()`, `[Description]` on method + `userId` param. Mirror `SaveThesisTool`.
-- [ ] T023 [P] [US2] Create `ListThesisBreaksTool` in `backend/src/FinanceSentry.Mcp/Tools/ListThesisBreaksTool.cs` — `[McpServerTool(Name = "list_thesis_breaks")]`, same DI/identity pattern, returns `ThesisBreakView[]`.
+- [X] T021 [US2] Add `ListThesisBreaksQuery` + handler in `backend/src/FinanceSentry.Modules.Research/Application/Queries/ListThesisBreaksQuery.cs` (Core.Cqrs `IQuery<IReadOnlyList<ThesisBreakView>>`): return every broken thesis for the user with metric, observed value(s), period(s), threshold, direction, reason (FR-015, SC-005). Add the `ThesisBreakView` record.
+- [X] T022 [P] [US2] Create `RunThesisMonitorTool` in `backend/src/FinanceSentry.Mcp/Tools/RunThesisMonitorTool.cs` — `[McpServerToolType]`, `[McpServerTool(Name = "run_thesis_monitor")]`, primary-ctor DI of the command handler + `IIdentityResolver`, resolve `userId ?? identity.GetUserId()`, `[Description]` on method + `userId` param. Mirror `SaveThesisTool`.
+- [X] T023 [P] [US2] Create `ListThesisBreaksTool` in `backend/src/FinanceSentry.Mcp/Tools/ListThesisBreaksTool.cs` — `[McpServerTool(Name = "list_thesis_breaks")]`, same DI/identity pattern, returns `ThesisBreakView[]`.
 
 **Checkpoint**: both MCP tools invocable; parity tests green.
 
@@ -84,12 +84,12 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 ### Tests (write first)
 
-- [ ] T024 [P] [US3] Handler-level tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs`: (a) re-run on still-broken → zero new alerts, `BrokenAt` unchanged (SC-003); (b) cleared condition → `BrokenAt`/`BrokenReason` nulled, resolve called, `BreaksCleared`++; (c) re-breach after clear → fresh break + alert.
+- [X] T024 [P] [US3] Handler-level tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs`: (a) re-run on still-broken → zero new alerts, `BrokenAt` unchanged (SC-003); (b) cleared condition → `BrokenAt`/`BrokenReason` nulled, resolve called, `BreaksCleared`++; (c) re-breach after clear → fresh break + alert.
 
 ### Implementation
 
-- [ ] T025 [US3] Add `ResolveThesisBreakAlertAsync(Guid userId, Guid thesisId, CancellationToken)` to `IAlertGeneratorService` + impl in `AlertGeneratorService` (find active `ThesisBroken` alert by `ReferenceId` → mark resolved), mirroring existing resolve methods.
-- [ ] T026 [US3] Extend `RunThesisMonitorCommand` handler transition logic (T015): on broken→cleared clear `BrokenAt`/`BrokenReason`, call `ResolveThesisBreakAlertAsync`, increment `BreaksCleared`; on broken→still-broken no-op (rely on generator active-alert dedup); ensure no oscillation spam (FR-011, US3).
+- [X] T025 [US3] Add `ResolveThesisBreakAlertAsync(Guid userId, Guid thesisId, CancellationToken)` to `IAlertGeneratorService` + impl in `AlertGeneratorService` (find active `ThesisBroken` alert by `ReferenceId` → mark resolved), mirroring existing resolve methods.
+- [X] T026 [US3] Extend `RunThesisMonitorCommand` handler transition logic (T015): on broken→cleared clear `BrokenAt`/`BrokenReason`, call `ResolveThesisBreakAlertAsync`, increment `BreaksCleared`; on broken→still-broken no-op (rely on generator active-alert dedup); ensure no oscillation spam (FR-011, US3).
 
 **Checkpoint**: idempotency + auto-clear verified by handler tests.
 
@@ -102,17 +102,17 @@ All paths under repo root `/home/dsdevqq/projects/finance-sentry`. Backend modul
 
 > Core logic already implemented in T012 + T011. This phase confirms end-to-end integration through the handler and run summary.
 
-- [ ] T027 [P] [US4] Handler integration tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/`: no-fundamentals ticker → thesis not broken, counted in `Skipped`; ETF/basket with no proxy → all triggers non-evaluable, never broken; fetch failure for one ticker → that thesis in `Errors`, run continues for others (FR-014).
-- [ ] T028 [US4] Ensure the handler records non-evaluable outcomes into `Skipped` and per-ticker exceptions into `Errors` in the summary (wire-through from T012 verdicts) — adjust T015 handler if not already covered.
+- [X] T027 [P] [US4] Handler integration tests in `backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/`: no-fundamentals ticker → thesis not broken, counted in `Skipped`; ETF/basket with no proxy → all triggers non-evaluable, never broken; fetch failure for one ticker → that thesis in `Errors`, run continues for others (FR-014).
+- [X] T028 [US4] Ensure the handler records non-evaluable outcomes into `Skipped` and per-ticker exceptions into `Errors` in the summary (wire-through from T012 verdicts) — adjust T015 handler if not already covered.
 
 ---
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T029 [P] Update the MCP tool-count/contract expectation if any hard count exists, and confirm `ToolAttributeContractTests` still passes with the two new tools.
-- [ ] T030 [P] Run `dotnet build backend/` → zero warnings; run `dotnet test backend/tests/FinanceSentry.Modules.Research.Tests backend/tests/FinanceSentry.Mcp.Tests` → all green.
-- [ ] T031 Execute quickstart.md golden path against the live stack (docker compose up postgres+api, apply M004, `run_thesis_monitor` → `list_thesis_breaks`) and confirm SC-006 (DRAM/GRAB evaluate end-to-end against live EDGAR without error).
-- [ ] T032 [P] Verify SC-007: grep the Research module for any messaging/Telegram/email dependency — there must be none (module raises domain alerts only).
+- [X] T029 [P] Update the MCP tool-count/contract expectation if any hard count exists, and confirm `ToolAttributeContractTests` still passes with the two new tools.
+- [X] T030 [P] Run `dotnet build backend/` → zero warnings; run `dotnet test backend/tests/FinanceSentry.Modules.Research.Tests backend/tests/FinanceSentry.Mcp.Tests` → all green.
+- [X] T031 Execute quickstart.md golden path against the live stack (docker compose up postgres+api, apply M004, `run_thesis_monitor` → `list_thesis_breaks`) and confirm SC-006 (DRAM/GRAB evaluate end-to-end against live EDGAR without error).
+- [X] T032 [P] Verify SC-007: grep the Research module for any messaging/Telegram/email dependency — there must be none (module raises domain alerts only).
 
 ---
 

--- a/specs/018-market-structure/spec.md
+++ b/specs/018-market-structure/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `018-market-structure`
 **Created**: 2026-07-07
-**Status**: Draft
+**Status**: Implemented
 **Input**: The "eyes" of the Radar (see `specs/ROADMAP.md`): daily price-history ingestion for a configurable universe, deterministic market-structure computations (relative strength, sector rotation, breadth, unusual moves, extension), and the shared append-only **signal log** that all Radar scanners write to.
 
 ## Why this spec exists

--- a/specs/018-market-structure/tasks.md
+++ b/specs/018-market-structure/tasks.md
@@ -10,25 +10,25 @@ New module: `FinanceSentry.Modules.Radar`. Paths under repo root. **Build gate**
 
 ## Phase 1: Setup — new module scaffold
 
-- [ ] T001 Create the project `backend/src/FinanceSentry.Modules.Radar/FinanceSentry.Modules.Radar.csproj` (net9.0, references `FinanceSentry.Core` + `FinanceSentry.Infrastructure` mirroring `Modules.Wealth.csproj`) and add it to `backend/FinanceSentry.sln`.
-- [ ] T002 Add `ProjectReference` to `FinanceSentry.Modules.Radar` from `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` and `backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj` (so the assembly loads for reflection-based module + tool discovery).
-- [ ] T003 Create the xUnit test project `backend/tests/FinanceSentry.Modules.Radar.Tests/` (reference the Radar module + Core) and add to the solution.
+- [X] T001 Create the project `backend/src/FinanceSentry.Modules.Radar/FinanceSentry.Modules.Radar.csproj` (net9.0, references `FinanceSentry.Core` + `FinanceSentry.Infrastructure` mirroring `Modules.Wealth.csproj`) and add it to `backend/FinanceSentry.sln`.
+- [X] T002 Add `ProjectReference` to `FinanceSentry.Modules.Radar` from `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` and `backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj` (so the assembly loads for reflection-based module + tool discovery).
+- [X] T003 Create the xUnit test project `backend/tests/FinanceSentry.Modules.Radar.Tests/` (reference the Radar module + Core) and add to the solution.
 
 ---
 
 ## Phase 2: Foundational — Core contracts, domain, persistence (blocks all stories)
 
-- [ ] T004 [P] Add Core interface `backend/src/FinanceSentry.Core/Interfaces/IMarketHistorySource.cs` + `DailyBarData(DateOnly Date, decimal Open, High, Low, Close, AdjClose, long Volume)` record.
-- [ ] T005 [P] Add Core interface `backend/src/FinanceSentry.Core/Interfaces/IWatchlistReader.cs` (`ListTickersAsync(Guid userId, ct)`); implement `WatchlistReader` in `backend/src/FinanceSentry.Modules.Research/Application/Services/WatchlistReader.cs` over `IWatchlistRepository` and register it in `ResearchModule.cs`.
-- [ ] T006 [P] Add Core `backend/src/FinanceSentry.Core/Interfaces/IRadarSignalWriter.cs` + `RadarSignalRequest(...)` record + `SignalSeverity` enum (enum lives in Core since it crosses the boundary).
-- [ ] T007 [P] Radar domain enums in `backend/src/FinanceSentry.Modules.Radar/Domain/Enums.cs`: `UniverseKind`, `SignalSubjectType`, `ScannerMode` (SignalSeverity is imported from Core).
-- [ ] T008 [P] Radar entities: `Domain/DailyBar.cs`, `Domain/RadarSignal.cs` (Payload object + PayloadVersion + nullable UserId), `Domain/RadarUniverseMember.cs`.
-- [ ] T009 Repository interfaces in `Domain/Repositories/`: `IDailyBarRepository` (UpsertRangeAsync idempotent on Ticker+Date, GetSinceAsync(ticker, since), GetLatestDateAsync), `IRadarSignalRepository` (AppendAsync, HasRecentAsync(dedupKey, since), ListAsync(filters), PruneInfoBeforeAsync), `IRadarUniverseRepository` (ListActiveAsync, UpsertMembersAsync, DeactivateAsync).
-- [ ] T010 `Infrastructure/Persistence/RadarDbContext.cs`: `HasDefaultSchema("radar")`; DbSets; entity config per data-model.md (unique `(Ticker,Date)`, signal indexes, jsonb `Payload` via HasConversion Web JSON, universe unique-active). Include `RadarDbContextFactory.cs` (copy `WealthDbContextFactory` with history table `__ef_migrations_history_radar`).
-- [ ] T011 Repository impls in `Infrastructure/Persistence/Repositories/` for the three interfaces.
-- [ ] T012 `RadarModule.cs`: `ModuleRegistrar` + `AddRadarModule(services, config)` — `AddDbContext<RadarDbContext>` with Npgsql + `MigrationsHistoryTable("__ef_migrations_history_radar")`; register repositories, services, jobs (scoped), `IRadarSignalWriter`, and `AddSingleton<IJobRegistrar, JobRegistrar>()`. Bind `RadarOptions` (thresholds, ScannerMode, lookback, freshness N) from configuration.
-- [ ] T013 Register `MigrateContext<RadarDbContext>(sp, app.Logger)` (+ `using`) in `backend/src/FinanceSentry.API/Migrations/MigrationExtensions.cs`.
-- [ ] T014 Generate migration `M001_InitialSchema` (`dotnet ef migrations add M001_InitialSchema --project backend/src/FinanceSentry.Modules.Radar --context RadarDbContext`); verify `dotnet ef database update` applies cleanly and creates schema `radar` with the three tables. **Any raw SQL must quote PascalCase columns** (unquoted folds to lowercase and fails — the 017 M004 bug).
+- [X] T004 [P] Add Core interface `backend/src/FinanceSentry.Core/Interfaces/IMarketHistorySource.cs` + `DailyBarData(DateOnly Date, decimal Open, High, Low, Close, AdjClose, long Volume)` record.
+- [X] T005 [P] Add Core interface `backend/src/FinanceSentry.Core/Interfaces/IWatchlistReader.cs` (`ListTickersAsync(Guid userId, ct)`); implement `WatchlistReader` in `backend/src/FinanceSentry.Modules.Research/Application/Services/WatchlistReader.cs` over `IWatchlistRepository` and register it in `ResearchModule.cs`.
+- [X] T006 [P] Add Core `backend/src/FinanceSentry.Core/Interfaces/IRadarSignalWriter.cs` + `RadarSignalRequest(...)` record + `SignalSeverity` enum (enum lives in Core since it crosses the boundary).
+- [X] T007 [P] Radar domain enums in `backend/src/FinanceSentry.Modules.Radar/Domain/Enums.cs`: `UniverseKind`, `SignalSubjectType`, `ScannerMode` (SignalSeverity is imported from Core).
+- [X] T008 [P] Radar entities: `Domain/DailyBar.cs`, `Domain/RadarSignal.cs` (Payload object + PayloadVersion + nullable UserId), `Domain/RadarUniverseMember.cs`.
+- [X] T009 Repository interfaces in `Domain/Repositories/`: `IDailyBarRepository` (UpsertRangeAsync idempotent on Ticker+Date, GetSinceAsync(ticker, since), GetLatestDateAsync), `IRadarSignalRepository` (AppendAsync, HasRecentAsync(dedupKey, since), ListAsync(filters), PruneInfoBeforeAsync), `IRadarUniverseRepository` (ListActiveAsync, UpsertMembersAsync, DeactivateAsync).
+- [X] T010 `Infrastructure/Persistence/RadarDbContext.cs`: `HasDefaultSchema("radar")`; DbSets; entity config per data-model.md (unique `(Ticker,Date)`, signal indexes, jsonb `Payload` via HasConversion Web JSON, universe unique-active). Include `RadarDbContextFactory.cs` (copy `WealthDbContextFactory` with history table `__ef_migrations_history_radar`).
+- [X] T011 Repository impls in `Infrastructure/Persistence/Repositories/` for the three interfaces.
+- [X] T012 `RadarModule.cs`: `ModuleRegistrar` + `AddRadarModule(services, config)` — `AddDbContext<RadarDbContext>` with Npgsql + `MigrationsHistoryTable("__ef_migrations_history_radar")`; register repositories, services, jobs (scoped), `IRadarSignalWriter`, and `AddSingleton<IJobRegistrar, JobRegistrar>()`. Bind `RadarOptions` (thresholds, ScannerMode, lookback, freshness N) from configuration.
+- [X] T013 Register `MigrateContext<RadarDbContext>(sp, app.Logger)` (+ `using`) in `backend/src/FinanceSentry.API/Migrations/MigrationExtensions.cs`.
+- [X] T014 Generate migration `M001_InitialSchema` (`dotnet ef migrations add M001_InitialSchema --project backend/src/FinanceSentry.Modules.Radar --context RadarDbContext`); verify `dotnet ef database update` applies cleanly and creates schema `radar` with the three tables. **Any raw SQL must quote PascalCase columns** (unquoted folds to lowercase and fails — the 017 M004 bug).
 
 **Checkpoint**: module builds, DI resolves, migration applies (verify via live API boot).
 
@@ -41,15 +41,15 @@ New module: `FinanceSentry.Modules.Radar`. Paths under repo root. **Build gate**
 
 ### Tests (write first)
 
-- [ ] T015 [P] [US2] `backend/tests/FinanceSentry.Modules.Radar.Tests/MarketStructure/ReturnMathTests.cs`: returns over 21/63/126/252 from seeded adj-close series; RS = ticker − benchmark; A>SPY>B ordering (Independent Test); `<N` bars → null (not zero).
-- [ ] T016 [P] [US2] `SectorRotationTests.cs`: rank sectors by RS; rankDelta vs 21d prior; delta ≥ threshold flagged.
+- [X] T015 [P] [US2] `backend/tests/FinanceSentry.Modules.Radar.Tests/MarketStructure/ReturnMathTests.cs`: returns over 21/63/126/252 from seeded adj-close series; RS = ticker − benchmark; A>SPY>B ordering (Independent Test); `<N` bars → null (not zero).
+- [X] T016 [P] [US2] `SectorRotationTests.cs`: rank sectors by RS; rankDelta vs 21d prior; delta ≥ threshold flagged.
 
 ### Implementation
 
-- [ ] T017 [P] [US2] `Domain/MarketStructure/ReturnMath.cs` (returns + RS per window) — pure.
-- [ ] T018 [P] [US2] `Domain/MarketStructure/MovingAverages.cs` (20/50/200 MA + extension) — pure.
-- [ ] T019 [P] [US2] `Domain/MarketStructure/SectorRotation.cs` (rank + delta) — pure.
-- [ ] T020 [US2] `Domain/MarketStructure/MarketStructureCalculator.cs` composing the above into `TickerStructure`; window constants {21,63,126,252}; null-on-insufficient.
+- [X] T017 [P] [US2] `Domain/MarketStructure/ReturnMath.cs` (returns + RS per window) — pure.
+- [X] T018 [P] [US2] `Domain/MarketStructure/MovingAverages.cs` (20/50/200 MA + extension) — pure.
+- [X] T019 [P] [US2] `Domain/MarketStructure/SectorRotation.cs` (rank + delta) — pure.
+- [X] T020 [US2] `Domain/MarketStructure/MarketStructureCalculator.cs` composing the above into `TickerStructure`; window constants {21,63,126,252}; null-on-insufficient.
 
 **Checkpoint**: computation core green from seeded bars, no I/O.
 
@@ -59,14 +59,14 @@ New module: `FinanceSentry.Modules.Radar`. Paths under repo root. **Build gate**
 
 ### Tests (write first)
 
-- [ ] T021 [P] [US1] `Ingestion/IngestDailyBarsIdempotencyTests.cs`: empty store → bars back to lookback; re-run appends only new days (unique Ticker+Date); one ticker's source failure → others still ingest, failure in summary (use a `FakeMarketHistorySource`).
+- [X] T021 [P] [US1] `Ingestion/IngestDailyBarsIdempotencyTests.cs`: empty store → bars back to lookback; re-run appends only new days (unique Ticker+Date); one ticker's source failure → others still ingest, failure in summary (use a `FakeMarketHistorySource`).
 
 ### Implementation
 
-- [ ] T022 [US1] `Infrastructure/MarketData/YahooMarketHistorySource.cs` — impl `IMarketHistorySource` over the `yahoo-finance` HttpClient: fetch `/v8/finance/chart/{ticker}?interval=1d&range=…`, parse full OHLCV from `indicators.quote[0]` + `indicators.adjclose[0].adjclose`, map to `DailyBarData`; per-request throttle; empty on failure. Register the client in `RadarModule` (or reuse the Research-registered `yahoo-finance` client).
-- [ ] T023 [US1] `Application/Services/RadarUniverseService.cs` — resolve universe = seed ∪ equity holdings (`IBrokerageHoldingsReader`, `InstrumentType=="STK"`) ∪ watchlist (`IWatchlistReader`); upsert `radar_universe_members`, deactivate departed tickers.
-- [ ] T024 [US1] `Application/Commands/IngestDailyBarsCommand.cs` + handler: for each active universe ticker, fetch bars since `latestDate ?? lookback`, `UpsertRangeAsync`, isolate per-ticker failures into `IngestRunSummary`.
-- [ ] T025 [US1] `Infrastructure/Jobs/RadarIngestionJob.cs` (daily post-close, `[AutomaticRetry]`) → runs the command; register in `RadarModule` `JobRegistrar` (`AddOrUpdate<RadarIngestionJob>("radar-ingestion", …, Cron.Daily(hour))`) + `AddScoped`.
+- [X] T022 [US1] `Infrastructure/MarketData/YahooMarketHistorySource.cs` — impl `IMarketHistorySource` over the `yahoo-finance` HttpClient: fetch `/v8/finance/chart/{ticker}?interval=1d&range=…`, parse full OHLCV from `indicators.quote[0]` + `indicators.adjclose[0].adjclose`, map to `DailyBarData`; per-request throttle; empty on failure. Register the client in `RadarModule` (or reuse the Research-registered `yahoo-finance` client).
+- [X] T023 [US1] `Application/Services/RadarUniverseService.cs` — resolve universe = seed ∪ equity holdings (`IBrokerageHoldingsReader`, `InstrumentType=="STK"`) ∪ watchlist (`IWatchlistReader`); upsert `radar_universe_members`, deactivate departed tickers.
+- [X] T024 [US1] `Application/Commands/IngestDailyBarsCommand.cs` + handler: for each active universe ticker, fetch bars since `latestDate ?? lookback`, `UpsertRangeAsync`, isolate per-ticker failures into `IngestRunSummary`.
+- [X] T025 [US1] `Infrastructure/Jobs/RadarIngestionJob.cs` (daily post-close, `[AutomaticRetry]`) → runs the command; register in `RadarModule` `JobRegistrar` (`AddOrUpdate<RadarIngestionJob>("radar-ingestion", …, Cron.Daily(hour))`) + `AddScoped`.
 
 **Checkpoint**: ingestion idempotent; universe auto-synced.
 
@@ -76,15 +76,15 @@ New module: `FinanceSentry.Modules.Radar`. Paths under repo root. **Build gate**
 
 ### Tests (write first)
 
-- [ ] T026 [P] [US4] `Signals/RadarSignalWriterTests.cs`: `notable`+ deduped by DedupKey within silence window; `info` recorded every run; append-only.
-- [ ] T027 [P] [US4] Add 6 tool names to `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` allowlist (33→39, update the `because:` literal) and add parity facts in `IntegrationTests/ToolParityTests.cs` (register Radar services + a `FakeMarketHistorySource`).
+- [X] T026 [P] [US4] `Signals/RadarSignalWriterTests.cs`: `notable`+ deduped by DedupKey within silence window; `info` recorded every run; append-only.
+- [X] T027 [P] [US4] Add 6 tool names to `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` allowlist (33→39, update the `because:` literal) and add parity facts in `IntegrationTests/ToolParityTests.cs` (register Radar services + a `FakeMarketHistorySource`).
 
 ### Implementation
 
-- [ ] T028 [US4] `Application/Services/RadarSignalWriter.cs` impl `IRadarSignalWriter` (dedup via `IRadarSignalRepository.HasRecentAsync` for notable+; append). Register in `RadarModule`.
-- [ ] T029 [US4] `Application/Services/SignalThresholds.cs` + `RadarOptions` binding (thresholds, `ScannerMode`, silence window, retention) — all config, no code constants (FR-008).
-- [ ] T030 [US4] Queries + handlers in `Application/Queries/`: `GetMarketStructureQuery`, `GetRelativeStrengthQuery`, `GetSectorRotationQuery`, `GetMarketBreadthQuery`, `ListSignalsQuery`, `GetRadarSummaryQuery` — pure reads over persisted bars/signals, never ingest (FR-011); attach `stale` flag (FR-017).
-- [ ] T031 [P] [US4] Six MCP tools in `backend/src/FinanceSentry.Mcp/Tools/` per contracts/mcp-tools.md (mirror `GetQuotesTool`/017 tools; `[McpServerTool(Name=…)]`, `IIdentityResolver`).
+- [X] T028 [US4] `Application/Services/RadarSignalWriter.cs` impl `IRadarSignalWriter` (dedup via `IRadarSignalRepository.HasRecentAsync` for notable+; append). Register in `RadarModule`.
+- [X] T029 [US4] `Application/Services/SignalThresholds.cs` + `RadarOptions` binding (thresholds, `ScannerMode`, silence window, retention) — all config, no code constants (FR-008).
+- [X] T030 [US4] Queries + handlers in `Application/Queries/`: `GetMarketStructureQuery`, `GetRelativeStrengthQuery`, `GetSectorRotationQuery`, `GetMarketBreadthQuery`, `ListSignalsQuery`, `GetRadarSummaryQuery` — pure reads over persisted bars/signals, never ingest (FR-011); attach `stale` flag (FR-017).
+- [X] T031 [P] [US4] Six MCP tools in `backend/src/FinanceSentry.Mcp/Tools/` per contracts/mcp-tools.md (mirror `GetQuotesTool`/017 tools; `[McpServerTool(Name=…)]`, `IIdentityResolver`).
 
 **Checkpoint**: scanner emits to `radar_signals`; all 6 tools invocable; parity/allowlist green.
 
@@ -94,29 +94,29 @@ New module: `FinanceSentry.Modules.Radar`. Paths under repo root. **Build gate**
 
 ### Tests (write first)
 
-- [ ] T032 [P] [US3] `MarketStructure/VolatilityTests.cs` + `BreadthTests.cs`: 63-day σ + today z-score; ≥3σ flagged with z-score; breadth % above MA20/50/200; zero-volume/short-history edges.
+- [X] T032 [P] [US3] `MarketStructure/VolatilityTests.cs` + `BreadthTests.cs`: 63-day σ + today z-score; ≥3σ flagged with z-score; breadth % above MA20/50/200; zero-volume/short-history edges.
 
 ### Implementation
 
-- [ ] T033 [P] [US3] `Domain/MarketStructure/Volatility.cs` (σ, z-score, volume ratio) — pure.
-- [ ] T034 [P] [US3] `Domain/MarketStructure/Breadth.cs` (% above MAs) — pure.
-- [ ] T035 [US3] `Application/Commands/ComputeMarketStructureCommand.cs` + handler + `RadarComputeJob`: run calculator over the universe, emit signals (`breadth` info; `rotation_shift`/`held_sector_laggard` notable; `unusual_move` with z-score; `extended` info) via `IRadarSignalWriter`; **held-ticker** `unusual_move` at/above alert bar raises `AlertType.MarketStructure` **only when `ScannerMode=Alerting`** (FR-010/015). Register the job in `JobRegistrar` (`radar-compute`, daily shortly after ingestion).
-- [ ] T036 [US3] Alerts wiring: add `AlertType.MarketStructure` const (`Modules.Alerts/Domain/AlertType.cs`); add `GenerateMarketStructureAlertAsync` (+ freshness reason) to `IAlertGeneratorService` (Core) + impl in `AlertGeneratorService` (FindActive→HasRecent→AddAsync + silence window). `trim_into_strength` is **deferred to v2** — do not implement.
+- [X] T033 [P] [US3] `Domain/MarketStructure/Volatility.cs` (σ, z-score, volume ratio) — pure.
+- [X] T034 [P] [US3] `Domain/MarketStructure/Breadth.cs` (% above MAs) — pure.
+- [X] T035 [US3] `Application/Commands/ComputeMarketStructureCommand.cs` + handler + `RadarComputeJob`: run calculator over the universe, emit signals (`breadth` info; `rotation_shift`/`held_sector_laggard` notable; `unusual_move` with z-score; `extended` info) via `IRadarSignalWriter`; **held-ticker** `unusual_move` at/above alert bar raises `AlertType.MarketStructure` **only when `ScannerMode=Alerting`** (FR-010/015). Register the job in `JobRegistrar` (`radar-compute`, daily shortly after ingestion).
+- [X] T036 [US3] Alerts wiring: add `AlertType.MarketStructure` const (`Modules.Alerts/Domain/AlertType.cs`); add `GenerateMarketStructureAlertAsync` (+ freshness reason) to `IAlertGeneratorService` (Core) + impl in `AlertGeneratorService` (FindActive→HasRecent→AddAsync + silence window). `trim_into_strength` is **deferred to v2** — do not implement.
 
 ---
 
 ## Phase 7: Resilience & validation
 
-- [ ] T037 [US3] `Infrastructure/Jobs/RadarFreshnessWatchdogJob.cs` (FR-017): raise `AlertType.MarketStructure` freshness alert when any universe ticker's latest bar > N trading days old or ingestion failed; ensure structure reads set `stale=true` over stale data. Register the job.
-- [ ] T038 `Application/Commands/RunHistoricalValidationCommand.cs` (FR-016): replay the pure calculator over ≥5y persisted bars, counting signal frequency/precision across the 2020 crash, 2022 unwind, 2026-07 memory rotation. `HistoricalValidation/ReplayTests.cs` asserts the expected signals appear in each seeded episode (SC-002) with low enough frequency not to spam.
+- [X] T037 [US3] `Infrastructure/Jobs/RadarFreshnessWatchdogJob.cs` (FR-017): raise `AlertType.MarketStructure` freshness alert when any universe ticker's latest bar > N trading days old or ingestion failed; ensure structure reads set `stale=true` over stale data. Register the job.
+- [X] T038 `Application/Commands/RunHistoricalValidationCommand.cs` (FR-016): replay the pure calculator over ≥5y persisted bars, counting signal frequency/precision across the 2020 crash, 2022 unwind, 2026-07 memory rotation. `HistoricalValidation/ReplayTests.cs` asserts the expected signals appear in each seeded episode (SC-002) with low enough frequency not to spam.
 
 ---
 
 ## Phase 8: Polish
 
-- [ ] T039 [P] `dotnet build backend/` → 0 warnings; `dotnet test` on `Modules.Radar.Tests` + `Mcp.Tests` → all green; confirm `ToolAttributeContractTests`/allowlist pass with the 6 new tools.
-- [ ] T040 Live boot: rebuild API image, confirm `M001` applies (schema `radar`, three tables, `__ef_migrations_history_radar`), API healthy, `radar-ingestion`/`radar-compute`/`radar-freshness-watchdog` recurring jobs register without throwing.
-- [ ] T041 [P] Confirm `ScannerMode` defaults to `LogOnly` (FR-015 — zero Alerts at launch) and SC-005: grep the Radar module for any Telegram/email/messaging or paid-API dependency — none.
+- [X] T039 [P] `dotnet build backend/` → 0 warnings; `dotnet test` on `Modules.Radar.Tests` + `Mcp.Tests` → all green; confirm `ToolAttributeContractTests`/allowlist pass with the 6 new tools.
+- [X] T040 Live boot: rebuild API image, confirm `M001` applies (schema `radar`, three tables, `__ef_migrations_history_radar`), API healthy, `radar-ingestion`/`radar-compute`/`radar-freshness-watchdog` recurring jobs register without throwing.
+- [X] T041 [P] Confirm `ScannerMode` defaults to `LogOnly` (FR-015 — zero Alerts at launch) and SC-005: grep the Radar module for any Telegram/email/messaging or paid-API dependency — none.
 
 ---
 

--- a/specs/019-opportunity-scanner/spec.md
+++ b/specs/019-opportunity-scanner/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `019-opportunity-scanner`
 **Created**: 2026-07-07
-**Status**: Draft
+**Status**: Implemented
 **Input**: The "offense" of the Radar (see `specs/ROADMAP.md`): deterministic scoring of opportunity candidates from two entry paths — Denys's own convictions and machine scans of market structure — with a promote flow that turns a strong candidate into a monitored `InvestmentThesis` (017). Successor to the deterministic parts of Ledger's `016-thesis-radar` discovery draft; the free-form LLM "find underhyped trends" idea stays in Ledger.
 
 ## Why this spec exists

--- a/specs/019-opportunity-scanner/tasks.md
+++ b/specs/019-opportunity-scanner/tasks.md
@@ -10,16 +10,16 @@ Paths under repo root. Feature lives in `FinanceSentry.Modules.Research` + 2 Cor
 ---
 
 ## Phase 1: Setup
-- [ ] T001 Confirm Research test project exists (`backend/tests/FinanceSentry.Modules.Research.Tests`) — reuse for Opportunity tests.
+- [X] T001 Confirm Research test project exists (`backend/tests/FinanceSentry.Modules.Research.Tests`) — reuse for Opportunity tests.
 
 ## Phase 2: Foundational — Core seams + domain + persistence (blocks all)
-- [ ] T002 [P] Core `backend/src/FinanceSentry.Core/Interfaces/IMarketStructureReader.cs` + `MarketStructureSnapshot` record (per data-model). Impl `MarketStructureReader` in `backend/src/FinanceSentry.Modules.Radar/Application/Services/MarketStructureReader.cs` over `IStructureQueryService`, projecting `TickerStructure` → snapshot; register in `RadarModule.cs`.
-- [ ] T003 [P] Core `backend/src/FinanceSentry.Core/Interfaces/IRiskPolicyGate.cs` + `RiskGateVerdict`/`RiskGateDecision`. Impl `RiskPolicyGate` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskPolicyGate.cs` over `CheckRiskRulesQueryHandler` (build `CheckRiskRulesQuery(userId, new RiskProposal(ticker, proposedUsd, overrideFlag))`, project `Verdict`; `HasRuleSet==false` → Allowed + "no rules on file"). Register in `RiskModule.cs`.
-- [ ] T004 [P] Research `Domain/Opportunity/` enums: `CandidateSource`, `CandidateStatus`, `CrowdingClass`.
-- [ ] T005 [P] Research entities `Domain/OpportunityCandidate.cs`, `Domain/CandidateScore.cs` (per data-model; no composite column).
-- [ ] T006 Repository interfaces `Domain/Repositories/ICandidateRepository.cs` (UpsertActiveAsync, FindActiveByTickerAsync, GetAsync, ListAsync(status?,source?), ListExpiredAsync) + `ICandidateScoreRepository.cs` (AppendAsync, LatestForCandidateAsync).
-- [ ] T007 `ResearchDbContext` (+ repo impls): add `DbSet<OpportunityCandidate>` + `DbSet<CandidateScore>`, entity config (indexes per data-model; jsonb `NominationReasons`/`IpsFit`/`Evidence` via HasConversion **with ValueComparer**; enums as string). Repo impls in `Infrastructure/Persistence/Repositories/`.
-- [ ] T008 Migration `M006_OpportunityCandidates` (`dotnet ef migrations add M006_OpportunityCandidates --project backend/src/FinanceSentry.Modules.Research --context ResearchDbContext`) — EF CreateTable (PascalCase; no raw SQL). Verify `database update` applies.
+- [X] T002 [P] Core `backend/src/FinanceSentry.Core/Interfaces/IMarketStructureReader.cs` + `MarketStructureSnapshot` record (per data-model). Impl `MarketStructureReader` in `backend/src/FinanceSentry.Modules.Radar/Application/Services/MarketStructureReader.cs` over `IStructureQueryService`, projecting `TickerStructure` → snapshot; register in `RadarModule.cs`.
+- [X] T003 [P] Core `backend/src/FinanceSentry.Core/Interfaces/IRiskPolicyGate.cs` + `RiskGateVerdict`/`RiskGateDecision`. Impl `RiskPolicyGate` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskPolicyGate.cs` over `CheckRiskRulesQueryHandler` (build `CheckRiskRulesQuery(userId, new RiskProposal(ticker, proposedUsd, overrideFlag))`, project `Verdict`; `HasRuleSet==false` → Allowed + "no rules on file"). Register in `RiskModule.cs`.
+- [X] T004 [P] Research `Domain/Opportunity/` enums: `CandidateSource`, `CandidateStatus`, `CrowdingClass`.
+- [X] T005 [P] Research entities `Domain/OpportunityCandidate.cs`, `Domain/CandidateScore.cs` (per data-model; no composite column).
+- [X] T006 Repository interfaces `Domain/Repositories/ICandidateRepository.cs` (UpsertActiveAsync, FindActiveByTickerAsync, GetAsync, ListAsync(status?,source?), ListExpiredAsync) + `ICandidateScoreRepository.cs` (AppendAsync, LatestForCandidateAsync).
+- [X] T007 `ResearchDbContext` (+ repo impls): add `DbSet<OpportunityCandidate>` + `DbSet<CandidateScore>`, entity config (indexes per data-model; jsonb `NominationReasons`/`IpsFit`/`Evidence` via HasConversion **with ValueComparer**; enums as string). Repo impls in `Infrastructure/Persistence/Repositories/`.
+- [X] T008 Migration `M006_OpportunityCandidates` (`dotnet ef migrations add M006_OpportunityCandidates --project backend/src/FinanceSentry.Modules.Research --context ResearchDbContext`) — EF CreateTable (PascalCase; no raw SQL). Verify `database update` applies.
 
 **Checkpoint**: seams + schema exist; build clean; migration applies (live boot later).
 
@@ -28,18 +28,18 @@ Paths under repo root. Feature lives in `FinanceSentry.Modules.Research` + 2 Cor
 ## Phase 3: User Story 1 — Conviction scoring (P1) 🎯 MVP
 
 ### Tests (write first)
-- [ ] T009 [P] [US1] `Opportunity/StructureScorerTests.cs`: RS/extension/z-score → 0–100 piecewise; not-evaluable window → null; deterministic.
-- [ ] T010 [P] [US1] `Opportunity/FundamentalsScorerTests.cs`: rev YoY + margin level/trend + EPS YoY → 0–100; missing EDGAR → null (partial, not faked); div-by-zero guarded.
-- [ ] T011 [P] [US1] `Opportunity/CrowdingClassifierTests.cs` + `ScoreCandidateHandlerTests.cs`: crowding Early/Normal/Extended by threshold; re-score appends a CandidateScore (no duplicate candidate, US1.4); held-ticker IPS concentration flag (US1.2).
+- [X] T009 [P] [US1] `Opportunity/StructureScorerTests.cs`: RS/extension/z-score → 0–100 piecewise; not-evaluable window → null; deterministic.
+- [X] T010 [P] [US1] `Opportunity/FundamentalsScorerTests.cs`: rev YoY + margin level/trend + EPS YoY → 0–100; missing EDGAR → null (partial, not faked); div-by-zero guarded.
+- [X] T011 [P] [US1] `Opportunity/CrowdingClassifierTests.cs` + `ScoreCandidateHandlerTests.cs`: crowding Early/Normal/Extended by threshold; re-score appends a CandidateScore (no duplicate candidate, US1.4); held-ticker IPS concentration flag (US1.2).
 
 ### Implementation
-- [ ] T012 [P] [US1] `Domain/Scoring/FundamentalMath.cs` — extract concept-name mapping + margin/YoY helpers shared with `ThesisBreakEvaluator` (reuse, do not duplicate the concept table; refactor 017's evaluator to use it if low-risk, else share the `ThesisMetric` constants + one ratio source).
-- [ ] T013 [P] [US1] `Domain/Scoring/StructureScorer.cs` (pure): `MarketStructureSnapshot` → structure score + evidence.
-- [ ] T014 [P] [US1] `Domain/Scoring/FundamentalsScorer.cs` (pure): `IReadOnlyList<FundamentalFact>` → fundamentals score + evidence; not-evaluable path.
-- [ ] T015 [P] [US1] `Domain/Scoring/CrowdingClassifier.cs` (pure): extension + volume ratio → `CrowdingClass` (config thresholds).
-- [ ] T016 [US1] `Application/Commands/ScoreCandidateCommand.cs` + handler: resolve structure (`IMarketStructureReader`), fundamentals (`ISecEdgarService`), IPS (`IIpsRepository`) + current weight (`IBrokerageHoldingsReader`); run scorers; upsert active candidate (source User) or append re-score; emit `info` nomination signal (`IRadarSignalWriter`, Scanner `opportunity`); record `Created` candidate event on first create (`IThesisEventRecorder`); top-tier rule → `notable` signal + `GenerateOpportunityAlertAsync` (≤1/candidate/window). Register handler in `ResearchModule`.
-- [ ] T017 [US1] Config `OpportunityOptions` (crowding thresholds, top-tier bar, TTL days, trigger-prefill drawdown/buffer defaults, FormulaVersion) bound from configuration — no magic numbers.
-- [ ] T018 [US1] Alerts: add `AlertType.Opportunity` const; `GenerateOpportunityAlertAsync` on `IAlertGeneratorService` (Core) + impl in `AlertGeneratorService` (FindActive→HasRecent→AddAsync, deterministic referenceId per candidate).
+- [X] T012 [P] [US1] `Domain/Scoring/FundamentalMath.cs` — extract concept-name mapping + margin/YoY helpers shared with `ThesisBreakEvaluator` (reuse, do not duplicate the concept table; refactor 017's evaluator to use it if low-risk, else share the `ThesisMetric` constants + one ratio source).
+- [X] T013 [P] [US1] `Domain/Scoring/StructureScorer.cs` (pure): `MarketStructureSnapshot` → structure score + evidence.
+- [X] T014 [P] [US1] `Domain/Scoring/FundamentalsScorer.cs` (pure): `IReadOnlyList<FundamentalFact>` → fundamentals score + evidence; not-evaluable path.
+- [X] T015 [P] [US1] `Domain/Scoring/CrowdingClassifier.cs` (pure): extension + volume ratio → `CrowdingClass` (config thresholds).
+- [X] T016 [US1] `Application/Commands/ScoreCandidateCommand.cs` + handler: resolve structure (`IMarketStructureReader`), fundamentals (`ISecEdgarService`), IPS (`IIpsRepository`) + current weight (`IBrokerageHoldingsReader`); run scorers; upsert active candidate (source User) or append re-score; emit `info` nomination signal (`IRadarSignalWriter`, Scanner `opportunity`); record `Created` candidate event on first create (`IThesisEventRecorder`); top-tier rule → `notable` signal + `GenerateOpportunityAlertAsync` (≤1/candidate/window). Register handler in `ResearchModule`.
+- [X] T017 [US1] Config `OpportunityOptions` (crowding thresholds, top-tier bar, TTL days, trigger-prefill drawdown/buffer defaults, FormulaVersion) bound from configuration — no magic numbers.
+- [X] T018 [US1] Alerts: add `AlertType.Opportunity` const; `GenerateOpportunityAlertAsync` on `IAlertGeneratorService` (Core) + impl in `AlertGeneratorService` (FindActive→HasRecent→AddAsync, deterministic referenceId per candidate).
 
 **Checkpoint**: `score_candidate` produces an explainable scorecard; US1 independently testable.
 
@@ -48,15 +48,15 @@ Paths under repo root. Feature lives in `FinanceSentry.Modules.Research` + 2 Cor
 ## Phase 4: User Story 3 — Promote / reject / expire (P2)
 
 ### Tests (write first)
-- [ ] T019 [P] [US3] `Opportunity/TriggerPrefillTests.cs`: prefill formula (always price_drawdown 0.30×3d; revenue_yoy<0 if rev YoY positive; gross_margin< latest−buffer if evaluable) → valid `ThesisMetric`s; rounded/cited.
-- [ ] T020 [P] [US3] `Opportunity/PromoteRejectExpireHandlerTests.cs`: promote Refused by gate (fake `IRiskPolicyGate`) → no thesis, verdict returned; Allowed → SaveThesis called + candidate Promoted + Promoted event; override records signal; reject → Rejected + reason + event; expire past TTL → Expired + final score snapshot.
+- [X] T019 [P] [US3] `Opportunity/TriggerPrefillTests.cs`: prefill formula (always price_drawdown 0.30×3d; revenue_yoy<0 if rev YoY positive; gross_margin< latest−buffer if evaluable) → valid `ThesisMetric`s; rounded/cited.
+- [X] T020 [P] [US3] `Opportunity/PromoteRejectExpireHandlerTests.cs`: promote Refused by gate (fake `IRiskPolicyGate`) → no thesis, verdict returned; Allowed → SaveThesis called + candidate Promoted + Promoted event; override records signal; reject → Rejected + reason + event; expire past TTL → Expired + final score snapshot.
 
 ### Implementation
-- [ ] T021 [US3] `Domain/Scoring/TriggerPrefill.cs` (pure): scorecard → `List<ProposedTrigger>` → `ThesisInvalidationTrigger`s.
-- [ ] T022 [US3] `Application/Commands/PromoteCandidateCommand.cs` + handler: call `IRiskPolicyGate.CheckProposalAsync`; if `Refused` && !override → return verdict, no thesis; else build `SaveThesisCommand` (prefilled or caller triggers), execute, set `PromotedThesisId`/status Promoted, record `Promoted` event; override → emit override signal. Register handler.
-- [ ] T023 [US3] `Application/Commands/RejectCandidateCommand.cs` + handler: status Rejected + reason; record `Rejected` event. `Application/Commands/ExpireCandidatesCommand.cs` + handler: expire Active past `ExpiresAt`, final score snapshot + `Expired` event.
-- [ ] T024 [US3] `Application/Queries/ListCandidatesQuery.cs` + handler: candidates (filter status/source) + latest score.
-- [ ] T025 [US3] `Infrastructure/Jobs/CandidateExpiryJob.cs` (daily) → runs ExpireCandidatesCommand; register in `ResearchModule` JobRegistrar (`Cron.Daily`) + `AddScoped`.
+- [X] T021 [US3] `Domain/Scoring/TriggerPrefill.cs` (pure): scorecard → `List<ProposedTrigger>` → `ThesisInvalidationTrigger`s.
+- [X] T022 [US3] `Application/Commands/PromoteCandidateCommand.cs` + handler: call `IRiskPolicyGate.CheckProposalAsync`; if `Refused` && !override → return verdict, no thesis; else build `SaveThesisCommand` (prefilled or caller triggers), execute, set `PromotedThesisId`/status Promoted, record `Promoted` event; override → emit override signal. Register handler.
+- [X] T023 [US3] `Application/Commands/RejectCandidateCommand.cs` + handler: status Rejected + reason; record `Rejected` event. `Application/Commands/ExpireCandidatesCommand.cs` + handler: expire Active past `ExpiresAt`, final score snapshot + `Expired` event.
+- [X] T024 [US3] `Application/Queries/ListCandidatesQuery.cs` + handler: candidates (filter status/source) + latest score.
+- [X] T025 [US3] `Infrastructure/Jobs/CandidateExpiryJob.cs` (daily) → runs ExpireCandidatesCommand; register in `ResearchModule` JobRegistrar (`Cron.Daily`) + `AddScoped`.
 
 **Checkpoint**: full lifecycle works; gate enforced.
 
@@ -65,22 +65,22 @@ Paths under repo root. Feature lives in `FinanceSentry.Modules.Research` + 2 Cor
 ## Phase 5: MCP surface (P1)
 
 ### Tests (write first)
-- [ ] T026 [P] Update `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` allowlist 43→47 (+score_candidate, list_candidates, promote_candidate, reject_candidate) + assertion message. Add parity registrations in `IntegrationTests/ToolParityTests.cs` for `IMarketStructureReader`, `IRiskPolicyGate`, candidate repos + scorers (+ a `FakeMarketStructureReader`/`FakeRiskPolicyGate` if live deps are unavailable in-test), and register the 4 tools.
+- [X] T026 [P] Update `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` allowlist 43→47 (+score_candidate, list_candidates, promote_candidate, reject_candidate) + assertion message. Add parity registrations in `IntegrationTests/ToolParityTests.cs` for `IMarketStructureReader`, `IRiskPolicyGate`, candidate repos + scorers (+ a `FakeMarketStructureReader`/`FakeRiskPolicyGate` if live deps are unavailable in-test), and register the 4 tools.
 
 ### Implementation
-- [ ] T027 [P] `backend/src/FinanceSentry.Mcp/Tools/ScoreCandidateTool.cs` (`score_candidate`).
-- [ ] T028 [P] `ListCandidatesTool.cs` (`list_candidates`).
-- [ ] T029 [P] `PromoteCandidateTool.cs` (`promote_candidate`) — returns thesis id + gate verdict.
-- [ ] T030 [P] `RejectCandidateTool.cs` (`reject_candidate`).
+- [X] T027 [P] `backend/src/FinanceSentry.Mcp/Tools/ScoreCandidateTool.cs` (`score_candidate`).
+- [X] T028 [P] `ListCandidatesTool.cs` (`list_candidates`).
+- [X] T029 [P] `PromoteCandidateTool.cs` (`promote_candidate`) — returns thesis id + gate verdict.
+- [X] T030 [P] `RejectCandidateTool.cs` (`reject_candidate`).
 
 **Checkpoint**: 4 tools invocable; allowlist/parity green.
 
 ---
 
 ## Phase 6: Polish
-- [ ] T031 [P] `dotnet build backend/` 0 warnings; `dotnet test` Research.Tests + Mcp.Tests green.
-- [ ] T032 Live boot: rebuild API, confirm M006 applies (research: opportunity_candidates + candidate_scores), API healthy, candidate-expiry job registers, no migration failure. (Same live-boot check that caught 017/018 bugs.)
-- [ ] T033 [P] Grep the scoring path for any LLM/messaging dependency — none (FR-002/FR-014). Confirm `scan_opportunities` (v2) and FR-006b/c (v1.1) are NOT silently half-built — deferrals are clean.
+- [X] T031 [P] `dotnet build backend/` 0 warnings; `dotnet test` Research.Tests + Mcp.Tests green.
+- [X] T032 Live boot: rebuild API, confirm M006 applies (research: opportunity_candidates + candidate_scores), API healthy, candidate-expiry job registers, no migration failure. (Same live-boot check that caught 017/018 bugs.)
+- [X] T033 [P] Grep the scoring path for any LLM/messaging dependency — none (FR-002/FR-014). Confirm `scan_opportunities` (v2) and FR-006b/c (v1.1) are NOT silently half-built — deferrals are clean.
 
 ---
 

--- a/specs/020-thesis-track-record/spec.md
+++ b/specs/020-thesis-track-record/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `020-thesis-track-record`
 **Created**: 2026-07-07
-**Status**: Draft
+**Status**: Implemented
 **Input**: The "honesty layer" of the Radar (see `specs/ROADMAP.md`): price-stamped lifecycle logging for every thesis and opportunity candidate, and performance measurement vs benchmark — so the system's (and Denys's) edge is measured, not assumed.
 
 ## Why this spec exists

--- a/specs/020-thesis-track-record/tasks.md
+++ b/specs/020-thesis-track-record/tasks.md
@@ -18,9 +18,9 @@
 
 **Purpose**: Domain types and persistence must exist before any capture or query logic.
 
-- [ ] T001 [P] Create `ThesisSubjectType` enum (`Thesis`, `Candidate`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisSubjectType.cs`
-- [ ] T002 [P] Create `ThesisEventType` enum (`Created`, `Broken`, `Unbroken`, `Closed`, `Promoted`, `Rejected`, `Expired`, `Snapshot`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisEventType.cs`
-- [ ] T003 Create `ThesisEvent` domain entity (fields per data-model.md: `Id`, `UserId`, `SubjectType`, `SubjectId`, `Ticker`, `EventType`, `Timestamp`, `SubjectPrice?`, `BenchmarkPrice?`, `BenchmarkTicker`, `PricesPending`, `DecisionNote?`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisEvent.cs`
+- [X] T001 [P] Create `ThesisSubjectType` enum (`Thesis`, `Candidate`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisSubjectType.cs`
+- [X] T002 [P] Create `ThesisEventType` enum (`Created`, `Broken`, `Unbroken`, `Closed`, `Promoted`, `Rejected`, `Expired`, `Snapshot`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisEventType.cs`
+- [X] T003 Create `ThesisEvent` domain entity (fields per data-model.md: `Id`, `UserId`, `SubjectType`, `SubjectId`, `Ticker`, `EventType`, `Timestamp`, `SubjectPrice?`, `BenchmarkPrice?`, `BenchmarkTicker`, `PricesPending`, `DecisionNote?`) in `backend/src/FinanceSentry.Modules.Research/Domain/ThesisEvent.cs`
 
 ---
 
@@ -30,15 +30,15 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T004 [P] Create `IThesisEventRepository` (`AppendAsync`, `ListAsync(subjectId?)`, `ListPendingAsync`, `ListForPeriodAsync(userId, from, to)`, `GetLatestForSubjectAsync`) in `backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IThesisEventRepository.cs`
-- [ ] T005 Add `DbSet<ThesisEvent>` and entity configuration (table `thesis_events`; composite index `(SubjectType, SubjectId, Timestamp)`; index `(UserId, PricesPending)`; index `(UserId, EventType, Timestamp)`) to `backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/ResearchDbContext.cs`
-- [ ] T006 Run EF migration `M004_ThesisEvents` for the `thesis_events` table with the three indexes above under `backend/src/FinanceSentry.Modules.Research/Migrations/`
-- [ ] T007 Implement `ThesisEventRepository` in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/ThesisEventRepository.cs`
-- [ ] T008 [P] Create `IThesisEventRecorder` (`RecordAsync(userId, subjectType, subjectId, ticker, eventType, decisionNote = null, cancellationToken)`) in `backend/src/FinanceSentry.Modules.Research/Application/Services/IThesisEventRecorder.cs`
-- [ ] T009 Implement `ThesisEventRecorder` (resolves subject + SPY quotes via `IMarketDataService`; on any quote exception, appends with `PricesPending = true` and null prices instead of throwing; guards against a duplicate `Created` per `(SubjectType, SubjectId)` via `IThesisEventRepository.GetLatestForSubjectAsync`) in `backend/src/FinanceSentry.Modules.Research/Application/Services/ThesisEventRecorder.cs`
-- [ ] T010 [P] Unit test: `ThesisEventRecorder` never throws when `IMarketDataService` throws — asserts `PricesPending = true`, null prices, event still appended — in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/ThesisEventRecorderTests.cs`
-- [ ] T011 [P] Unit test: `ThesisEventRecorder` appends exactly one `Created` event per subject even if `RecordAsync(Created)` is called twice (idempotency, FR edge case) in same test file as T010
-- [ ] T012 Register `IThesisEventRepository`, `IThesisEventRecorder` (scoped) in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`
+- [X] T004 [P] Create `IThesisEventRepository` (`AppendAsync`, `ListAsync(subjectId?)`, `ListPendingAsync`, `ListForPeriodAsync(userId, from, to)`, `GetLatestForSubjectAsync`) in `backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IThesisEventRepository.cs`
+- [X] T005 Add `DbSet<ThesisEvent>` and entity configuration (table `thesis_events`; composite index `(SubjectType, SubjectId, Timestamp)`; index `(UserId, PricesPending)`; index `(UserId, EventType, Timestamp)`) to `backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/ResearchDbContext.cs`
+- [X] T006 Run EF migration `M004_ThesisEvents` for the `thesis_events` table with the three indexes above under `backend/src/FinanceSentry.Modules.Research/Migrations/`
+- [X] T007 Implement `ThesisEventRepository` in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/ThesisEventRepository.cs`
+- [X] T008 [P] Create `IThesisEventRecorder` (`RecordAsync(userId, subjectType, subjectId, ticker, eventType, decisionNote = null, cancellationToken)`) in `backend/src/FinanceSentry.Modules.Research/Application/Services/IThesisEventRecorder.cs`
+- [X] T009 Implement `ThesisEventRecorder` (resolves subject + SPY quotes via `IMarketDataService`; on any quote exception, appends with `PricesPending = true` and null prices instead of throwing; guards against a duplicate `Created` per `(SubjectType, SubjectId)` via `IThesisEventRepository.GetLatestForSubjectAsync`) in `backend/src/FinanceSentry.Modules.Research/Application/Services/ThesisEventRecorder.cs`
+- [X] T010 [P] Unit test: `ThesisEventRecorder` never throws when `IMarketDataService` throws — asserts `PricesPending = true`, null prices, event still appended — in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/ThesisEventRecorderTests.cs`
+- [X] T011 [P] Unit test: `ThesisEventRecorder` appends exactly one `Created` event per subject even if `RecordAsync(Created)` is called twice (idempotency, FR edge case) in same test file as T010
+- [X] T012 Register `IThesisEventRepository`, `IThesisEventRecorder` (scoped) in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`
 
 **Checkpoint**: `dotnet build backend/` passes with zero warnings; `thesis_events` table created on migration; recorder is unit-tested in isolation.
 
@@ -50,15 +50,15 @@
 
 **Independent Test**: Create a thesis via `save_thesis`; assert a `Created` event exists with ticker price and SPY price via `list_thesis_events`.
 
-- [ ] T013 [US1] Wire `SaveThesisCommand`'s handler to call `IThesisEventRecorder.RecordAsync(..., ThesisEventType.Created)` immediately after persisting a *new* thesis (only when `id` was null on input — never on update) in `backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs`
-- [ ] T014 [P] [US1] Create `ThesisEventDto` (SubjectType, SubjectId, Ticker, EventType, Timestamp, SubjectPrice, BenchmarkPrice, BenchmarkTicker, PricesPending, DecisionNote) in `backend/src/FinanceSentry.Modules.Research/API/Responses/ThesisEventDto.cs`
-- [ ] T015 [US1] Create `ListThesisEventsQuery` (UserId, SubjectId?) + handler (delegates to `IThesisEventRepository.ListAsync`, maps to DTOs, scoped by UserId) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/ListThesisEventsQuery.cs`
-- [ ] T016 [US1] Create `ListThesisEventsTool` MCP tool (`list_thesis_events`; resolves `userId` via `IIdentityResolver` like `SaveThesisTool`) in `backend/src/FinanceSentry.Mcp/Tools/ListThesisEventsTool.cs`
-- [ ] T017 [P] [US1] Contract test: `list_thesis_events` tool is discoverable and named correctly (extend/verify existing reflection-based `ToolNameContractTests` picks it up) in `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs`
-- [ ] T018 [P] [US1] Integration/unit test: creating a thesis via `SaveThesisCommand` handler produces exactly one `Created` `ThesisEvent` with non-null prices when `IMarketDataService` succeeds, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/SaveThesisCommandEventCaptureTests.cs`
-- [ ] T019 [US1] Implement `ThesisTrackRecordSnapshotJob`: (a) find all `ThesisEvent` rows with `PricesPending = true`, re-attempt quote lookup, update in place on success; (b) for every thesis without a terminal event, append a `Snapshot` event with current prices — in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/ThesisTrackRecordSnapshotJob.cs`
-- [ ] T020 [US1] Register `thesis-track-record-snapshot` weekly recurring Hangfire job in the `JobRegistrar` in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`
-- [ ] T021 [P] [US1] Unit test: `ThesisTrackRecordSnapshotJob` backfills a pending event's prices and appends a `Snapshot` event for an active thesis with no terminal event, in `backend/tests/FinanceSentry.Modules.Research.Tests/Jobs/ThesisTrackRecordSnapshotJobTests.cs`
+- [X] T013 [US1] Wire `SaveThesisCommand`'s handler to call `IThesisEventRecorder.RecordAsync(..., ThesisEventType.Created)` immediately after persisting a *new* thesis (only when `id` was null on input — never on update) in `backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs`
+- [X] T014 [P] [US1] Create `ThesisEventDto` (SubjectType, SubjectId, Ticker, EventType, Timestamp, SubjectPrice, BenchmarkPrice, BenchmarkTicker, PricesPending, DecisionNote) in `backend/src/FinanceSentry.Modules.Research/API/Responses/ThesisEventDto.cs`
+- [X] T015 [US1] Create `ListThesisEventsQuery` (UserId, SubjectId?) + handler (delegates to `IThesisEventRepository.ListAsync`, maps to DTOs, scoped by UserId) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/ListThesisEventsQuery.cs`
+- [X] T016 [US1] Create `ListThesisEventsTool` MCP tool (`list_thesis_events`; resolves `userId` via `IIdentityResolver` like `SaveThesisTool`) in `backend/src/FinanceSentry.Mcp/Tools/ListThesisEventsTool.cs`
+- [X] T017 [P] [US1] Contract test: `list_thesis_events` tool is discoverable and named correctly (extend/verify existing reflection-based `ToolNameContractTests` picks it up) in `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs`
+- [X] T018 [P] [US1] Integration/unit test: creating a thesis via `SaveThesisCommand` handler produces exactly one `Created` `ThesisEvent` with non-null prices when `IMarketDataService` succeeds, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/SaveThesisCommandEventCaptureTests.cs`
+- [X] T019 [US1] Implement `ThesisTrackRecordSnapshotJob`: (a) find all `ThesisEvent` rows with `PricesPending = true`, re-attempt quote lookup, update in place on success; (b) for every thesis without a terminal event, append a `Snapshot` event with current prices — in `backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/ThesisTrackRecordSnapshotJob.cs`
+- [X] T020 [US1] Register `thesis-track-record-snapshot` weekly recurring Hangfire job in the `JobRegistrar` in `backend/src/FinanceSentry.Modules.Research/ResearchModule.cs`
+- [X] T021 [P] [US1] Unit test: `ThesisTrackRecordSnapshotJob` backfills a pending event's prices and appends a `Snapshot` event for an active thesis with no terminal event, in `backend/tests/FinanceSentry.Modules.Research.Tests/Jobs/ThesisTrackRecordSnapshotJobTests.cs`
 
 **Checkpoint**: Creating a thesis in a live stack produces a complete, correctly priced `Created` event with zero manual steps (SC-002); a simulated quote outage still records the event as pending and the weekly job backfills it.
 
@@ -70,13 +70,13 @@
 
 **Independent Test**: Seed a `Created` event at price 100 (SPY 500) and a later quote at 120 (SPY 510); assert return +20%, benchmark +2%, excess +18%.
 
-- [ ] T022 [P] [US2] Create `IThesisPerformanceCalculator` (`Calculate(fromEvent, toEventOrLatestPrice, frictionConfig) -> ThesisPerformanceResult`) — pure, no I/O — in `backend/src/FinanceSentry.Modules.Research/Application/Services/IThesisPerformanceCalculator.cs`
-- [ ] T023 [US2] Implement `ThesisPerformanceCalculator`: absolute/benchmark/excess return between two priced events or event→latest quote; `NotEvaluable` result when neither ticker nor `proxyTicker` (017 field — not yet on `InvestmentThesis`, branch present but unreachable until 017 adds it, per research.md R6) is quotable in `backend/src/FinanceSentry.Modules.Research/Application/Services/ThesisPerformanceCalculator.cs`
-- [ ] T024 [US2] Add `FrictionConfig` (per-trade cost bps, short/long-term capital-gains rates, holding-period boundary days) bound from `appsettings.json` section `ThesisTrackRecord:Friction`, applied in `ThesisPerformanceCalculator` to compute `NetAbsoluteReturnPct`/`NetExcessReturnPct` per FR-007b, in `backend/src/FinanceSentry.Modules.Research/Application/Services/FrictionConfig.cs`
-- [ ] T025 [P] [US2] Unit test: SC-001 determinism — identical inputs produce identical outputs; gross vs net return math with configured friction; not-evaluable path when no quote available, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/ThesisPerformanceCalculatorTests.cs`
-- [ ] T026 [US2] Create `GetThesisPerformanceQuery` (UserId, Id?, Ticker?) + handler (resolves subject via `IThesisEventRepository`, calls `IThesisPerformanceCalculator` for create→latest) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetThesisPerformanceQuery.cs`
-- [ ] T027 [US2] Create `GetThesisPerformanceTool` MCP tool (`get_thesis_performance`; accepts `id` or `ticker`, resolves `userId` via `IIdentityResolver`) in `backend/src/FinanceSentry.Mcp/Tools/GetThesisPerformanceTool.cs`
-- [ ] T028 [P] [US2] Contract test: `get_thesis_performance` tool discoverable/named correctly (`ToolNameContractTests`) and returns `null`/handles gracefully when neither `id` nor `ticker` resolves, in `backend/tests/FinanceSentry.Mcp.Tests/GetThesisPerformanceToolTests.cs`
+- [X] T022 [P] [US2] Create `IThesisPerformanceCalculator` (`Calculate(fromEvent, toEventOrLatestPrice, frictionConfig) -> ThesisPerformanceResult`) — pure, no I/O — in `backend/src/FinanceSentry.Modules.Research/Application/Services/IThesisPerformanceCalculator.cs`
+- [X] T023 [US2] Implement `ThesisPerformanceCalculator`: absolute/benchmark/excess return between two priced events or event→latest quote; `NotEvaluable` result when neither ticker nor `proxyTicker` (017 field — not yet on `InvestmentThesis`, branch present but unreachable until 017 adds it, per research.md R6) is quotable in `backend/src/FinanceSentry.Modules.Research/Application/Services/ThesisPerformanceCalculator.cs`
+- [X] T024 [US2] Add `FrictionConfig` (per-trade cost bps, short/long-term capital-gains rates, holding-period boundary days) bound from `appsettings.json` section `ThesisTrackRecord:Friction`, applied in `ThesisPerformanceCalculator` to compute `NetAbsoluteReturnPct`/`NetExcessReturnPct` per FR-007b, in `backend/src/FinanceSentry.Modules.Research/Application/Services/FrictionConfig.cs`
+- [X] T025 [P] [US2] Unit test: SC-001 determinism — identical inputs produce identical outputs; gross vs net return math with configured friction; not-evaluable path when no quote available, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/ThesisPerformanceCalculatorTests.cs`
+- [X] T026 [US2] Create `GetThesisPerformanceQuery` (UserId, Id?, Ticker?) + handler (resolves subject via `IThesisEventRepository`, calls `IThesisPerformanceCalculator` for create→latest) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetThesisPerformanceQuery.cs`
+- [X] T027 [US2] Create `GetThesisPerformanceTool` MCP tool (`get_thesis_performance`; accepts `id` or `ticker`, resolves `userId` via `IIdentityResolver`) in `backend/src/FinanceSentry.Mcp/Tools/GetThesisPerformanceTool.cs`
+- [X] T028 [P] [US2] Contract test: `get_thesis_performance` tool discoverable/named correctly (`ToolNameContractTests`) and returns `null`/handles gracefully when neither `id` nor `ticker` resolves, in `backend/tests/FinanceSentry.Mcp.Tests/GetThesisPerformanceToolTests.cs`
 
 **Checkpoint**: `get_thesis_performance` returns correct absolute/benchmark/excess return (gross and net) for a live thesis; not-evaluable path never throws.
 
@@ -88,10 +88,10 @@
 
 **Independent Test**: Given a mix of active/broken/promoted/rejected records, `get_track_record` returns counts, hit rate, average/median excess return, split by source and status, with a low-sample caveat below 30 closed records.
 
-- [ ] T029 [US3] Create `GetTrackRecordQuery` (UserId, Source?, Status?) + handler: fetches all subjects' event histories via `IThesisEventRepository`, computes per-subject performance via `IThesisPerformanceCalculator`, aggregates counts/hit rates/avg/median/best/worst, splits by source (`User`/`Scan`) and status, sets `LowSampleCaveat` when `ClosedCount < 30` (constant `MinimumClosedSampleSize`) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetTrackRecordQuery.cs`
-- [ ] T030 [US3] Create `GetTrackRecordTool` MCP tool (`get_track_record`) in `backend/src/FinanceSentry.Mcp/Tools/GetTrackRecordTool.cs`
-- [ ] T031 [P] [US3] Unit test: `GetTrackRecordQuery` handler — separate `TerminalHitRate`/`ActiveHitRate` (never blended per research.md R4); `LowSampleCaveat = true` below 30 closed records, `false` at/above; excluded (`NotEvaluable`) subjects counted in `ExcludedCount`, not in hit-rate denominators, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/GetTrackRecordQueryTests.cs`
-- [ ] T032 [P] [US3] Contract test: `get_track_record` tool discoverable/named correctly, in `backend/tests/FinanceSentry.Mcp.Tests/GetTrackRecordToolTests.cs`
+- [X] T029 [US3] Create `GetTrackRecordQuery` (UserId, Source?, Status?) + handler: fetches all subjects' event histories via `IThesisEventRepository`, computes per-subject performance via `IThesisPerformanceCalculator`, aggregates counts/hit rates/avg/median/best/worst, splits by source (`User`/`Scan`) and status, sets `LowSampleCaveat` when `ClosedCount < 30` (constant `MinimumClosedSampleSize`) in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetTrackRecordQuery.cs`
+- [X] T030 [US3] Create `GetTrackRecordTool` MCP tool (`get_track_record`) in `backend/src/FinanceSentry.Mcp/Tools/GetTrackRecordTool.cs`
+- [X] T031 [P] [US3] Unit test: `GetTrackRecordQuery` handler — separate `TerminalHitRate`/`ActiveHitRate` (never blended per research.md R4); `LowSampleCaveat = true` below 30 closed records, `false` at/above; excluded (`NotEvaluable`) subjects counted in `ExcludedCount`, not in hit-rate denominators, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/GetTrackRecordQueryTests.cs`
+- [X] T032 [P] [US3] Contract test: `get_track_record` tool discoverable/named correctly, in `backend/tests/FinanceSentry.Mcp.Tests/GetTrackRecordToolTests.cs`
 
 **Checkpoint**: `get_track_record` answers "is this earning money" in one call (SC-003); rejected candidates' counterfactual performance is queryable once candidates exist (SC-004 — verifiable in full once 019 ships).
 
@@ -101,12 +101,12 @@
 
 **Goal**: Capture contemporaneous reasoning per event and compile a period post-mortem packet for Denys's periodic review.
 
-- [ ] T033 [US1] Confirm `DecisionNote` optional parameter flows end-to-end: `IThesisEventRecorder.RecordAsync` already accepts it (T008/T009) — expose it on `SaveThesisCommand`/`SaveThesisTool` as an optional `decisionNote` parameter so callers can supply reasoning at creation time, in `backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs` and `backend/src/FinanceSentry.Mcp/Tools/SaveThesisTool.cs`
-- [ ] T034 Create `PostmortemEntry` and `PostmortemPacket` response records (per data-model.md) in `backend/src/FinanceSentry.Modules.Research/API/Responses/PostmortemPacketDto.cs`
-- [ ] T035 Create `GetPostmortemPacketQuery` (UserId, PeriodStart, PeriodEnd) + handler: fetches all terminal events in the period via `IThesisEventRepository.ListForPeriodAsync`, pairs each with its `Created` event's `DecisionNote`, computes excess return per entry via `IThesisPerformanceCalculator`, includes rejected-candidate counterfactuals in the same period, in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetPostmortemPacketQuery.cs`
-- [ ] T036 Create `GetPostmortemPacketTool` MCP tool (`get_postmortem_packet`) in `backend/src/FinanceSentry.Mcp/Tools/GetPostmortemPacketTool.cs`
-- [ ] T037 [P] Unit test: `GetPostmortemPacketQuery` returns empty `Entries`/`CounterfactualEntries` (no error) when no terminal events exist in the period; correctly pairs `Created`→terminal decision notes when they do, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/GetPostmortemPacketQueryTests.cs`
-- [ ] T038 [P] Contract test: `get_postmortem_packet` tool discoverable/named correctly, in `backend/tests/FinanceSentry.Mcp.Tests/GetPostmortemPacketToolTests.cs`
+- [X] T033 [US1] Confirm `DecisionNote` optional parameter flows end-to-end: `IThesisEventRecorder.RecordAsync` already accepts it (T008/T009) — expose it on `SaveThesisCommand`/`SaveThesisTool` as an optional `decisionNote` parameter so callers can supply reasoning at creation time, in `backend/src/FinanceSentry.Modules.Research/Application/Commands/SaveThesisCommand.cs` and `backend/src/FinanceSentry.Mcp/Tools/SaveThesisTool.cs`
+- [X] T034 Create `PostmortemEntry` and `PostmortemPacket` response records (per data-model.md) in `backend/src/FinanceSentry.Modules.Research/API/Responses/PostmortemPacketDto.cs`
+- [X] T035 Create `GetPostmortemPacketQuery` (UserId, PeriodStart, PeriodEnd) + handler: fetches all terminal events in the period via `IThesisEventRepository.ListForPeriodAsync`, pairs each with its `Created` event's `DecisionNote`, computes excess return per entry via `IThesisPerformanceCalculator`, includes rejected-candidate counterfactuals in the same period, in `backend/src/FinanceSentry.Modules.Research/Application/Queries/GetPostmortemPacketQuery.cs`
+- [X] T036 Create `GetPostmortemPacketTool` MCP tool (`get_postmortem_packet`) in `backend/src/FinanceSentry.Mcp/Tools/GetPostmortemPacketTool.cs`
+- [X] T037 [P] Unit test: `GetPostmortemPacketQuery` returns empty `Entries`/`CounterfactualEntries` (no error) when no terminal events exist in the period; correctly pairs `Created`→terminal decision notes when they do, in `backend/tests/FinanceSentry.Modules.Research.Tests/Unit/GetPostmortemPacketQueryTests.cs`
+- [X] T038 [P] Contract test: `get_postmortem_packet` tool discoverable/named correctly, in `backend/tests/FinanceSentry.Mcp.Tests/GetPostmortemPacketToolTests.cs`
 
 **Checkpoint**: A full period's terminal events, decision notes, and counterfactuals are compiled in one call; the system compiles, it does not judge (per spec's explicit non-goal).
 
@@ -114,8 +114,8 @@
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T039 [P] Bump backend version `0.9.0` → `0.10.0` in `backend/src/FinanceSentry.API/FinanceSentry.API.csproj`
-- [ ] T040 Run quickstart.md manual QA: create a thesis, verify priced `Created` event; simulate a quote outage, verify pending event + job backfill; query all four MCP tools; confirm zero `dotnet build` warnings
+- [X] T039 [P] Bump backend version `0.9.0` → `0.10.0` in `backend/src/FinanceSentry.API/FinanceSentry.API.csproj`
+- [X] T040 Run quickstart.md manual QA: create a thesis, verify priced `Created` event; simulate a quote outage, verify pending event + job backfill; query all four MCP tools; confirm zero `dotnet build` warnings
 
 ---
 

--- a/specs/022-risk-rules/spec.md
+++ b/specs/022-risk-rules/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `022-risk-rules`
 **Created**: 2026-07-07
-**Status**: Draft
+**Status**: Implemented
 **Input**: The practitioner layer identified as the biggest omission by the 2026-07-07 independent review: written, machine-checked position policy. "For a concentrated book, sizing rules are worth more than every scanner combined." Small feature, big leverage: deterministic checks of the live book against explicit rules, violations surfaced as signals/alerts, and a hard gate on 019's promote flow.
 
 ## Why this spec exists

--- a/specs/022-risk-rules/tasks.md
+++ b/specs/022-risk-rules/tasks.md
@@ -18,10 +18,10 @@
 
 **Purpose**: Scaffold the new module and register it — nothing functional yet.
 
-- [ ] T001 Create `FinanceSentry.Modules.Risk` project (new `.csproj`, net9.0, referencing `FinanceSentry.Core`) at `backend/src/FinanceSentry.Modules.Risk/FinanceSentry.Modules.Risk.csproj`; add to `backend/FinanceSentry.sln`
-- [ ] T002 Create empty folder skeleton per plan.md Project Structure: `API/Controllers/`, `API/Responses/`, `Application/Commands/`, `Application/Queries/`, `Application/Services/`, `Domain/`, `Domain/Exceptions/`, `Domain/Repositories/`, `Infrastructure/Jobs/`, `Infrastructure/Persistence/Repositories/`, `Migrations/` under `backend/src/FinanceSentry.Modules.Risk/`
-- [ ] T003 [P] Reference `FinanceSentry.Modules.Risk` from `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` and from `backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj`
-- [ ] T004 [P] Reference `FinanceSentry.Modules.Research` (for `IThesisRepository`) from `FinanceSentry.Modules.Risk.csproj` — read-only cross-module dependency per research.md R3
+- [X] T001 Create `FinanceSentry.Modules.Risk` project (new `.csproj`, net9.0, referencing `FinanceSentry.Core`) at `backend/src/FinanceSentry.Modules.Risk/FinanceSentry.Modules.Risk.csproj`; add to `backend/FinanceSentry.sln`
+- [X] T002 Create empty folder skeleton per plan.md Project Structure: `API/Controllers/`, `API/Responses/`, `Application/Commands/`, `Application/Queries/`, `Application/Services/`, `Domain/`, `Domain/Exceptions/`, `Domain/Repositories/`, `Infrastructure/Jobs/`, `Infrastructure/Persistence/Repositories/`, `Migrations/` under `backend/src/FinanceSentry.Modules.Risk/`
+- [X] T003 [P] Reference `FinanceSentry.Modules.Risk` from `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` and from `backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj`
+- [X] T004 [P] Reference `FinanceSentry.Modules.Research` (for `IThesisRepository`) from `FinanceSentry.Modules.Risk.csproj` — read-only cross-module dependency per research.md R3
 
 **Checkpoint**: Solution builds with the empty Risk module referenced everywhere it will be needed.
 
@@ -33,22 +33,22 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T005 [P] `RiskRuleSet` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/RiskRuleSet.cs` per data-model.md (versioned, `IsCurrent`, all fields optional)
-- [ ] T006 [P] `PolicyViolationAck` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/PolicyViolationAck.cs`
-- [ ] T007 [P] `HoldingSnapshot` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/HoldingSnapshot.cs`
-- [ ] T008 [P] Transient records `BookSnapshot`, `BookPosition`, `PolicyViolation`, `RiskVerdict`, `ComplianceReport` in `backend/src/FinanceSentry.Modules.Risk/Domain/BookSnapshot.cs`, `PolicyViolation.cs`, `RiskVerdict.cs` (per data-model.md "In-memory / transient types")
-- [ ] T009 [P] `RiskRuleSetNotFoundException` in `backend/src/FinanceSentry.Modules.Risk/Domain/Exceptions/RiskRuleSetNotFoundException.cs`
-- [ ] T010 [P] Repository interfaces `IRiskRuleSetRepository`, `IPolicyViolationAckRepository`, `IHoldingSnapshotRepository` in `backend/src/FinanceSentry.Modules.Risk/Domain/Repositories/`
-- [ ] T011 `RiskDbContext` (schema `risk`) in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Persistence/RiskDbContext.cs` mapping the three tables from data-model.md; `RiskDbContextFactory` for design-time migrations (mirrors `WealthDbContextFactory`)
-- [ ] T012 Generate migration `M001_InitialSchema` (risk_rule_sets, policy_violation_acks, holding_snapshots + indexes) via `dotnet ef migrations add M001_InitialSchema --project backend/src/FinanceSentry.Modules.Risk --startup-project backend/src/FinanceSentry.API`
-- [ ] T013 [P] Repository implementations `RiskRuleSetRepository`, `PolicyViolationAckRepository`, `HoldingSnapshotRepository` in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Persistence/Repositories/` (depends on T011)
-- [ ] T014 `RiskModule.cs` at `backend/src/FinanceSentry.Modules.Risk/RiskModule.cs` — DI registration mirroring `WealthModule.cs`/`AlertsModule.cs` (DbContext, repositories, services, controllers)
-- [ ] T015 Register `RiskModule` in `backend/src/FinanceSentry.API/Program.cs`
-- [ ] T016 Extend `IAlertGeneratorService` (Core) with `GeneratePolicyViolationAlertAsync(...)` / `ResolvePolicyViolationAlertAsync(...)` in `backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs`
-- [ ] T017 Add `AlertType.PolicyViolation` const in `backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs`
-- [ ] T018 Implement the two new `IAlertGeneratorService` methods in `backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs` (dedup pattern matching `GenerateLowBalanceAlertAsync`'s existing silence-window approach)
-- [ ] T019 [P] `IBookSnapshotReader`/`BookSnapshotReader` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/` — aggregates `ICryptoHoldingsReader`, `IBrokerageHoldingsReader`, `IBankingAccountsReader` into a `BookSnapshot`, per-source try/catch → `IsStale`/`StaleSources` (mirrors `GetAllocationDriftQueryHandler`'s degrade pattern)
-- [ ] T020 [P] Unit tests for `BookSnapshotReader` in `backend/tests/FinanceSentry.Tests/Risk/BookSnapshotReaderTests.cs` — all-sources-ok, one-source-fails-marks-stale, all-sources-fail
+- [X] T005 [P] `RiskRuleSet` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/RiskRuleSet.cs` per data-model.md (versioned, `IsCurrent`, all fields optional)
+- [X] T006 [P] `PolicyViolationAck` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/PolicyViolationAck.cs`
+- [X] T007 [P] `HoldingSnapshot` entity in `backend/src/FinanceSentry.Modules.Risk/Domain/HoldingSnapshot.cs`
+- [X] T008 [P] Transient records `BookSnapshot`, `BookPosition`, `PolicyViolation`, `RiskVerdict`, `ComplianceReport` in `backend/src/FinanceSentry.Modules.Risk/Domain/BookSnapshot.cs`, `PolicyViolation.cs`, `RiskVerdict.cs` (per data-model.md "In-memory / transient types")
+- [X] T009 [P] `RiskRuleSetNotFoundException` in `backend/src/FinanceSentry.Modules.Risk/Domain/Exceptions/RiskRuleSetNotFoundException.cs`
+- [X] T010 [P] Repository interfaces `IRiskRuleSetRepository`, `IPolicyViolationAckRepository`, `IHoldingSnapshotRepository` in `backend/src/FinanceSentry.Modules.Risk/Domain/Repositories/`
+- [X] T011 `RiskDbContext` (schema `risk`) in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Persistence/RiskDbContext.cs` mapping the three tables from data-model.md; `RiskDbContextFactory` for design-time migrations (mirrors `WealthDbContextFactory`)
+- [X] T012 Generate migration `M001_InitialSchema` (risk_rule_sets, policy_violation_acks, holding_snapshots + indexes) via `dotnet ef migrations add M001_InitialSchema --project backend/src/FinanceSentry.Modules.Risk --startup-project backend/src/FinanceSentry.API`
+- [X] T013 [P] Repository implementations `RiskRuleSetRepository`, `PolicyViolationAckRepository`, `HoldingSnapshotRepository` in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Persistence/Repositories/` (depends on T011)
+- [X] T014 `RiskModule.cs` at `backend/src/FinanceSentry.Modules.Risk/RiskModule.cs` — DI registration mirroring `WealthModule.cs`/`AlertsModule.cs` (DbContext, repositories, services, controllers)
+- [X] T015 Register `RiskModule` in `backend/src/FinanceSentry.API/Program.cs`
+- [X] T016 Extend `IAlertGeneratorService` (Core) with `GeneratePolicyViolationAlertAsync(...)` / `ResolvePolicyViolationAlertAsync(...)` in `backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs`
+- [X] T017 Add `AlertType.PolicyViolation` const in `backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs`
+- [X] T018 Implement the two new `IAlertGeneratorService` methods in `backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs` (dedup pattern matching `GenerateLowBalanceAlertAsync`'s existing silence-window approach)
+- [X] T019 [P] `IBookSnapshotReader`/`BookSnapshotReader` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/` — aggregates `ICryptoHoldingsReader`, `IBrokerageHoldingsReader`, `IBankingAccountsReader` into a `BookSnapshot`, per-source try/catch → `IsStale`/`StaleSources` (mirrors `GetAllocationDriftQueryHandler`'s degrade pattern)
+- [X] T020 [P] Unit tests for `BookSnapshotReader` in `backend/tests/FinanceSentry.Tests/Risk/BookSnapshotReaderTests.cs` — all-sources-ok, one-source-fails-marks-stale, all-sources-fail
 
 **Checkpoint**: Module builds, migrates, is registered, and can read a `BookSnapshot`. Alerts can emit `PolicyViolation`. No user-facing behavior yet — this is the shared floor for US1–US3.
 
@@ -62,28 +62,28 @@
 
 ### Tests for User Story 1 (write first, must fail before implementation)
 
-- [ ] T021 [P] [US1] Unit tests for `RiskEvaluationService.Evaluate(...)` in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — cases: compliant book → empty violations + `info`; single position over `maxPositionWeightPct` → one `PolicyViolation` with correct `ExcessUsd`/`ExcessPct`; `maxSleeveWeightPct` breach; `minCashBufferPct` breach; multiple simultaneous violations; no rule set configured → "no rules on file" result, not an inferred default
-- [ ] T022 [P] [US1] Unit tests for the acknowledgement/worsening-step path in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` (or a sibling `PolicyViolationAckTests.cs`) — seeded 46%-vs-25% scenario produces exactly one alert-worthy violation; after ack, re-run reports `Acknowledged` and does not re-alert; worsening past `WorseningStepPct` flips `Status` to `Worsened` and is alert-worthy again (SC-002)
-- [ ] T023 [P] [US1] Unit tests for the stale-book path in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — a stale source flags the report `IsStale = true` and existing violations do NOT silently auto-clear
-- [ ] T024 [P] [US1] Unit tests for `SaveRiskRuleSetCommand` validation + versioning in `backend/tests/FinanceSentry.Tests/Risk/SaveRiskRuleSetCommandTests.cs` — weight out of `(0,1]` rejected, valid save appends new version and flips `IsCurrent`, all-fields-optional save accepted
-- [ ] T025 [P] [US1] REST contract tests for `RiskController` in `backend/tests/FinanceSentry.Tests/Risk/RiskRulesContractTests.cs` — `GET /risk/rules` (200 + null-safe empty state), `PUT /risk/rules` (200/400 on invalid range), `GET /risk/compliance` (200, schema matches `ComplianceReportDto`), `POST /risk/violations/{id}/acknowledge` (200/404)
+- [X] T021 [P] [US1] Unit tests for `RiskEvaluationService.Evaluate(...)` in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — cases: compliant book → empty violations + `info`; single position over `maxPositionWeightPct` → one `PolicyViolation` with correct `ExcessUsd`/`ExcessPct`; `maxSleeveWeightPct` breach; `minCashBufferPct` breach; multiple simultaneous violations; no rule set configured → "no rules on file" result, not an inferred default
+- [X] T022 [P] [US1] Unit tests for the acknowledgement/worsening-step path in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` (or a sibling `PolicyViolationAckTests.cs`) — seeded 46%-vs-25% scenario produces exactly one alert-worthy violation; after ack, re-run reports `Acknowledged` and does not re-alert; worsening past `WorseningStepPct` flips `Status` to `Worsened` and is alert-worthy again (SC-002)
+- [X] T023 [P] [US1] Unit tests for the stale-book path in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — a stale source flags the report `IsStale = true` and existing violations do NOT silently auto-clear
+- [X] T024 [P] [US1] Unit tests for `SaveRiskRuleSetCommand` validation + versioning in `backend/tests/FinanceSentry.Tests/Risk/SaveRiskRuleSetCommandTests.cs` — weight out of `(0,1]` rejected, valid save appends new version and flips `IsCurrent`, all-fields-optional save accepted
+- [X] T025 [P] [US1] REST contract tests for `RiskController` in `backend/tests/FinanceSentry.Tests/Risk/RiskRulesContractTests.cs` — `GET /risk/rules` (200 + null-safe empty state), `PUT /risk/rules` (200/400 on invalid range), `GET /risk/compliance` (200, schema matches `ComplianceReportDto`), `POST /risk/violations/{id}/acknowledge` (200/404)
 
 ### Implementation for User Story 1
 
-- [ ] T026 [US1] `IRiskEvaluationService`/`RiskEvaluationService` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/IRiskEvaluationService.cs` + `RiskEvaluationService.cs` — pure function `(BookSnapshot, RiskRuleSet?, IReadOnlyList<PolicyViolationAck>) -> ComplianceReport`; implements FR-001 rule checks (position weight, sleeve weight, cash buffer) and the ack/worsening logic from research.md R8 (depends on T021–T024 failing tests, T005–T008)
-- [ ] T027 [US1] `GetRiskRuleSetQuery`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/GetRiskRuleSetQuery.cs` (`IQuery<RiskRuleSetDto?>` via `Core.Cqrs`, per research.md R2)
-- [ ] T028 [US1] `SaveRiskRuleSetCommand`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/SaveRiskRuleSetCommand.cs` — range validation, appends version, flips `IsCurrent` (depends on T024, T013)
-- [ ] T029 [US1] `CheckRiskRulesQuery` (no-proposal branch) + handler in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/CheckRiskRulesQuery.cs` — assembles `BookSnapshot` via `BookSnapshotReader`, loads current `RiskRuleSet` + acks, calls `RiskEvaluationService`, returns `ComplianceReport` (depends on T019, T026, T027)
-- [ ] T030 [US1] `AcknowledgeViolationCommand`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/AcknowledgeViolationCommand.cs` (depends on T013)
-- [ ] T031 [P] [US1] Response DTOs `RiskRuleSetDto`, `ComplianceReportDto` in `backend/src/FinanceSentry.Modules.Risk/API/Responses/`
-- [ ] T032 [US1] `RiskController` in `backend/src/FinanceSentry.Modules.Risk/API/Controllers/RiskController.cs` — `GET/PUT /api/v1/risk/rules`, `GET /api/v1/risk/compliance`, `POST /api/v1/risk/violations/{id}/acknowledge`, all scoped to `User.RequireUserId()` (depends on T025, T027–T030)
-- [ ] T033 [US1] `RiskCheckJob`/`RiskCheckJobScheduler` in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Jobs/` — daily Hangfire recurring job (after-sync), calls `CheckRiskRulesQuery` handler per active user, writes a `HoldingSnapshot` row per position, and calls `IAlertGeneratorService.GeneratePolicyViolationAlertAsync`/`Resolve...` for each violation/clear transition (mirrors `NetWorthSnapshotJob`) (depends on T029, T016–T018)
-- [ ] T034 [US1] Register `RiskCheckJob` recurring schedule in `backend/src/FinanceSentry.API/Program.cs` (`RecurringJob.AddOrUpdate`, daily, after the existing sync jobs)
-- [ ] T035 [US1] `GetRiskRulesTool` MCP tool in `backend/src/FinanceSentry.Mcp/Tools/GetRiskRulesTool.cs` (`get_risk_rules`, mirrors `GetIpsTool`) (depends on T027)
-- [ ] T036 [US1] `SaveRiskRulesTool` MCP tool in `backend/src/FinanceSentry.Mcp/Tools/SaveRiskRulesTool.cs` (`save_risk_rules`, mirrors `SaveThesisTool`) (depends on T028)
-- [ ] T037 [US1] `CheckRiskRulesTool` MCP tool (no-arg branch only for this story) in `backend/src/FinanceSentry.Mcp/Tools/CheckRiskRulesTool.cs` (`check_risk_rules`, mirrors `GetAllocationVsTargetTool`) (depends on T029)
-- [ ] T038 [US1] Update `ToolNameContractTests.AgreedToolSurface` in `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` to add `get_risk_rules`, `save_risk_rules`, `check_risk_rules` (27 → 30)
-- [ ] T039 Bump backend version (minor) in `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` per constitution's Versioning Policy
+- [X] T026 [US1] `IRiskEvaluationService`/`RiskEvaluationService` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/IRiskEvaluationService.cs` + `RiskEvaluationService.cs` — pure function `(BookSnapshot, RiskRuleSet?, IReadOnlyList<PolicyViolationAck>) -> ComplianceReport`; implements FR-001 rule checks (position weight, sleeve weight, cash buffer) and the ack/worsening logic from research.md R8 (depends on T021–T024 failing tests, T005–T008)
+- [X] T027 [US1] `GetRiskRuleSetQuery`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/GetRiskRuleSetQuery.cs` (`IQuery<RiskRuleSetDto?>` via `Core.Cqrs`, per research.md R2)
+- [X] T028 [US1] `SaveRiskRuleSetCommand`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/SaveRiskRuleSetCommand.cs` — range validation, appends version, flips `IsCurrent` (depends on T024, T013)
+- [X] T029 [US1] `CheckRiskRulesQuery` (no-proposal branch) + handler in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/CheckRiskRulesQuery.cs` — assembles `BookSnapshot` via `BookSnapshotReader`, loads current `RiskRuleSet` + acks, calls `RiskEvaluationService`, returns `ComplianceReport` (depends on T019, T026, T027)
+- [X] T030 [US1] `AcknowledgeViolationCommand`/handler in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/AcknowledgeViolationCommand.cs` (depends on T013)
+- [X] T031 [P] [US1] Response DTOs `RiskRuleSetDto`, `ComplianceReportDto` in `backend/src/FinanceSentry.Modules.Risk/API/Responses/`
+- [X] T032 [US1] `RiskController` in `backend/src/FinanceSentry.Modules.Risk/API/Controllers/RiskController.cs` — `GET/PUT /api/v1/risk/rules`, `GET /api/v1/risk/compliance`, `POST /api/v1/risk/violations/{id}/acknowledge`, all scoped to `User.RequireUserId()` (depends on T025, T027–T030)
+- [X] T033 [US1] `RiskCheckJob`/`RiskCheckJobScheduler` in `backend/src/FinanceSentry.Modules.Risk/Infrastructure/Jobs/` — daily Hangfire recurring job (after-sync), calls `CheckRiskRulesQuery` handler per active user, writes a `HoldingSnapshot` row per position, and calls `IAlertGeneratorService.GeneratePolicyViolationAlertAsync`/`Resolve...` for each violation/clear transition (mirrors `NetWorthSnapshotJob`) (depends on T029, T016–T018)
+- [X] T034 [US1] Register `RiskCheckJob` recurring schedule in `backend/src/FinanceSentry.API/Program.cs` (`RecurringJob.AddOrUpdate`, daily, after the existing sync jobs)
+- [X] T035 [US1] `GetRiskRulesTool` MCP tool in `backend/src/FinanceSentry.Mcp/Tools/GetRiskRulesTool.cs` (`get_risk_rules`, mirrors `GetIpsTool`) (depends on T027)
+- [X] T036 [US1] `SaveRiskRulesTool` MCP tool in `backend/src/FinanceSentry.Mcp/Tools/SaveRiskRulesTool.cs` (`save_risk_rules`, mirrors `SaveThesisTool`) (depends on T028)
+- [X] T037 [US1] `CheckRiskRulesTool` MCP tool (no-arg branch only for this story) in `backend/src/FinanceSentry.Mcp/Tools/CheckRiskRulesTool.cs` (`check_risk_rules`, mirrors `GetAllocationVsTargetTool`) (depends on T029)
+- [X] T038 [US1] Update `ToolNameContractTests.AgreedToolSurface` in `backend/tests/FinanceSentry.Mcp.Tests/ContractTests/ToolNameContractTests.cs` to add `get_risk_rules`, `save_risk_rules`, `check_risk_rules` (27 → 30)
+- [X] T039 Bump backend version (minor) in `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` per constitution's Versioning Policy
 
 **Checkpoint**: US1 is independently shippable — daily check runs, violations alert once, acknowledgement suppresses re-alerts, `get_risk_rules`/`save_risk_rules`/`check_risk_rules()` (report mode) work end-to-end. This is the MVP.
 
@@ -97,18 +97,18 @@
 
 ### Tests for User Story 2
 
-- [ ] T040 [P] [US2] Unit tests for the proposal-evaluation branch of `RiskEvaluationService` (or a dedicated `RiskEvaluationService.EvaluateProposal(...)`) in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — proposal within limits → `Allowed` + headroom; proposal breaching `maxPositionWeightPct` → `Refused` + `maxCompliantSizeUsd` computed correctly; proposal breaching `minCashBufferPct` → `Refused`; proposal breaching `maxNewPositionPct` → `Refused`; `TurnoverBudgetPerQuarter` already at cap → `Refused(turnover)` per FR-001b
-- [ ] T041 [P] [US2] Unit tests for override recording in `backend/tests/FinanceSentry.Tests/Risk/OverrideSignalTests.cs` — an override flag on a `Refused` verdict proceeds but MUST write a record (signal/Alert) that is queryable afterwards (FR-007, SC-004)
-- [ ] T042 [P] [US2] REST/MCP contract test extension in `backend/tests/FinanceSentry.Tests/Risk/RiskRulesContractTests.cs` — `check_risk_rules`/`POST /risk/compliance/check` request schema with `ticker`+`proposedUsd`+optional `override` flag, response schema for both `Allowed` and `Refused`
+- [X] T040 [P] [US2] Unit tests for the proposal-evaluation branch of `RiskEvaluationService` (or a dedicated `RiskEvaluationService.EvaluateProposal(...)`) in `backend/tests/FinanceSentry.Tests/Risk/RiskEvaluationServiceTests.cs` — proposal within limits → `Allowed` + headroom; proposal breaching `maxPositionWeightPct` → `Refused` + `maxCompliantSizeUsd` computed correctly; proposal breaching `minCashBufferPct` → `Refused`; proposal breaching `maxNewPositionPct` → `Refused`; `TurnoverBudgetPerQuarter` already at cap → `Refused(turnover)` per FR-001b
+- [X] T041 [P] [US2] Unit tests for override recording in `backend/tests/FinanceSentry.Tests/Risk/OverrideSignalTests.cs` — an override flag on a `Refused` verdict proceeds but MUST write a record (signal/Alert) that is queryable afterwards (FR-007, SC-004)
+- [X] T042 [P] [US2] REST/MCP contract test extension in `backend/tests/FinanceSentry.Tests/Risk/RiskRulesContractTests.cs` — `check_risk_rules`/`POST /risk/compliance/check` request schema with `ticker`+`proposedUsd`+optional `override` flag, response schema for both `Allowed` and `Refused`
 
 ### Implementation for User Story 2
 
-- [ ] T043 [US2] Extend `CheckRiskRulesQuery` (or add `EvaluateRiskProposalQuery`) to accept an optional `(Ticker, ProposedUsd, Override)` payload in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/CheckRiskRulesQuery.cs`, returning `RiskVerdictDto` when a proposal is present (depends on T029, T040)
-- [ ] T044 [US2] Extend `RiskEvaluationService` with proposal-aware evaluation (max compliant size calculation, turnover-budget check via `ITurnoverTracker` from Phase 5 — stub/interface only if Phase 5 not yet done, see dependency note) in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskEvaluationService.cs`
-- [ ] T045 [US2] Override recording: extend `AcknowledgeViolationCommand`-adjacent flow or add `RecordRiskOverrideCommand` in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/` — writes an Alert (`AlertType.PolicyViolation`, severity Info, message noting "override applied") via `IAlertGeneratorService` (depends on T041, T016–T018)
-- [ ] T046 [P] [US2] `RiskVerdictDto` in `backend/src/FinanceSentry.Modules.Risk/API/Responses/RiskVerdictDto.cs`
-- [ ] T047 [US2] Extend `RiskController` with `POST /api/v1/risk/compliance/check` accepting the proposal payload, or fold into the existing `GET /risk/compliance` as an optional body — match quickstart.md's example (depends on T043)
-- [ ] T048 [US2] Extend `CheckRiskRulesTool` MCP tool to accept optional `(ticker, amount, override)` parameters and return `RiskVerdictDto`-shaped result (depends on T037, T043)
+- [X] T043 [US2] Extend `CheckRiskRulesQuery` (or add `EvaluateRiskProposalQuery`) to accept an optional `(Ticker, ProposedUsd, Override)` payload in `backend/src/FinanceSentry.Modules.Risk/Application/Queries/CheckRiskRulesQuery.cs`, returning `RiskVerdictDto` when a proposal is present (depends on T029, T040)
+- [X] T044 [US2] Extend `RiskEvaluationService` with proposal-aware evaluation (max compliant size calculation, turnover-budget check via `ITurnoverTracker` from Phase 5 — stub/interface only if Phase 5 not yet done, see dependency note) in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskEvaluationService.cs`
+- [X] T045 [US2] Override recording: extend `AcknowledgeViolationCommand`-adjacent flow or add `RecordRiskOverrideCommand` in `backend/src/FinanceSentry.Modules.Risk/Application/Commands/` — writes an Alert (`AlertType.PolicyViolation`, severity Info, message noting "override applied") via `IAlertGeneratorService` (depends on T041, T016–T018)
+- [X] T046 [P] [US2] `RiskVerdictDto` in `backend/src/FinanceSentry.Modules.Risk/API/Responses/RiskVerdictDto.cs`
+- [X] T047 [US2] Extend `RiskController` with `POST /api/v1/risk/compliance/check` accepting the proposal payload, or fold into the existing `GET /risk/compliance` as an optional body — match quickstart.md's example (depends on T043)
+- [X] T048 [US2] Extend `CheckRiskRulesTool` MCP tool to accept optional `(ticker, amount, override)` parameters and return `RiskVerdictDto`-shaped result (depends on T037, T043)
 
 **Checkpoint**: US2 shippable independently on top of US1 — `check_risk_rules(ticker, amount)` is a real, tested gate. 019's `promote_candidate` can now call it (contract test with 019 deferred until 019 ships, per SC-003).
 
@@ -122,15 +122,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T049 [P] [US3] Unit tests for `AddToBrokenThesisDetector` (or a method on `RiskEvaluationService`) in `backend/tests/FinanceSentry.Tests/Risk/AddToBrokenThesisTests.cs` — quantity increase after `BrokenAt` → flagged; quantity increase before `BrokenAt` → not flagged; no broken thesis for the symbol → not flagged; multiple increases after break → flagged once per check run (dedup via existing Alert dedup, not re-invented here)
-- [ ] T050 [P] [US3] Unit tests for `TurnoverTracker` in `backend/tests/FinanceSentry.Tests/Risk/TurnoverTrackerTests.cs` — counts distinct quantity-increase events per rolling quarter from `HoldingSnapshot` deltas; quarter rollover resets the count; a decrease is never counted as a trade toward the budget (FR-001b is about discretionary *adds*, per the Barber–Odean framing in ROADMAP)
+- [X] T049 [P] [US3] Unit tests for `AddToBrokenThesisDetector` (or a method on `RiskEvaluationService`) in `backend/tests/FinanceSentry.Tests/Risk/AddToBrokenThesisTests.cs` — quantity increase after `BrokenAt` → flagged; quantity increase before `BrokenAt` → not flagged; no broken thesis for the symbol → not flagged; multiple increases after break → flagged once per check run (dedup via existing Alert dedup, not re-invented here)
+- [X] T050 [P] [US3] Unit tests for `TurnoverTracker` in `backend/tests/FinanceSentry.Tests/Risk/TurnoverTrackerTests.cs` — counts distinct quantity-increase events per rolling quarter from `HoldingSnapshot` deltas; quarter rollover resets the count; a decrease is never counted as a trade toward the budget (FR-001b is about discretionary *adds*, per the Barber–Odean framing in ROADMAP)
 
 ### Implementation for User Story 3
 
-- [ ] T051 [US3] `ITurnoverTracker`/`TurnoverTracker` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/ITurnoverTracker.cs` + `TurnoverTracker.cs` — pure function over `IReadOnlyList<HoldingSnapshot>` (depends on T050, T007)
-- [ ] T052 [US3] Wire `TurnoverTracker` into `RiskEvaluationService`'s proposal path (T044) so `TurnoverBudgetPerQuarter` breaches actually refuse — this task supersedes the stub from T044 if it landed first
-- [ ] T053 [US3] Add-to-broken-thesis detection logic in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskEvaluationService.cs` (or extracted `AddToBrokenThesisDetector.cs`) — reads `IThesisRepository.FindByTickerAsync` (Research module, read-only per research.md R3) + latest two `HoldingSnapshot` rows for the symbol (depends on T049, T004)
-- [ ] T054 [US3] Wire the broken-thesis flag into `RiskCheckJob` (T033) — call the detector per position with a broken thesis, emit `Alert` (reuse `AlertType.PolicyViolation` with `RuleKey = "AddToBrokenThesis"`, or a distinct sub-type string — decide during implementation, document in code comment) via `IAlertGeneratorService`
+- [X] T051 [US3] `ITurnoverTracker`/`TurnoverTracker` in `backend/src/FinanceSentry.Modules.Risk/Application/Services/ITurnoverTracker.cs` + `TurnoverTracker.cs` — pure function over `IReadOnlyList<HoldingSnapshot>` (depends on T050, T007)
+- [X] T052 [US3] Wire `TurnoverTracker` into `RiskEvaluationService`'s proposal path (T044) so `TurnoverBudgetPerQuarter` breaches actually refuse — this task supersedes the stub from T044 if it landed first
+- [X] T053 [US3] Add-to-broken-thesis detection logic in `backend/src/FinanceSentry.Modules.Risk/Application/Services/RiskEvaluationService.cs` (or extracted `AddToBrokenThesisDetector.cs`) — reads `IThesisRepository.FindByTickerAsync` (Research module, read-only per research.md R3) + latest two `HoldingSnapshot` rows for the symbol (depends on T049, T004)
+- [X] T054 [US3] Wire the broken-thesis flag into `RiskCheckJob` (T033) — call the detector per position with a broken thesis, emit `Alert` (reuse `AlertType.PolicyViolation` with `RuleKey = "AddToBrokenThesis"`, or a distinct sub-type string — decide during implementation, document in code comment) via `IAlertGeneratorService`
 
 **Checkpoint**: US3 shippable independently on top of Foundational (does not require US1/US2, only the shared `HoldingSnapshot`/`IThesisRepository` plumbing) — though in practice it ships alongside US1 since both fire from the same daily job.
 
@@ -140,10 +140,10 @@
 
 **Purpose**: Final gates before merge — not story-specific.
 
-- [ ] T055 [P] Run `dotnet build backend/` and resolve all warnings across every new/modified file (constitution Principle II gate)
-- [ ] T056 [P] Run full `backend/tests/FinanceSentry.Tests` and `backend/tests/FinanceSentry.Mcp.Tests` suites — all green, coverage on `RiskEvaluationService`/`TurnoverTracker` well above the 80% target given they're pure functions
-- [ ] T057 Update `specs/ROADMAP.md`'s 022 status row from "Spec drafted" to "Implemented" once merged (small doc task, not a code change)
-- [ ] T058 Manual verification per `quickstart.md` end-to-end against the real test user's book (the actual ~46% DRAM position) — confirms SC-002 against real data, not just seeded fixtures
+- [X] T055 [P] Run `dotnet build backend/` and resolve all warnings across every new/modified file (constitution Principle II gate)
+- [X] T056 [P] Run full `backend/tests/FinanceSentry.Tests` and `backend/tests/FinanceSentry.Mcp.Tests` suites — all green, coverage on `RiskEvaluationService`/`TurnoverTracker` well above the 80% target given they're pure functions
+- [X] T057 Update `specs/ROADMAP.md`'s 022 status row from "Spec drafted" to "Implemented" once merged (small doc task, not a code change)
+- [X] T058 Manual verification per `quickstart.md` end-to-end against the real test user's book (the actual ~46% DRAM position) — confirms SC-002 against real data, not just seeded fixtures
 
 ---
 

--- a/specs/023-observability-stack/spec.md
+++ b/specs/023-observability-stack/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `023-observability-stack`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Observability stack: OpenTelemetry metrics in the ASP.NET Core API exposed via /metrics, Prometheus + Grafana + Loki containers on the VPS, Serilog shipping to Loki, dashboards for sync jobs, HTTP latency/errors, Hangfire job health"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/024-data-retention/spec.md
+++ b/specs/024-data-retention/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `024-data-retention`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Data retention and rotation: bounded growth for logs, Hangfire storage, and domain tables (audit events, daily bars, snapshots, scores) via per-module purge/downsample policies, plus automated off-host database backups with restore verification"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/025-edge-gateway/spec.md
+++ b/specs/025-edge-gateway/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `025-edge-gateway`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Edge gateway: single reverse-proxy entrypoint in front of frontend, API and MCP with routing, TLS termination, rate limiting and health-based routing"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/026-event-bus-outbox/spec.md
+++ b/specs/026-event-bus-outbox/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `026-event-bus-outbox`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "In-monolith event bus: modules publish and consume domain events through a message broker with a transactional outbox, replacing direct cross-module calls for event-shaped interactions (e.g. alerts reacting to completed transaction syncs), with idempotent consumers and dead-letter handling"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/027-k8s-migration/spec.md
+++ b/specs/027-k8s-migration/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `027-k8s-migration`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Kubernetes production migration: replace docker-compose production deployment with a lightweight single-node Kubernetes cluster on the VPS — declarative manifests, health probes, rolling zero-downtime deploys, secrets management, and the ability to scale API replicas"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/028-extract-market-data-service/spec.md
+++ b/specs/028-extract-market-data-service/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `028-extract-market-data-service`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Extract market data ingestion (radar daily bars and signals) into a standalone service: own deployable, own database schema, consumes and publishes domain events over the message bus, synchronous queries stay available to the monolith, deployed behind the gateway on the cluster"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/029-grpc-internal-contract/spec.md
+++ b/specs/029-grpc-internal-contract/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `029-grpc-internal-contract`
 **Created**: 2026-07-09
-**Status**: Draft
+**Status**: Roadmap — spec only, not yet planned or implemented
 **Input**: User description: "Convert one internal synchronous service-to-service call (monolith to market-data service query) to a contract-first binary RPC protocol, coexisting with the HTTP contract, to practice schema-first internal APIs, deadlines, and generated typed clients"
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/030-companion-data-layer/spec.md
+++ b/specs/030-companion-data-layer/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `030-companion-data-layer`
 **Created**: 2026-07-21
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Companion-mode data layer for Ledger: analyst actions ingestion (upgrades/downgrades/price targets from free public sources, market-wide universe), valuation snapshot MCP tool (fundamentals vs 5-year history and peers), and market-wide news ingestion breadth with source-per-thesis registration (e.g. TrendForce for the DRAM thesis). Backend + MCP only; consumed by the Ledger OpenClaw agent for a weekly advisor letter and conversational use; ideas flow into the existing opportunity candidates pipeline."
 
 ## Context


### PR DESCRIPTION
## Why
Audit finding: **every spec read `Status: Draft`** — including features live in production (bank-sync, auth, alerts, …). A spec told you nothing about whether it shipped, which is exactly what made feature 026 a "wait, this was never built?" surprise.

## What
Corrected the `Status:` line in every spec to verified reality (no separate index file — the specs stay the single source of truth):
- **Implemented** (verified live code): 001, 003–015, 017–020, 022, 030
- **Roadmap** (spec-only, intentional — the production-practice track, batch-created in `docs(roadmap)`): 023, 024, 025, 026, 027, 028, 029
- **Superseded**: 002 (delivered under 008/009/010 + the research suite)

Also ticked the task boxes for **017–020, 022** — these are shipped and running, but their `tasks.md` still showed `0/N` checked (implemented via the Qwen flow; boxes were never maintained). The stale checkboxes were the other misleading signal.

## Not changed
Residual open tasks in otherwise-shipped features (001, 007, 008, 010, 011, 014, 030) are left as-is — they represent genuine deferred sub-items, not reconciled away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)