### PR TITLE
chore: 031 → Implemented; backlog adds 033/034

### DIFF
--- a/specs/031-companion-notifications/spec.md
+++ b/specs/031-companion-notifications/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `031-companion-notifications`
 **Created**: 2026-07-22
-**Status**: In planning
+**Status**: Implemented
 **Input**: User description: "Companion notification modes + event-driven push. Finance Sentry owns the policy (materiality, mode preference, dedup/rate-limit/quiet-hours) and dispatches material events to the companion agent; the agent triages and delivers. No new push channels in FS."
 
 ## Overview

--- a/specs/ROADMAP.md
+++ b/specs/ROADMAP.md
@@ -11,7 +11,8 @@
 
 | Spec | Kind | Depends on | Note |
 |---|---|---|---|
-| `031-companion-notifications` | Feature | — | In review (PR #294) — FS-owned notification modes + event push |
+| `033-analytics-query-tool` | Feature | — | **Planned — ready to implement.** Guarded read-only query tool (escape-hatch for the long tail; relieves tool sprawl) |
+| `034-research-rag` | Feature | — | Spec + **research done**; ready to plan/implement. Semantic search over the text corpus (news/filings/notes); complements 033 (prose vs numbers) |
 | `032-agent-as-code` | Architecture | 031 (proves the pattern) | Draft — agent definition in the repo, CI-deployed to the runtime |
 | `023-observability-stack` | Platform | — | Don't orchestrate what you can't observe — do this rung first |
 | `024-data-retention` | Platform | 023 | Retention policies + verified off-host backups |


### PR DESCRIPTION
Housekeeping per the definition-of-done convention: 031 shipped in #294 so its Status flips to Implemented, and the ROADMAP backlog is updated (drop 031, add 033 analytics-query-tool [planned, ready to build] and 034 research-rag [spec + research done]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)