### PR TITLE
fix(ui): UI hardening sweep — native cmn-select (drop ng-zorro), chart labels, dev-cache

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -14,7 +14,12 @@ services:
       - finance-sentry-network
     volumes:
       - ../frontend:/app
+      # Keep container-generated build artifacts OFF the host bind mount. ng serve runs as root
+      # in this container, so without these anonymous volumes it writes root-owned node_modules/
+      # and .angular/cache/ files back onto the host repo — which then break a host-side `ng serve`
+      # (EACCES on vite dep re-optimization, unremovable without sudo).
       - /app/node_modules
+      - /app/.angular
 
   api:
     build:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-sentry",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-sentry",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "workspaces": [
         "projects/dsdevq-common/*"
       ],
@@ -25,7 +25,6 @@
         "chart.js": "^4.5.1",
         "chroma-js": "^3.2.0",
         "lucide-angular": "^1.0.0",
-        "ng-zorro-antd": "21.2.2",
         "rxjs": "^7.8.0",
         "tslib": "^2.6.0",
         "zone.js": "^0.16.0"
@@ -2413,43 +2412,6 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
-    "node_modules/@ant-design/colors": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
-      "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/fast-color": "^2.0.6"
-      }
-    },
-    "node_modules/@ant-design/fast-color": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
-      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=8.x"
-      }
-    },
-    "node_modules/@ant-design/icons-angular": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-angular/-/icons-angular-21.0.0.tgz",
-      "integrity": "sha512-Io1DSg0JyzsxQtF2T9LfQSZL22d7zSYyNz0RiUCOhtMoDnnGis1oU6mPs5JzZTRtVdgpuLUhS6GVTlT+dmP1nA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
@@ -4116,6 +4078,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4456,15 +4419,6 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
-      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -11302,22 +11256,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -16092,26 +16030,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ng-zorro-antd": {
-      "version": "21.2.2",
-      "resolved": "https://registry.npmjs.org/ng-zorro-antd/-/ng-zorro-antd-21.2.2.tgz",
-      "integrity": "sha512-mYgc5aDGkBLFwQwcuCW63ESM9oIaCAHCen0PkB77YSfe79f9SVunmUcSsiGPS4lFVmW8VWiL2TYeW53oc9yGOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@angular/cdk": "^21.0.0",
-        "@ant-design/icons-angular": "^21.0.0",
-        "@ctrl/tinycolor": "^3.6.0",
-        "date-fns": "^2.16.1",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/forms": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "@angular/router": "^21.0.0"
-      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -23094,8 +23012,7 @@
         "@angular/core": "^21.2.0",
         "@angular/forms": "^21.2.0",
         "@angular/platform-browser": "^21.2.0",
-        "@angular/router": "^21.2.0",
-        "ng-zorro-antd": "^21.2.0"
+        "@angular/router": "^21.2.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,6 @@
     "chart.js": "^4.5.1",
     "chroma-js": "^3.2.0",
     "lucide-angular": "^1.0.0",
-    "ng-zorro-antd": "21.2.2",
     "rxjs": "^7.8.0",
     "tslib": "^2.6.0",
     "zone.js": "^0.16.0"

--- a/frontend/projects/dsdevq-common/ui/package.json
+++ b/frontend/projects/dsdevq-common/ui/package.json
@@ -6,8 +6,7 @@
     "@angular/core": "^21.2.0",
     "@angular/forms": "^21.2.0",
     "@angular/platform-browser": "^21.2.0",
-    "@angular/router": "^21.2.0",
-    "ng-zorro-antd": "^21.2.0"
+    "@angular/router": "^21.2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.spec.ts
@@ -4,7 +4,6 @@ import {SelectComponent, type SelectValue} from './select.component';
 
 interface SelectInternals {
   value(): SelectValue;
-  onValueChange(v: SelectValue): void;
   onBlur(): void;
   disabled(): boolean;
 }
@@ -17,30 +16,32 @@ describe('SelectComponent', () => {
     fixture = TestBed.createComponent(SelectComponent);
   });
 
-  function selectElement(): HTMLElement | null {
-    return fixture.nativeElement.querySelector('nz-select');
+  function nativeSelect(): HTMLSelectElement | null {
+    return fixture.nativeElement.querySelector('select');
   }
 
   function internals(): SelectInternals {
     return fixture.componentInstance as unknown as SelectInternals;
   }
 
-  it('renders the configured select options', () => {
+  it('renders the configured options as native <option> elements', () => {
     fixture.componentRef.setInput('options', [
       {label: 'Euro', value: 'eur'},
       {label: 'US Dollar', value: 'usd', disabled: true},
     ]);
     fixture.detectChanges();
 
-    expect(fixture.componentInstance.options()).toHaveLength(2);
-    expect(selectElement()).not.toBeNull();
+    const options = fixture.nativeElement.querySelectorAll('select option');
+    // options + the placeholder option
+    expect(options.length).toBe(3);
+    expect(nativeSelect()).not.toBeNull();
   });
 
   it('applies size classes', () => {
     fixture.componentRef.setInput('size', 'lg');
     fixture.detectChanges();
 
-    expect(selectElement()?.className).toContain('cmn-select--lg');
+    expect(nativeSelect()?.className).toContain('text-cmn-base');
   });
 
   it('writes external form values', () => {
@@ -57,13 +58,21 @@ describe('SelectComponent', () => {
     expect(internals().value()).toBeNull();
   });
 
-  it('emits form changes when selection changes', () => {
+  it('emits form changes when the native selection changes', () => {
+    fixture.componentRef.setInput('options', [
+      {label: 'Euro', value: 'eur'},
+      {label: 'US Dollar', value: 'usd'},
+    ]);
+    fixture.detectChanges();
+
     let emitted: SelectValue = null;
     fixture.componentInstance.registerOnChange(value => {
       emitted = value;
     });
 
-    internals().onValueChange('usd');
+    const el = fixture.nativeElement.querySelector('select') as HTMLSelectElement;
+    el.value = 'usd';
+    el.dispatchEvent(new Event('change'));
 
     expect(emitted).toBe('usd');
     expect(internals().value()).toBe('usd');

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/select/select.component.ts
@@ -6,8 +6,9 @@ import {
   input,
   signal,
 } from '@angular/core';
-import {ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {NzSelectModule} from 'ng-zorro-antd/select';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+
+import {IconComponent} from '../icon/icon.component';
 
 export type SelectSize = 'sm' | 'md' | 'lg';
 export type SelectMode = 'default' | 'multiple';
@@ -20,23 +21,26 @@ export interface SelectOption {
   disabled?: boolean;
 }
 
-const BASE_CLASSES = 'cmn-select block w-full';
-
 const SIZE_CLASSES: Record<SelectSize, string> = {
-  sm: 'cmn-select--sm',
-  md: 'cmn-select--md',
-  lg: 'cmn-select--lg',
+  sm: 'py-1 text-cmn-xs',
+  md: 'py-1.5 text-cmn-sm',
+  lg: 'py-2 text-cmn-base',
 };
 
-const NZ_SIZE: Record<SelectSize, 'small' | 'default' | 'large'> = {
-  sm: 'small',
-  md: 'default',
-  lg: 'large',
+const ICON_SIZE: Record<SelectSize, 'sm' | 'md' | 'lg'> = {
+  sm: 'sm',
+  md: 'sm',
+  lg: 'md',
 };
 
+/**
+ * Native-backed select. Deliberately built on a plain <select> + design tokens rather than a
+ * third-party widget: it needs no external stylesheet or icon registration, stays consistent
+ * with the app's Tailwind theme, and gets accessibility + keyboard type-ahead for free.
+ */
 @Component({
   selector: 'cmn-select',
-  imports: [FormsModule, NzSelectModule],
+  imports: [IconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [
     {
@@ -46,27 +50,39 @@ const NZ_SIZE: Record<SelectSize, 'small' | 'default' | 'large'> = {
     },
   ],
   template: `
-    <nz-select
-      [ngModel]="value()"
-      [nzAllowClear]="allowClear()"
-      [nzDisabled]="disabled()"
-      [nzMode]="mode()"
-      [nzPlaceHolder]="placeholder()"
-      [nzShowSearch]="showSearch()"
-      [nzSize]="nzSize()"
-      [nzStatus]="hasError() ? 'error' : ''"
-      [class]="classes()"
-      (ngModelChange)="onValueChange($event)"
-      (nzBlur)="onBlur()"
-    >
-      @for (option of options(); track option.value) {
-        <nz-option
-          [nzDisabled]="option.disabled ?? false"
-          [nzLabel]="option.label"
-          [nzValue]="option.value"
+    <div class="cmn-select relative w-full">
+      <select
+        #native
+        [class]="selectClasses()"
+        [disabled]="disabled()"
+        [multiple]="mode() === 'multiple'"
+        [attr.aria-invalid]="hasError() ? 'true' : null"
+        (change)="onNativeChange($event)"
+        (blur)="onBlur()"
+      >
+        @if (mode() !== 'multiple') {
+          <option [selected]="isEmpty()" [disabled]="!allowClear()" value="">
+            {{ placeholder() || 'Select…' }}
+          </option>
+        }
+        @for (option of options(); track option.value) {
+          <option
+            [value]="option.value"
+            [selected]="isSelected(option.value)"
+            [disabled]="option.disabled ?? false"
+          >
+            {{ option.label }}
+          </option>
+        }
+      </select>
+      @if (mode() !== 'multiple') {
+        <cmn-icon
+          [size]="iconSize()"
+          name="ChevronDown"
+          class="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-text-secondary"
         />
       }
-    </nz-select>
+    </div>
   `,
 })
 export class SelectComponent implements ControlValueAccessor {
@@ -75,17 +91,30 @@ export class SelectComponent implements ControlValueAccessor {
   public readonly size = input<SelectSize>('md');
   public readonly mode = input<SelectMode>('default');
   public readonly allowClear = input<boolean>(false);
+  // Kept for API compatibility; native selects have built-in keyboard type-ahead.
   public readonly showSearch = input<boolean>(false);
   public readonly hasError = input<boolean>(false);
 
-  public readonly classes = computed(() => [BASE_CLASSES, SIZE_CLASSES[this.size()]].join(' '));
-  public readonly nzSize = computed(() => NZ_SIZE[this.size()]);
+  public readonly iconSize = computed(() => ICON_SIZE[this.size()]);
+  public readonly selectClasses = computed(() =>
+    [
+      'block w-full appearance-none rounded border bg-surface-bg pl-cmn-2 pr-8',
+      'text-text-primary outline-none transition-colors',
+      'focus:border-accent-default disabled:cursor-not-allowed disabled:opacity-60',
+      this.hasError() ? 'border-error-default' : 'border-surface-raised',
+      SIZE_CLASSES[this.size()],
+      this.mode() === 'multiple' ? 'pr-cmn-2' : '',
+    ].join(' ')
+  );
 
   protected readonly value = signal<SelectValue>(null);
   protected readonly disabled = signal<boolean>(false);
+  protected readonly isEmpty = computed(() => {
+    const v = this.value();
+    return v === null || v === undefined || v === '';
+  });
 
   private onChange: (value: SelectValue) => void = (_: SelectValue) => void 0;
-
   private onTouched: () => void = () => void 0;
 
   public writeValue(value: SelectValue | undefined): void {
@@ -104,9 +133,21 @@ export class SelectComponent implements ControlValueAccessor {
     this.disabled.set(isDisabled);
   }
 
-  protected onValueChange(value: SelectValue): void {
-    this.value.set(value);
-    this.onChange(value);
+  protected isSelected(optionValue: SelectOptionValue): boolean {
+    const v = this.value();
+    return Array.isArray(v) ? v.includes(optionValue) : v === optionValue;
+  }
+
+  protected onNativeChange(event: Event): void {
+    const target = event.target as HTMLSelectElement;
+    let next: SelectValue;
+    if (this.mode() === 'multiple') {
+      next = Array.from(target.selectedOptions).map(o => o.value);
+    } else {
+      next = target.value === '' ? null : target.value;
+    }
+    this.value.set(next);
+    this.onChange(next);
   }
 
   protected onBlur(): void {

--- a/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
@@ -22,6 +22,12 @@ const COMPACT_FORMATTER = new Intl.NumberFormat('en-US', {
 });
 
 const MONTH_FORMATTER = new Intl.DateTimeFormat('en-US', {month: 'short', year: '2-digit'});
+const DAY_FORMATTER = new Intl.DateTimeFormat('en-US', {month: 'short', day: 'numeric'});
+
+// Below this span the snapshots are effectively daily, so month-year labels ("Jul 26")
+// collapse to a single repeated value — use day-level labels ("Jul 5") instead.
+const SHORT_SPAN_DAYS = 92;
+const MS_PER_DAY = 86_400_000;
 
 const MONTH_KEY_PAD = 2;
 
@@ -84,12 +90,19 @@ export function dashboardComputed(store: StateSignals) {
       }))
     ),
 
-    netWorthHistoryData: computed((): ChartPoint[] =>
-      store.netWorthHistory().map(s => ({
-        label: MONTH_FORMATTER.format(new Date(s.snapshotDate)),
+    netWorthHistoryData: computed((): ChartPoint[] => {
+      const history = store.netWorthHistory();
+      if (history.length === 0) {
+        return [];
+      }
+      const times = history.map(s => new Date(s.snapshotDate).getTime());
+      const spanDays = (Math.max(...times) - Math.min(...times)) / MS_PER_DAY;
+      const formatter = spanDays <= SHORT_SPAN_DAYS ? DAY_FORMATTER : MONTH_FORMATTER;
+      return history.map(s => ({
+        label: formatter.format(new Date(s.snapshotDate)),
         value: s.totalNetWorth,
-      }))
-    ),
+      }));
+    }),
 
     isHistoryLoading: computed(() => store.historyLoading()),
     historyErrorMessage: computed(() => store.historyError()),


### PR DESCRIPTION
First batch of the UI/UX hardening sweep (#317). Each change verified end-to-end via Playwright against real data.

### Fixes
- **`cmn-select` rebuilt on a native `<select>`; ng-zorro removed entirely.** `cmn-select` was built on ng-zorro's `<nz-select>`, but ng-zorro's CSS and icon registration were never wired up — so the control rendered broken *and* threw an unregistered-icon runtime error. ng-zorro had exactly one consumer, so rather than pull in the whole antd theme, `cmn-select` now uses a native `<select>` + design tokens + a Lucide chevron (same public API). Removes `ng-zorro-antd` from both package.json files and the lockfile.
  - Fixes #312 (budgets category selector broken), #314 (icon runtime error), #315 (two icon systems / drop ng-zorro).
- **Net-worth chart x-axis labels.** Every point formatted as "Jul 26" (month+year) — with daily snapshots over ~1 month they all collapsed to one label. Now span-aware: ≤92 days uses "MMM d" (distinct daily labels), longer keeps "MMM yy".
- **Dev-container cache.** The frontend dev container ran `ng serve` as root over a bind mount, writing root-owned `.angular/cache` files onto the host (breaking a host-side `ng serve`). Added `- /app/.angular` as an anonymous volume, mirroring `node_modules`.

### Also done outside this diff (data, no deploy)
- Removed the single mock IBKR paper-trade net-worth snapshot (2026-06-30, $42,471) — the ~$50K spike on the dashboard chart (#308). Chart now peaks at ~$18K.

### Verification
Local `ng serve` + real VPS data over Playwright: budgets shows a working native select with 17 categories, settings 2 selects, zero console errors; net-worth chart reads Jul 1 … Jul 23 with no spike.

Part of #317. Remaining there: #306, #307, #309, #310, #311, #313, #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)