### PR TITLE
fix(bank-sync): reconcile pending transactions on sync (#310)

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/PendingReconciler.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/PendingReconciler.cs
@@ -1,0 +1,46 @@
+namespace FinanceSentry.Modules.BankSync.Application.Services;
+
+using FinanceSentry.Modules.BankSync.Domain;
+
+/// <summary>
+/// Decides which existing <b>pending</b> transactions have been superseded by a settled
+/// (posted) version and should therefore be retired.
+///
+/// A pending transaction and its later posted counterpart hash differently — the pending
+/// version hashes on its transaction date, the posted version on its posted date (see
+/// <see cref="TransactionDeduplicationService"/>) — so deduplication keeps both. Without
+/// reconciliation the pending row lingers forever as a stale duplicate. Once a posted row
+/// exists for the same account + amount + description, the pending row is stale.
+/// </summary>
+public static class PendingReconciler
+{
+    /// <summary>
+    /// Returns the pending rows from <paramref name="existingActive"/> that now have a
+    /// settled (posted) twin — among the existing rows or the batch just inserted.
+    /// Only existing rows are considered for retirement; freshly inserted rows are current.
+    /// </summary>
+    public static IReadOnlyList<Transaction> SelectStalePending(
+        IEnumerable<Transaction> existingActive,
+        IEnumerable<Transaction> newlyInserted)
+    {
+        var existing = existingActive as IReadOnlyList<Transaction> ?? existingActive.ToList();
+
+        var postedKeys = existing
+            .Concat(newlyInserted)
+            .Where(t => !t.IsPending)
+            .Select(Key)
+            .ToHashSet();
+
+        if (postedKeys.Count == 0)
+            return [];
+
+        return existing
+            .Where(t => t.IsPending && postedKeys.Contains(Key(t)))
+            .ToList();
+    }
+
+    // Pending↔posted match key: same account, amount, and merchant text. Deliberately excludes
+    // the date, which is exactly what differs between the two versions.
+    private static string Key(Transaction t) =>
+        $"{t.AccountId}|{t.Amount:F2}|{t.Description.Trim().ToLowerInvariant()}";
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -200,15 +200,7 @@ public class ScheduledSyncService(
         var (candidates, nextCursor) = await _plaid.SyncTransactionsAsync(
             accessToken, account.Id, account.UserId, cred.PlaidSyncCursor, ct);
 
-        var existing = (await _transactions.GetByAccountIdAsync(account.Id, ct))
-            .Select(t => t.UniqueHash)
-            .ToHashSet();
-
-        var newCandidates = _dedup.FilterDuplicates(candidates, existing);
-        var entities = newCandidates.Select(_dedup.ToEntity).ToList();
-
-        if (entities.Count > 0)
-            await _transactions.AddRangeAsync(entities, ct);
+        var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
 
         cred.PlaidSyncCursor = nextCursor;
         cred.UpdateLastUsedAt();
@@ -252,15 +244,7 @@ public class ScheduledSyncService(
         var (candidates, _) = await provider.SyncTransactionsAsync(
             plainToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
 
-        var existing = (await _transactions.GetByAccountIdAsync(account.Id, ct))
-            .Select(t => t.UniqueHash)
-            .ToHashSet();
-
-        var newCandidates = _dedup.FilterDuplicates(candidates, existing);
-        var entities = newCandidates.Select(_dedup.ToEntity).ToList();
-
-        if (entities.Count > 0)
-            await _transactions.AddRangeAsync(entities, ct);
+        var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
 
         // T031: update last sync timestamp on credential
         cred.LastSyncAt = DateTime.UtcNow;
@@ -335,15 +319,7 @@ public class ScheduledSyncService(
         var (candidates, _) = await provider.SyncTransactionsAsync(
             tokenSet.AccessToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
 
-        var existing = (await _transactions.GetByAccountIdAsync(account.Id, ct))
-            .Select(t => t.UniqueHash)
-            .ToHashSet();
-
-        var newCandidates = _dedup.FilterDuplicates(candidates, existing);
-        var entities = newCandidates.Select(_dedup.ToEntity).ToList();
-
-        if (entities.Count > 0)
-            await _transactions.AddRangeAsync(entities, ct);
+        var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
 
         connection.LastSyncAt = DateTime.UtcNow;
         await _truelayerConnections.UpdateAsync(connection, ct);
@@ -409,5 +385,37 @@ public class ScheduledSyncService(
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Persists newly-synced candidates (deduplicated) and then retires any existing pending
+    /// row that now has a settled/posted twin, so pending transactions don't linger as stale
+    /// duplicates once they clear. See <see cref="PendingReconciler"/>.
+    /// </summary>
+    private async Task<IReadOnlyList<Domain.Transaction>> PersistAndReconcileAsync(
+        Guid accountId, IEnumerable<TransactionCandidate> candidates, CancellationToken ct)
+    {
+        var existingRows = (await _transactions.GetByAccountIdAsync(accountId, ct)).ToList();
+        var existingHashes = existingRows.Select(t => t.UniqueHash).ToHashSet();
+
+        var entities = _dedup.FilterDuplicates(candidates, existingHashes)
+            .Select(_dedup.ToEntity)
+            .ToList();
+        if (entities.Count > 0)
+            await _transactions.AddRangeAsync(entities, ct);
+
+        var stale = PendingReconciler.SelectStalePending(existingRows, entities);
+        if (stale.Count > 0)
+        {
+            var now = DateTime.UtcNow;
+            foreach (var t in stale)
+            {
+                t.IsActive = false;
+                t.DeletedAt = now;
+            }
+            await _transactions.SaveChangesAsync(ct);
+        }
+
+        return entities;
     }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/PendingReconcilerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/PendingReconcilerTests.cs
@@ -1,0 +1,82 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Application;
+
+using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Domain;
+using FluentAssertions;
+using Xunit;
+
+public class PendingReconcilerTests
+{
+    private static readonly Guid Account = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid User = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+
+    private static Transaction Tx(decimal amount, string description, bool pending, string hash) =>
+        new(Account, User, amount, new DateTime(2026, 7, 5, 0, 0, 0, DateTimeKind.Utc), description, hash, pending);
+
+    [Fact]
+    public void RetiresPending_WhenPostedTwinExistsAmongExisting()
+    {
+        var pending = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-pending");
+        var posted = Tx(15.38m, "Lidl Ireland Ltd", pending: false, "h-posted");
+
+        var stale = PendingReconciler.SelectStalePending([pending, posted], []);
+
+        stale.Should().ContainSingle().Which.Should().BeSameAs(pending);
+    }
+
+    [Fact]
+    public void RetiresPending_WhenPostedTwinArrivesInNewBatch()
+    {
+        var pending = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-pending");
+        var postedNew = Tx(15.38m, "Lidl Ireland Ltd", pending: false, "h-posted-new");
+
+        var stale = PendingReconciler.SelectStalePending([pending], [postedNew]);
+
+        stale.Should().ContainSingle().Which.Should().BeSameAs(pending);
+    }
+
+    [Fact]
+    public void KeepsPending_WhenNoPostedTwin()
+    {
+        var pending = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-pending");
+        var otherPosted = Tx(9.99m, "Tesco Stores", pending: false, "h-other");
+
+        var stale = PendingReconciler.SelectStalePending([pending, otherPosted], []);
+
+        stale.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void KeepsPending_WhenOnlyTwinIsAlsoPending()
+    {
+        var pendingA = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-a");
+        var pendingB = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-b");
+
+        var stale = PendingReconciler.SelectStalePending([pendingA, pendingB], []);
+
+        stale.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MatchIsCaseInsensitiveOnDescription()
+    {
+        var pending = Tx(20m, "AMAZON.IE", pending: true, "h-pending");
+        var posted = Tx(20m, "amazon.ie", pending: false, "h-posted");
+
+        var stale = PendingReconciler.SelectStalePending([pending, posted], []);
+
+        stale.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void DoesNotRetireFreshlyInsertedPending()
+    {
+        // A pending row only in the new batch is current, never retired here.
+        var newPending = Tx(15.38m, "Lidl Ireland Ltd", pending: true, "h-new-pending");
+        var posted = Tx(15.38m, "Lidl Ireland Ltd", pending: false, "h-posted");
+
+        var stale = PendingReconciler.SelectStalePending([], [newPending, posted]);
+
+        stale.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Part of the UI hardening sweep (#317).

## Problem
Pending and posted versions of a transaction hash differently — pending hashes on its transaction date, posted on its posted date (see `TransactionDeduplicationService`) — so dedup keeps **both**. Once a pending transaction settled, the posted version was inserted as a new row and the pending row was **never retired**, accumulating stale "pending" duplicates. On the live DB, TrueLayer had 35 pending rows, some 3 weeks old.

## Fix
- **`PendingReconciler`** (pure, unit-tested): after a sync batch is persisted, retire any existing pending row that now has a settled (posted) twin for the same **account + amount + description** (the date deliberately excluded — that's what differs between the two versions).
- Extracted the identical persist block from all three sync paths (Plaid / Monobank / TrueLayer) into **`PersistAndReconcileAsync`**, which runs dedup-insert + reconciliation.
- Works with **incremental** syncs (keyed on the settled twin existing, not "absent from this batch").

## Verification
- 6 new unit tests for the reconciler; 331 unit tests green; zero warnings.
- **Live caveat:** can't be exercised end-to-end until TrueLayer consent is reconnected (#309). The existing stale rows were already cleaned directly in the DB (TrueLayer pending 35 → 3, 10 duplicates removed, no data loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)