### PR TITLE
feat(bank-sync): expand merchant keywords + transfer-description fallback

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategoryResolver.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/CategoryResolver.cs
@@ -45,7 +45,14 @@ public sealed class CategoryResolver(IServiceScopeFactory scopeFactory) : ICateg
     public string ResolveDescription(string? description)
     {
         EnsureLoaded();
-        return MerchantKeywordMatcher.Resolve(description, _merchantKeywords!);
+
+        // Prefer a specific merchant match ("To Go Sushi" -> food), then fall back to the
+        // directional-transfer prefix ("To Mario Scalas" -> transfer out).
+        var byKeyword = MerchantKeywordMatcher.Resolve(description, _merchantKeywords!);
+        if (byKeyword != CategoryKeys.Uncategorized)
+            return byKeyword;
+
+        return TransferDescriptionClassifier.Resolve(description) ?? CategoryKeys.Uncategorized;
     }
 
     public void Refresh()

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
@@ -174,5 +174,21 @@ public static class MerchantKeywordSeedData
         ("b&q", CategoryKeys.HomeImprovement),
         ("homebase", CategoryKeys.HomeImprovement),
         ("hardware", CategoryKeys.HomeImprovement),
+
+        // --- Second-pass coverage (from observed uncategorized TrueLayer merchants) ---
+        ("apple.com", CategoryKeys.GeneralServices),
+        ("hetzner", CategoryKeys.GeneralServices),
+        ("top-up", CategoryKeys.RentAndUtilities),   // mobile top-up
+        ("gymbeam", CategoryKeys.GeneralMerchandise), // sports-nutrition shop; must beat "gym"
+        ("gym", CategoryKeys.Medical),
+        ("cafe", CategoryKeys.FoodAndDrink),
+        ("boojum", CategoryKeys.FoodAndDrink),
+        ("beshoffs", CategoryKeys.FoodAndDrink),
+        ("dublinbikes", CategoryKeys.Transportation),
+        ("bleeper", CategoryKeys.Transportation),
+        ("ticketmaster", CategoryKeys.Entertainment), // longer than "klarna", so it wins
+        ("klarna", CategoryKeys.GeneralMerchandise),
+        ("carrolls irish", CategoryKeys.GeneralMerchandise),
+        ("fee-qtr", CategoryKeys.BankFees),
     ];
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/TransferDescriptionClassifier.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/TransferDescriptionClassifier.cs
@@ -1,0 +1,46 @@
+namespace FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
+
+using FinanceSentry.Modules.BankSync.Domain;
+
+/// <summary>
+/// Classifies bank-transfer transactions from their description prefix, for providers that
+/// give no structured category (TrueLayer). Open-banking feeds render peer/account transfers
+/// with a directional prefix — "To &lt;name/account&gt;" for outgoing, "From …" / "Payment from …"
+/// for incoming — which is a reliable signal that a merchant-keyword match is not.
+///
+/// Deliberately conservative: only the directional prefixes match, and the trailing space is
+/// required so "Tobacco"/"Tommy" don't trip the "To" branch. Merchant-keyword matching runs
+/// first (see <see cref="CategoryResolver.ResolveDescription"/>), so "To Go Sushi" still lands
+/// as food rather than a transfer.
+/// </summary>
+public static class TransferDescriptionClassifier
+{
+    private static readonly string[] OutgoingPrefixes = ["To "];
+    private static readonly string[] IncomingPrefixes = ["From ", "Payment from "];
+
+    /// <summary>
+    /// Returns <see cref="CategoryKeys.TransferOut"/> / <see cref="CategoryKeys.TransferIn"/>
+    /// for a directional-prefix description, or <c>null</c> when it is not a recognizable transfer.
+    /// </summary>
+    public static string? Resolve(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            return null;
+
+        var d = description.TrimStart();
+
+        foreach (var prefix in IncomingPrefixes)
+        {
+            if (d.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return CategoryKeys.TransferIn;
+        }
+
+        foreach (var prefix in OutgoingPrefixes)
+        {
+            if (d.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return CategoryKeys.TransferOut;
+        }
+
+        return null;
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
@@ -26,6 +26,13 @@ public class MerchantKeywordSeedDataTests
     [InlineData("Leap Card App", CategoryKeys.Transportation)]
     [InlineData("Fitzmaurice Chemists", CategoryKeys.Medical)]
     [InlineData("East Wall Medical Cent", CategoryKeys.Medical)]
+    [InlineData("apple.com/bill", CategoryKeys.GeneralServices)]
+    [InlineData("Hetzner Online Gmbh", CategoryKeys.GeneralServices)]
+    [InlineData("Feel Fit Gym", CategoryKeys.Medical)]
+    [InlineData("Dublinbikes Internet", CategoryKeys.Transportation)]
+    [InlineData("Sq *olives Room Cafe 1", CategoryKeys.FoodAndDrink)]
+    [InlineData("*MOBI TOP-UP 0857860057", CategoryKeys.RentAndUtilities)]
+    [InlineData("Klarna*mstore.ie", CategoryKeys.GeneralMerchandise)]
     public void Resolve_KnownMerchantDescriptions_MapToExpectedCategory(string description, string expected)
     {
         MerchantKeywordMatcher.Resolve(description, Prepared).Should().Be(expected);
@@ -36,6 +43,19 @@ public class MerchantKeywordSeedDataTests
     {
         MerchantKeywordMatcher.Resolve("UBER EATS Amsterdam", Prepared).Should().Be(CategoryKeys.FoodAndDrink);
         MerchantKeywordMatcher.Resolve("Uber trip Dublin", Prepared).Should().Be(CategoryKeys.Transportation);
+    }
+
+    [Fact]
+    public void Resolve_LongerKeywordWins_GymbeamIsMerchandiseNotGym()
+    {
+        MerchantKeywordMatcher.Resolve("Gymbeam Italy S.r.l.", Prepared).Should().Be(CategoryKeys.GeneralMerchandise);
+        MerchantKeywordMatcher.Resolve("Feel Fit Gym", Prepared).Should().Be(CategoryKeys.Medical);
+    }
+
+    [Fact]
+    public void Resolve_LongerKeywordWins_TicketmasterViaKlarnaIsEntertainment()
+    {
+        MerchantKeywordMatcher.Resolve("Klarna* Ticketmaster.", Prepared).Should().Be(CategoryKeys.Entertainment);
     }
 
     [Theory]

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StubCategoryResolver.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StubCategoryResolver.cs
@@ -18,7 +18,7 @@ internal sealed class StubCategoryResolver : ICategoryResolver
     public string ResolvePlaidPrimary(string? primary)
         => string.IsNullOrWhiteSpace(primary) ? CategoryKeys.Uncategorized : primary.Trim().ToUpperInvariant();
 
-    // Minimal keyword set so adapter/service tests can exercise the description fallback.
+    // Minimal keyword set + transfer prefix so adapter/service tests can exercise the fallback.
     public string ResolveDescription(string? description)
     {
         if (string.IsNullOrWhiteSpace(description))
@@ -28,7 +28,7 @@ internal sealed class StubCategoryResolver : ICategoryResolver
             return CategoryKeys.FoodAndDrink;
         if (h.Contains("amazon"))
             return CategoryKeys.GeneralMerchandise;
-        return CategoryKeys.Uncategorized;
+        return TransferDescriptionClassifier.Resolve(description) ?? CategoryKeys.Uncategorized;
     }
 
     public void Refresh()

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TransferDescriptionClassifierTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TransferDescriptionClassifierTests.cs
@@ -1,0 +1,40 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
+using FluentAssertions;
+using Xunit;
+
+public class TransferDescriptionClassifierTests
+{
+    [Theory]
+    [InlineData("To Mario Scalas", CategoryKeys.TransferOut)]
+    [InlineData("To Denys Sychov", CategoryKeys.TransferOut)]
+    [InlineData("To Interactive Brokers LLC", CategoryKeys.TransferOut)]
+    [InlineData("To Instant Access Savings", CategoryKeys.TransferOut)]
+    [InlineData("From Instant Access Savings", CategoryKeys.TransferIn)]
+    [InlineData("From investment account", CategoryKeys.TransferIn)]
+    [InlineData("Payment from Andrea Di Florio", CategoryKeys.TransferIn)]
+    public void Resolve_DirectionalPrefix_ClassifiesTransfer(string description, string expected)
+    {
+        TransferDescriptionClassifier.Resolve(description).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Tobacco Shop")]      // "To" without the trailing space must not match
+    [InlineData("Tommy Hilfiger")]
+    [InlineData("Lidl Ireland Ltd")]
+    [InlineData("Fromage Cheese Co")] // "From" without the trailing space must not match
+    [InlineData("")]
+    [InlineData(null)]
+    public void Resolve_NonTransfer_ReturnsNull(string? description)
+    {
+        TransferDescriptionClassifier.Resolve(description).Should().BeNull();
+    }
+
+    [Fact]
+    public void Resolve_LeadingWhitespace_IsTrimmedBeforeMatching()
+    {
+        TransferDescriptionClassifier.Resolve("   To Someone").Should().Be(CategoryKeys.TransferOut);
+    }
+}


### PR DESCRIPTION
## Why

Follow-up to #303. After the merchant-keyword bridge shipped, TrueLayer dropped from 100% → 35% uncategorized. This closes the two biggest remaining buckets in the observed uncategorized descriptions: **person/account transfers** and **~dozen uncovered merchants**.

## Change

- **+14 merchant keywords** for merchants seen in the live uncategorized set: `apple.com`, `hetzner`, `gym`/`gymbeam`, `cafe`, `boojum`, `beshoffs`, `dublinbikes`, `bleeper`, `ticketmaster`, `klarna`, mobile `top-up`, `carrolls irish`, `fee-qtr`. Longest-first matching keeps `gymbeam`→merchandise over `gym`→medical, and `ticketmaster`→entertainment over `klarna`→merchandise.
- **`TransferDescriptionClassifier`** — directional-prefix heuristic: `To …` → `TRANSFER_OUT`, `From …`/`Payment from …` → `TRANSFER_IN`. The trailing space is required so `Tobacco`/`Tommy`/`Fromage` don't trip it. Merchant-keyword matching runs first, so `To Go Sushi` stays food.
- `CategoryResolver.ResolveDescription` composes the two (keyword → transfer → uncategorized).

Seeder is idempotent, so the new keywords seed on deploy; existing rows re-map via the `recategorize` command (no provider re-fetch — descriptions are already stored).

## Verification

- In-container build clean, **325 unit tests green** (23 new: transfer classifier, new merchants, longest-first precedence cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)