### PR TITLE
fix(ui): chart hover tooltips (#307) + dashboard range persisted in URL (#306)

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/line-chart/line-chart.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/line-chart/line-chart.component.ts
@@ -119,9 +119,15 @@ export class LineChartComponent implements AfterViewInit, OnDestroy {
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        // Points are hidden (pointRadius: 0); with Chart.js's default intersect:true the
+        // tooltip would only fire when hovering exactly on an invisible point, so it never
+        // showed. Index mode surfaces the nearest point for the hovered x-position.
+        interaction: {mode: 'index', intersect: false},
         plugins: {
           legend: {display: false},
           tooltip: {
+            mode: 'index',
+            intersect: false,
             callbacks: {
               label: tooltipCtx => {
                 const val = tooltipCtx.parsed.y as number;

--- a/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.effects.ts
+++ b/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.effects.ts
@@ -1,5 +1,6 @@
 import {inject, type Signal, untracked} from '@angular/core';
 import {toObservable} from '@angular/core/rxjs-interop';
+import {ActivatedRoute, Router} from '@angular/router';
 import {extractErrorCode} from '@dsdevq-common/core';
 import {rxMethod} from '@ngrx/signals/rxjs-interop';
 import {catchError, EMPTY, pipe, switchMap, tap, timer} from 'rxjs';
@@ -76,16 +77,42 @@ export function dashboardEffects(store: EffectsStore) {
 interface HookStore extends EffectsStore {
   load: () => void;
   loadNetWorthHistory: (range: HistoryRange) => void;
+  setHistoryRange: (range: HistoryRange) => void;
+}
+
+const HISTORY_RANGE_VALUES: readonly HistoryRange[] = ['3m', '6m', '1y', 'all'];
+
+function isHistoryRange(value: string | null): value is HistoryRange {
+  return value !== null && (HISTORY_RANGE_VALUES as readonly string[]).includes(value);
 }
 
 export function dashboardHooks(store: HookStore): void {
   const bankSyncService = inject(BankSyncService);
+  const router = inject(Router);
+  const route = inject(ActivatedRoute);
+
+  // Restore the selected window from the URL so a refresh / deep-link keeps it.
+  const urlRange = route.snapshot.queryParamMap.get('range');
+  if (isHistoryRange(urlRange)) {
+    store.setHistoryRange(urlRange);
+  }
 
   store.load();
-  store.loadNetWorthHistory(store.historyRange());
 
+  // Keep the URL in sync with the selected range (replaceUrl so range clicks don't
+  // pollute browser history), and reload history whenever it changes.
   toObservable(store.historyRange)
-    .pipe(tap(range => untracked(() => store.loadNetWorthHistory(range))))
+    .pipe(
+      tap(range => {
+        void router.navigate([], {
+          relativeTo: route,
+          queryParams: {range},
+          queryParamsHandling: 'merge',
+          replaceUrl: true,
+        });
+        untracked(() => store.loadNetWorthHistory(range));
+      })
+    )
     .subscribe();
 
   rxMethod<void>(


### PR DESCRIPTION
Part of the UI hardening sweep (#317). Both verified end-to-end via Playwright against real data.

- **#307 chart hover tooltips.** The line chart hides its points (`pointRadius: 0`), but Chart.js's default `intersect: true` only shows a tooltip when the cursor is exactly on a point — so it never appeared. Set index-mode interaction (`mode: 'index', intersect: false`) on the chart and tooltip so hovering anywhere along the x-axis surfaces the nearest point's date + value. Verified: hovering shows e.g. "Jul 12 / $15,310".
- **#306 dashboard range persisted in URL.** The 3M/6M/1Y/All window lived only in store state, so refresh/deep-link reset it. The dashboard hooks now read `?range=` on init and write it back (replaceUrl, merge) on change. Verified: click 6M → `?range=6m`; loading `?range=3m` restores the 3M selection.

Remaining in #317: #309, #311, #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)