### PR TITLE
fix(bank-sync): categorize TrueLayer transactions from description text

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/CategoryMapping/ICategoryResolver.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/CategoryMapping/ICategoryResolver.cs
@@ -18,6 +18,13 @@ public interface ICategoryResolver
     /// </summary>
     string ResolvePlaidPrimary(string? primary);
 
+    /// <summary>
+    /// Resolves a category from a free-text transaction description via the runtime-editable
+    /// <c>merchant_keywords</c> table (longest keyword wins). Used as a fallback for providers
+    /// that return no MCC or category name. Returns UNCATEGORIZED when nothing matches.
+    /// </summary>
+    string ResolveDescription(string? description);
+
     /// <summary>Drops the in-memory cache so the next resolve reloads from the database.</summary>
     void Refresh();
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransactionRecategorizationService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransactionRecategorizationService.cs
@@ -108,8 +108,11 @@ public class TransactionRecategorizationService(
     private async Task<int> ReFetchMissingSignalAsync(
         IReadOnlyList<BankAccount> userAccounts, IReadOnlyList<Transaction> txns, CancellationToken ct)
     {
+        // Rows still lacking any structured signal AND not rescued by description matching in
+        // pass 1. Description-matched rows already carry a real category, so skip the re-fetch.
         var missingByAccount = txns
             .Where(t => t.Mcc is null && string.IsNullOrWhiteSpace(t.SourceCategory))
+            .Where(t => t.MerchantCategory is null || t.MerchantCategory == CategoryKeys.Uncategorized)
             .GroupBy(t => t.AccountId)
             .ToDictionary(g => g.Key, g => g.ToList());
 
@@ -156,7 +159,11 @@ public class TransactionRecategorizationService(
             return _categoryResolver.ResolveMcc(t.Mcc);
         if (!string.IsNullOrWhiteSpace(t.SourceCategory))
             return _categoryResolver.ResolvePlaidPrimary(t.SourceCategory);
-        return null;
+
+        // No structured signal (e.g. TrueLayer): recover from the free-text description.
+        // A miss returns null so the row stays eligible for a provider re-fetch (pass 2).
+        var byDescription = _categoryResolver.ResolveDescription(t.Description);
+        return byDescription == CategoryKeys.Uncategorized ? null : byDescription;
     }
 
     private async Task<IReadOnlyList<TransactionCandidate>> FetchCandidatesAsync(

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/MerchantKeyword.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/MerchantKeyword.cs
@@ -1,0 +1,26 @@
+namespace FinanceSentry.Modules.BankSync.Domain;
+
+/// <summary>
+/// Maps a lowercase substring of a transaction description to a canonical
+/// <see cref="Category"/> key.
+///
+/// Some providers (notably TrueLayer for many EU banks) return no MCC and no category
+/// name — the only signal is the free-text description ("Lidl Ireland Ltd", "amazon.ie").
+/// This bridge table lets us recover a category from that text. It is the same pattern as
+/// <see cref="MccCategory"/>: the taxonomy (Plaid PFC) is external; only this glue is ours,
+/// and every row is editable at runtime so a manual correction wins over re-seeding.
+/// </summary>
+public class MerchantKeyword
+{
+    /// <summary>Surrogate primary key.</summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Lowercase substring matched (case-insensitively) against the transaction description.
+    /// Longer keywords are tried first so "uber eats" wins over "uber".
+    /// </summary>
+    public string Keyword { get; set; } = string.Empty;
+
+    /// <summary>FK to <see cref="Category.Key"/>.</summary>
+    public string CategoryKey { get; set; } = string.Empty;
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategoryResolver.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategoryResolver.cs
@@ -19,6 +19,10 @@ public sealed class CategoryResolver(IServiceScopeFactory scopeFactory) : ICateg
     private IReadOnlyDictionary<int, string>? _mccToKey;
     private IReadOnlySet<string>? _validKeys;
 
+    // Ordered longest-keyword-first so a more specific match (e.g. "uber eats") wins over a
+    // shorter substring ("uber"). Keywords are stored lowercase for case-insensitive matching.
+    private IReadOnlyList<(string Keyword, string CategoryKey)>? _merchantKeywords;
+
     public string ResolveMcc(int? mcc)
     {
         EnsureLoaded();
@@ -38,23 +42,30 @@ public sealed class CategoryResolver(IServiceScopeFactory scopeFactory) : ICateg
         return _validKeys!.Contains(normalized) ? normalized : CategoryKeys.Uncategorized;
     }
 
+    public string ResolveDescription(string? description)
+    {
+        EnsureLoaded();
+        return MerchantKeywordMatcher.Resolve(description, _merchantKeywords!);
+    }
+
     public void Refresh()
     {
         lock (_gate)
         {
             _mccToKey = null;
             _validKeys = null;
+            _merchantKeywords = null;
         }
     }
 
     private void EnsureLoaded()
     {
-        if (_mccToKey is not null && _validKeys is not null)
+        if (_mccToKey is not null && _validKeys is not null && _merchantKeywords is not null)
             return;
 
         lock (_gate)
         {
-            if (_mccToKey is not null && _validKeys is not null)
+            if (_mccToKey is not null && _validKeys is not null && _merchantKeywords is not null)
                 return;
 
             using var scope = _scopeFactory.CreateScope();
@@ -66,6 +77,12 @@ public sealed class CategoryResolver(IServiceScopeFactory scopeFactory) : ICateg
 
             _mccToKey = db.MccCategories.AsNoTracking()
                 .ToDictionary(m => m.Mcc, m => m.CategoryKey);
+
+            var rawKeywords = db.MerchantKeywords.AsNoTracking()
+                .Select(m => new { m.Keyword, m.CategoryKey })
+                .AsEnumerable()
+                .Select(m => (m.Keyword, m.CategoryKey));
+            _merchantKeywords = MerchantKeywordMatcher.Prepare(rawKeywords);
         }
     }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategorySeeder.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategorySeeder.cs
@@ -20,6 +20,22 @@ public static class CategorySeeder
     {
         SeedCategories(db);
         SeedMccCategories(db);
+        SeedMerchantKeywords(db);
+    }
+
+    private static void SeedMerchantKeywords(BankSyncDbContext db)
+    {
+        var existing = db.MerchantKeywords.Select(m => m.Keyword).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var toAdd = MerchantKeywordSeedData.Keywords
+            .Where(k => !existing.Contains(k.Keyword))
+            .Select(k => new MerchantKeyword { Keyword = k.Keyword, CategoryKey = k.CategoryKey })
+            .ToList();
+
+        if (toAdd.Count == 0)
+            return;
+
+        db.MerchantKeywords.AddRange(toAdd);
+        db.SaveChanges();
     }
 
     private static void SeedCategories(BankSyncDbContext db)

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordMatcher.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordMatcher.cs
@@ -1,0 +1,41 @@
+namespace FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
+
+using FinanceSentry.Modules.BankSync.Domain;
+
+/// <summary>
+/// Pure matching logic shared by <see cref="CategoryResolver"/> and its tests: matches a
+/// free-text description (case-insensitively) against a keyword list, longest keyword first
+/// so a more specific match ("uber eats") wins over a shorter substring ("uber").
+/// </summary>
+public static class MerchantKeywordMatcher
+{
+    /// <summary>
+    /// Orders keywords longest-first and lowercases them for matching. Call once at load time.
+    /// </summary>
+    public static IReadOnlyList<(string Keyword, string CategoryKey)> Prepare(
+        IEnumerable<(string Keyword, string CategoryKey)> keywords)
+        => keywords
+            .Select(k => (Keyword: k.Keyword.ToLowerInvariant(), k.CategoryKey))
+            .OrderByDescending(k => k.Keyword.Length)
+            .ToList();
+
+    /// <summary>
+    /// Returns the category of the first (longest) keyword contained in the description,
+    /// or UNCATEGORIZED when none match. <paramref name="prepared"/> must come from
+    /// <see cref="Prepare"/> (lowercased, longest-first).
+    /// </summary>
+    public static string Resolve(
+        string? description, IReadOnlyList<(string Keyword, string CategoryKey)> prepared)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return CategoryKeys.Uncategorized;
+
+        var haystack = description.ToLowerInvariant();
+        foreach (var (keyword, categoryKey) in prepared)
+        {
+            if (haystack.Contains(keyword, StringComparison.Ordinal))
+                return categoryKey;
+        }
+        return CategoryKeys.Uncategorized;
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
@@ -1,0 +1,178 @@
+namespace FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
+
+using FinanceSentry.Modules.BankSync.Domain;
+
+/// <summary>
+/// Seed rows for the <c>merchant_keywords</c> bridge table — a lowercase description
+/// substring mapped to a Plaid PFC primary key. Used as a fallback for providers that
+/// return no structured category (e.g. TrueLayer for many EU banks), where the merchant
+/// name is only present inside the free-text description.
+///
+/// This is a starter set, not an authority: rows are runtime-editable, longer keywords win
+/// over shorter ones, and the canonical taxonomy remains Plaid's (see <see cref="CategoryKeys"/>).
+/// </summary>
+public static class MerchantKeywordSeedData
+{
+    public static readonly IReadOnlyList<(string Keyword, string CategoryKey)> Keywords =
+    [
+        // --- Groceries & supermarkets (FOOD_AND_DRINK) ---
+        ("lidl", CategoryKeys.FoodAndDrink),
+        ("tesco", CategoryKeys.FoodAndDrink),
+        ("aldi", CategoryKeys.FoodAndDrink),
+        ("supervalu", CategoryKeys.FoodAndDrink),
+        ("dunnes", CategoryKeys.FoodAndDrink),
+        ("centra", CategoryKeys.FoodAndDrink),
+        ("eurospar", CategoryKeys.FoodAndDrink),
+        ("spar", CategoryKeys.FoodAndDrink),
+        ("costcutter", CategoryKeys.FoodAndDrink),
+        ("iceland", CategoryKeys.FoodAndDrink),
+        ("marks & spencer", CategoryKeys.FoodAndDrink),
+        ("m&s", CategoryKeys.FoodAndDrink),
+        ("grocery", CategoryKeys.FoodAndDrink),
+        ("supermarket", CategoryKeys.FoodAndDrink),
+
+        // --- Restaurants, cafes, takeaway (FOOD_AND_DRINK) ---
+        ("mcdonald", CategoryKeys.FoodAndDrink),
+        ("burger king", CategoryKeys.FoodAndDrink),
+        ("kfc", CategoryKeys.FoodAndDrink),
+        ("subway", CategoryKeys.FoodAndDrink),
+        ("starbucks", CategoryKeys.FoodAndDrink),
+        ("costa coffee", CategoryKeys.FoodAndDrink),
+        ("insomnia", CategoryKeys.FoodAndDrink),
+        ("coffee", CategoryKeys.FoodAndDrink),
+        ("restaurant", CategoryKeys.FoodAndDrink),
+        ("pizza", CategoryKeys.FoodAndDrink),
+        ("domino", CategoryKeys.FoodAndDrink),
+        ("nando", CategoryKeys.FoodAndDrink),
+        ("thai", CategoryKeys.FoodAndDrink),
+        ("sushi", CategoryKeys.FoodAndDrink),
+        ("zakura", CategoryKeys.FoodAndDrink),
+        ("papi chulo", CategoryKeys.FoodAndDrink),
+        ("camile", CategoryKeys.FoodAndDrink),
+        ("deliveroo", CategoryKeys.FoodAndDrink),
+        ("just eat", CategoryKeys.FoodAndDrink),
+        ("uber eats", CategoryKeys.FoodAndDrink),
+        ("bar ", CategoryKeys.FoodAndDrink),
+        ("pub", CategoryKeys.FoodAndDrink),
+
+        // --- General merchandise / shopping (GENERAL_MERCHANDISE) ---
+        ("amazon", CategoryKeys.GeneralMerchandise),
+        ("ebay", CategoryKeys.GeneralMerchandise),
+        ("aliexpress", CategoryKeys.GeneralMerchandise),
+        ("shein", CategoryKeys.GeneralMerchandise),
+        ("temu", CategoryKeys.GeneralMerchandise),
+        ("argos", CategoryKeys.GeneralMerchandise),
+        ("penneys", CategoryKeys.GeneralMerchandise),
+        ("primark", CategoryKeys.GeneralMerchandise),
+        ("zara", CategoryKeys.GeneralMerchandise),
+        ("h&m", CategoryKeys.GeneralMerchandise),
+        ("tk maxx", CategoryKeys.GeneralMerchandise),
+        ("currys", CategoryKeys.GeneralMerchandise),
+        ("harvey norman", CategoryKeys.GeneralMerchandise),
+        ("smyths", CategoryKeys.GeneralMerchandise),
+        ("decathlon", CategoryKeys.GeneralMerchandise),
+        ("ikea", CategoryKeys.GeneralMerchandise),
+
+        // --- Transport & fuel (TRANSPORTATION) ---
+        ("leap card", CategoryKeys.Transportation),
+        ("dublin bus", CategoryKeys.Transportation),
+        ("bus eireann", CategoryKeys.Transportation),
+        ("irish rail", CategoryKeys.Transportation),
+        ("luas", CategoryKeys.Transportation),
+        ("free now", CategoryKeys.Transportation),
+        ("freenow", CategoryKeys.Transportation),
+        ("bolt.eu", CategoryKeys.Transportation),
+        ("uber", CategoryKeys.Transportation),
+        ("taxi", CategoryKeys.Transportation),
+        ("circle k", CategoryKeys.Transportation),
+        ("applegreen", CategoryKeys.Transportation),
+        ("maxol", CategoryKeys.Transportation),
+        ("texaco", CategoryKeys.Transportation),
+        ("esso", CategoryKeys.Transportation),
+        ("petrol", CategoryKeys.Transportation),
+        ("fuel", CategoryKeys.Transportation),
+        ("parking", CategoryKeys.Transportation),
+        ("eflow", CategoryKeys.Transportation),
+        ("toll", CategoryKeys.Transportation),
+
+        // --- Travel (TRAVEL) ---
+        ("booking.com", CategoryKeys.Travel),
+        ("airbnb", CategoryKeys.Travel),
+        ("ryanair", CategoryKeys.Travel),
+        ("aer lingus", CategoryKeys.Travel),
+        ("expedia", CategoryKeys.Travel),
+        ("hotel", CategoryKeys.Travel),
+        ("hostel", CategoryKeys.Travel),
+
+        // --- Bills & utilities / telecom / hosting (RENT_AND_UTILITIES) ---
+        ("electric ireland", CategoryKeys.RentAndUtilities),
+        ("bord gais", CategoryKeys.RentAndUtilities),
+        ("sse airtricity", CategoryKeys.RentAndUtilities),
+        ("virgin media", CategoryKeys.RentAndUtilities),
+        ("vodafone", CategoryKeys.RentAndUtilities),
+        ("gomo", CategoryKeys.RentAndUtilities),
+        ("eir ", CategoryKeys.RentAndUtilities),
+        ("three ", CategoryKeys.RentAndUtilities),
+        ("sky ", CategoryKeys.RentAndUtilities),
+
+        // --- Entertainment / streaming (ENTERTAINMENT) ---
+        ("netflix", CategoryKeys.Entertainment),
+        ("spotify", CategoryKeys.Entertainment),
+        ("disney", CategoryKeys.Entertainment),
+        ("youtube", CategoryKeys.Entertainment),
+        ("prime video", CategoryKeys.Entertainment),
+        ("cinema", CategoryKeys.Entertainment),
+        ("odeon", CategoryKeys.Entertainment),
+        ("steam games", CategoryKeys.Entertainment),
+        ("steampowered", CategoryKeys.Entertainment),
+        ("playstation", CategoryKeys.Entertainment),
+        ("xbox", CategoryKeys.Entertainment),
+        ("nintendo", CategoryKeys.Entertainment),
+        ("twitch", CategoryKeys.Entertainment),
+        ("patreon", CategoryKeys.Entertainment),
+
+        // --- Digital / SaaS / dev services (GENERAL_SERVICES) ---
+        ("openai", CategoryKeys.GeneralServices),
+        ("chatgpt", CategoryKeys.GeneralServices),
+        ("anthropic", CategoryKeys.GeneralServices),
+        ("claude", CategoryKeys.GeneralServices),
+        ("github", CategoryKeys.GeneralServices),
+        ("microsoft", CategoryKeys.GeneralServices),
+        ("google ", CategoryKeys.GeneralServices),
+        ("adobe", CategoryKeys.GeneralServices),
+        ("notion", CategoryKeys.GeneralServices),
+        ("figma", CategoryKeys.GeneralServices),
+        ("digitalocean", CategoryKeys.GeneralServices),
+        ("netcup", CategoryKeys.GeneralServices),
+        ("namecheap", CategoryKeys.GeneralServices),
+        ("godaddy", CategoryKeys.GeneralServices),
+        ("cloudflare", CategoryKeys.GeneralServices),
+        ("aws", CategoryKeys.GeneralServices),
+
+        // --- Medical & pharmacy (MEDICAL) ---
+        ("pharmacy", CategoryKeys.Medical),
+        ("chemist", CategoryKeys.Medical),
+        ("boots", CategoryKeys.Medical),
+        ("lloyds pharmacy", CategoryKeys.Medical),
+        ("mccabes", CategoryKeys.Medical),
+        ("hickeys", CategoryKeys.Medical),
+        ("medical", CategoryKeys.Medical),
+        ("clinic", CategoryKeys.Medical),
+        ("dental", CategoryKeys.Medical),
+        ("doctor", CategoryKeys.Medical),
+        ("hospital", CategoryKeys.Medical),
+
+        // --- Personal care (PERSONAL_CARE) ---
+        ("hair", CategoryKeys.PersonalCare),
+        ("barber", CategoryKeys.PersonalCare),
+        ("salon", CategoryKeys.PersonalCare),
+        ("beauty", CategoryKeys.PersonalCare),
+        ("spa ", CategoryKeys.PersonalCare),
+
+        // --- Home improvement / hardware (HOME_IMPROVEMENT) ---
+        ("woodie", CategoryKeys.HomeImprovement),
+        ("b&q", CategoryKeys.HomeImprovement),
+        ("homebase", CategoryKeys.HomeImprovement),
+        ("hardware", CategoryKeys.HomeImprovement),
+    ];
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/BankSyncDbContext.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/BankSyncDbContext.cs
@@ -14,6 +14,7 @@ public class BankSyncDbContext(DbContextOptions<BankSyncDbContext> options) : Db
     public DbSet<TrueLayerConnection> TrueLayerConnections { get; set; } = null!;
     public DbSet<Category> Categories { get; set; } = null!;
     public DbSet<MccCategory> MccCategories { get; set; } = null!;
+    public DbSet<MerchantKeyword> MerchantKeywords { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -103,6 +104,15 @@ public class BankSyncDbContext(DbContextOptions<BankSyncDbContext> options) : Db
         mccb.Property(mc => mc.Description).IsRequired().HasMaxLength(255);
         mccb.HasIndex(mc => mc.CategoryKey).HasDatabaseName("idx_mcc_category_category_key");
         mccb.HasOne<Category>().WithMany().HasForeignKey(mc => mc.CategoryKey).OnDelete(DeleteBehavior.Restrict);
+
+        var mkb = modelBuilder.Entity<MerchantKeyword>();
+        mkb.ToTable("merchant_keywords");
+        mkb.HasKey(mk => mk.Id);
+        mkb.Property(mk => mk.Keyword).IsRequired().HasMaxLength(100);
+        mkb.Property(mk => mk.CategoryKey).IsRequired().HasMaxLength(100);
+        mkb.HasIndex(mk => mk.Keyword).IsUnique().HasDatabaseName("idx_merchant_keyword_keyword_unique");
+        mkb.HasIndex(mk => mk.CategoryKey).HasDatabaseName("idx_merchant_keyword_category_key");
+        mkb.HasOne<Category>().WithMany().HasForeignKey(mk => mk.CategoryKey).OnDelete(DeleteBehavior.Restrict);
 
         var sjb = modelBuilder.Entity<SyncJob>();
         sjb.HasKey(sj => sj.Id);

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/TrueLayer/TrueLayerAdapter.cs
@@ -2,6 +2,7 @@ namespace FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer;
 
 using FinanceSentry.Modules.BankSync.Application.Services;
 using FinanceSentry.Modules.BankSync.Application.Services.CategoryMapping;
+using FinanceSentry.Modules.BankSync.Domain;
 using FinanceSentry.Modules.BankSync.Domain.Interfaces;
 
 /// <summary>
@@ -10,11 +11,15 @@ using FinanceSentry.Modules.BankSync.Domain.Interfaces;
 /// exchanging the per-connection refresh_token for a fresh access_token before
 /// invoking this adapter.
 /// </summary>
-public class TrueLayerAdapter(ITrueLayerClient client, TrueLayerCategoryMapper categoryMapper) : IBankProvider
+public class TrueLayerAdapter(
+    ITrueLayerClient client,
+    TrueLayerCategoryMapper categoryMapper,
+    ICategoryResolver categoryResolver) : IBankProvider
 {
     private const int InitialSyncWindowDays = 90;
 
     private readonly TrueLayerCategoryMapper _categoryMapper = categoryMapper;
+    private readonly ICategoryResolver _categoryResolver = categoryResolver;
 
     public string ProviderName => "truelayer";
 
@@ -63,31 +68,43 @@ public class TrueLayerAdapter(ITrueLayerClient client, TrueLayerCategoryMapper c
 
         var candidates = booked
             .Concat(pending)
-            .Select(t => MapTransaction(t, accountId, userId, _categoryMapper))
+            .Select(MapTransaction)
             .ToList();
 
         return (candidates, DateTime.UtcNow);
+
+        TransactionCandidate MapTransaction(TrueLayerTransaction t)
+        {
+            var amount = Math.Abs(t.Amount);
+            var txType = t.Amount < 0 || t.TransactionType == "debit" ? "debit" : "credit";
+
+            // Prefer TrueLayer's own classification; many EU banks return it empty, so fall
+            // back to matching the free-text description against the merchant-keyword table.
+            var category = _categoryMapper.Map(t.Classification);
+            if (category == CategoryKeys.Uncategorized)
+                category = _categoryResolver.ResolveDescription(t.Description);
+
+            // Persist the raw classification (when present) so a later re-map is traceable.
+            var sourceCategory = t.Classification is { Count: > 0 }
+                ? string.Join(" > ", t.Classification)
+                : null;
+
+            return new TransactionCandidate(
+                AccountId: accountId,
+                UserId: userId,
+                Amount: amount,
+                TransactionDate: t.Timestamp,
+                PostedDate: t.IsPending ? null : t.Timestamp,
+                Description: t.Description,
+                IsPending: t.IsPending,
+                TransactionType: txType,
+                MerchantName: t.MerchantName,
+                MerchantCategory: category,
+                PlaidTransactionId: null,
+                SourceCategory: sourceCategory);
+        }
     }
 
     public Task DisconnectAsync(string credential, CancellationToken ct = default)
         => Task.CompletedTask;
-
-    private static TransactionCandidate MapTransaction(TrueLayerTransaction t, Guid accountId, Guid userId, TrueLayerCategoryMapper categoryMapper)
-    {
-        var amount = Math.Abs(t.Amount);
-        var txType = t.Amount < 0 || t.TransactionType == "debit" ? "debit" : "credit";
-
-        return new TransactionCandidate(
-            AccountId: accountId,
-            UserId: userId,
-            Amount: amount,
-            TransactionDate: t.Timestamp,
-            PostedDate: t.IsPending ? null : t.Timestamp,
-            Description: t.Description,
-            IsPending: t.IsPending,
-            TransactionType: txType,
-            MerchantName: t.MerchantName,
-            MerchantCategory: categoryMapper.Map(t.Classification),
-            PlaidTransactionId: null);
-    }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260723074326_M006_MerchantKeywords.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260723074326_M006_MerchantKeywords.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.BankSync.Migrations
 {
     [DbContext(typeof(BankSyncDbContext))]
-    partial class BankSyncDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723074326_M006_MerchantKeywords")]
+    partial class M006_MerchantKeywords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260723074326_M006_MerchantKeywords.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260723074326_M006_MerchantKeywords.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.BankSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class M006_MerchantKeywords : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "merchant_keywords",
+                schema: "bank_sync",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Keyword = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    CategoryKey = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_merchant_keywords", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_merchant_keywords_categories_CategoryKey",
+                        column: x => x.CategoryKey,
+                        principalSchema: "bank_sync",
+                        principalTable: "categories",
+                        principalColumn: "Key",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_merchant_keyword_category_key",
+                schema: "bank_sync",
+                table: "merchant_keywords",
+                column: "CategoryKey");
+
+            migrationBuilder.CreateIndex(
+                name: "idx_merchant_keyword_keyword_unique",
+                schema: "bank_sync",
+                table: "merchant_keywords",
+                column: "Keyword",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "merchant_keywords",
+                schema: "bank_sync");
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Integration/BankSync/PlaidAdapterIntegrationTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/BankSync/PlaidAdapterIntegrationTests.cs
@@ -30,6 +30,8 @@ file sealed class PassthroughCategoryResolver : ICategoryResolver
     public string ResolvePlaidPrimary(string? primary)
         => string.IsNullOrWhiteSpace(primary) ? CategoryKeys.Uncategorized : primary.Trim().ToUpperInvariant();
 
+    public string ResolveDescription(string? description) => CategoryKeys.Uncategorized;
+
     public void Refresh()
     {
     }

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
@@ -1,0 +1,73 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Exercises the real curated merchant-keyword seed list through the same matcher the
+/// resolver uses, over actual transaction descriptions observed from TrueLayer. Guards both
+/// the seed data quality and the longest-first matching rule without needing a database.
+/// </summary>
+public class MerchantKeywordSeedDataTests
+{
+    private static readonly IReadOnlyList<(string Keyword, string CategoryKey)> Prepared =
+        MerchantKeywordMatcher.Prepare(MerchantKeywordSeedData.Keywords);
+
+    [Theory]
+    [InlineData("Lidl Ireland Ltd", CategoryKeys.FoodAndDrink)]
+    [InlineData("Tesco Stores 6913", CategoryKeys.FoodAndDrink)]
+    [InlineData("Camile Thai Dublin", CategoryKeys.FoodAndDrink)]
+    [InlineData("amazon.ie", CategoryKeys.GeneralMerchandise)]
+    [InlineData("Openai *chatgpt Subscr", CategoryKeys.GeneralServices)]
+    [InlineData("Github, Inc.", CategoryKeys.GeneralServices)]
+    [InlineData("Netcup", CategoryKeys.GeneralServices)]
+    [InlineData("Leap Card App", CategoryKeys.Transportation)]
+    [InlineData("Fitzmaurice Chemists", CategoryKeys.Medical)]
+    [InlineData("East Wall Medical Cent", CategoryKeys.Medical)]
+    public void Resolve_KnownMerchantDescriptions_MapToExpectedCategory(string description, string expected)
+    {
+        MerchantKeywordMatcher.Resolve(description, Prepared).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_LongerKeywordWins_UberEatsIsFoodNotTransport()
+    {
+        MerchantKeywordMatcher.Resolve("UBER EATS Amsterdam", Prepared).Should().Be(CategoryKeys.FoodAndDrink);
+        MerchantKeywordMatcher.Resolve("Uber trip Dublin", Prepared).Should().Be(CategoryKeys.Transportation);
+    }
+
+    [Theory]
+    [InlineData("To Denys Sychov")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Resolve_UnknownOrEmpty_IsUncategorized(string? description)
+    {
+        MerchantKeywordMatcher.Resolve(description, Prepared).Should().Be(CategoryKeys.Uncategorized);
+    }
+
+    [Fact]
+    public void SeedData_AllCategoryKeysAreCanonical()
+    {
+        var canonical = new HashSet<string>
+        {
+            CategoryKeys.Income, CategoryKeys.TransferIn, CategoryKeys.TransferOut,
+            CategoryKeys.LoanPayments, CategoryKeys.BankFees, CategoryKeys.Entertainment,
+            CategoryKeys.FoodAndDrink, CategoryKeys.GeneralMerchandise, CategoryKeys.HomeImprovement,
+            CategoryKeys.Medical, CategoryKeys.PersonalCare, CategoryKeys.GeneralServices,
+            CategoryKeys.GovernmentAndNonProfit, CategoryKeys.Transportation, CategoryKeys.Travel,
+            CategoryKeys.RentAndUtilities, CategoryKeys.Uncategorized,
+        };
+
+        MerchantKeywordSeedData.Keywords.Select(k => k.CategoryKey)
+            .Should().OnlyContain(key => canonical.Contains(key));
+    }
+
+    [Fact]
+    public void SeedData_HasNoDuplicateKeywords()
+    {
+        MerchantKeywordSeedData.Keywords.Select(k => k.Keyword.ToLowerInvariant())
+            .Should().OnlyHaveUniqueItems();
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StubCategoryResolver.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StubCategoryResolver.cs
@@ -18,6 +18,19 @@ internal sealed class StubCategoryResolver : ICategoryResolver
     public string ResolvePlaidPrimary(string? primary)
         => string.IsNullOrWhiteSpace(primary) ? CategoryKeys.Uncategorized : primary.Trim().ToUpperInvariant();
 
+    // Minimal keyword set so adapter/service tests can exercise the description fallback.
+    public string ResolveDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return CategoryKeys.Uncategorized;
+        var h = description.ToLowerInvariant();
+        if (h.Contains("lidl") || h.Contains("tesco"))
+            return CategoryKeys.FoodAndDrink;
+        if (h.Contains("amazon"))
+            return CategoryKeys.GeneralMerchandise;
+        return CategoryKeys.Uncategorized;
+    }
+
     public void Refresh()
     {
     }

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TrueLayerAdapterTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TrueLayerAdapterTests.cs
@@ -14,7 +14,8 @@ public class TrueLayerAdapterTests
     private const string ExternalAccountId = "tl-acct-1234abcd";
 
     private readonly Mock<ITrueLayerClient> _clientMock = new(MockBehavior.Strict);
-    private TrueLayerAdapter CreateSut() => new(_clientMock.Object, new TrueLayerCategoryMapper());
+    private TrueLayerAdapter CreateSut() =>
+        new(_clientMock.Object, new TrueLayerCategoryMapper(), StubCategoryResolver.Instance);
 
     [Fact]
     public void ProviderName_IsTrueLayer()
@@ -153,6 +154,39 @@ public class TrueLayerAdapterTests
         credit.TransactionType.Should().Be("credit");
         credit.IsPending.Should().BeTrue();
         credit.PostedDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SyncTransactionsAsync_EmptyClassification_FallsBackToDescriptionKeyword()
+    {
+        // Many EU banks return no classification; the merchant name is only in the description.
+        var booked = new TrueLayerTransaction(
+            TransactionId: "tx-9",
+            Timestamp: new DateTime(2026, 7, 1, 12, 0, 0, DateTimeKind.Utc),
+            Amount: -12.34m,
+            Currency: "EUR",
+            Description: "Lidl Ireland Ltd",
+            MerchantName: null,
+            TransactionType: "debit",
+            IsPending: false,
+            Classification: []);
+
+        _clientMock
+            .Setup(c => c.GetTransactionsAsync(AccessToken, ExternalAccountId, It.IsAny<DateOnly?>(), It.IsAny<DateOnly?>(), default))
+            .ReturnsAsync([booked]);
+        _clientMock
+            .Setup(c => c.GetPendingTransactionsAsync(AccessToken, ExternalAccountId, default))
+            .ReturnsAsync([]);
+
+        var (candidates, _) = await CreateSut().SyncTransactionsAsync(
+            credential: AccessToken,
+            externalAccountId: ExternalAccountId,
+            accountId: AccountId,
+            userId: UserId,
+            since: null);
+
+        candidates.Should().ContainSingle();
+        candidates[0].MerchantCategory.Should().Be("FOOD_AND_DRINK");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

~99% of transactions showed **Uncategorized** on the frontend. The dynamic-category overhaul (Plaid PFC + MCC bridge) is already merged/deployed — this was a data/runtime gap, not a missing merge.

Prod DB breakdown: **TrueLayer 1205 (89%), Plaid 144, Monobank 63**.
- Monobank 63/63 categorized (MCC → resolver works).
- Plaid 144: pre-overhaul rows, not actively syncing.
- **TrueLayer 1205: all uncategorized, incl. today's.** For the connected Irish bank, TrueLayer returns an **empty `transaction_classification` array and null `merchant_name`** — no MCC, no category. The only signal is the free-text `Description` ("Lidl Ireland Ltd", "Tesco Stores 6913", "amazon.ie").

The adapter mapped the empty classification → `UNCATEGORIZED` and never persisted a raw signal.

## Fix

Merchant-keyword bridge table (keyword → Plaid PFC category), mirroring the existing MCC bridge — taxonomy stays external, only the keyword map is ours and it's runtime-editable.

- New `bank_sync.merchant_keywords` table + migration **M006** (EF-generated: Designer + snapshot).
- `MerchantKeywordSeedData` (~150 curated keywords) seeded idempotently by `CategorySeeder`.
- `MerchantKeywordMatcher`: longest-keyword-first, case-insensitive substring match ("uber eats" beats "uber").
- `ICategoryResolver.ResolveDescription()`; `CategoryResolver` snapshot loads keywords.
- `TrueLayerAdapter` falls back to description matching when classification is empty; persists raw classification to `SourceCategory` when present.
- `TransactionRecategorizationService` pass 1 recovers existing rows from the stored description (no provider re-fetch); pass 2 skips rescued rows.

## Backfill

Existing 1349 rows fix in place via `recategorize` (description already in DB — no TrueLayer re-fetch). Run post-deploy:
`docker exec finance-sentry-api dotnet FinanceSentry.API.dll recategorize <userId>`

## Verification

- In-container `dotnet build` clean (0 warnings).
- **302 unit tests green** (16 new, incl. matching the real seed list against actual observed descriptions).
- Full migration chain (incl. M006) applies to a throwaway Postgres 14.
- No frontend change needed (all PFC keys already seeded + labeled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)