### PR TITLE
chore(api): add detect-subscriptions CLI verb

### DIFF
--- a/backend/src/FinanceSentry.API/Commands/SubscriptionDetectionCommand.cs
+++ b/backend/src/FinanceSentry.API/Commands/SubscriptionDetectionCommand.cs
@@ -1,0 +1,26 @@
+namespace FinanceSentry.API.Commands;
+
+using FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// One-shot maintenance command: runs the recurring subscription-detection job on demand
+/// (the same job Hangfire schedules daily). Useful after a detection-logic change or a
+/// data backfill, since Hangfire here uses in-memory storage and can't be triggered out of band.
+///
+/// Invoked via <c>dotnet FinanceSentry.API.dll detect-subscriptions</c> — not a web endpoint.
+/// </summary>
+public static class SubscriptionDetectionCommand
+{
+    public const string Verb = "detect-subscriptions";
+
+    public static async Task RunAsync(IServiceProvider services, string[] args)
+    {
+        using var scope = services.CreateScope();
+        var job = scope.ServiceProvider.GetRequiredService<SubscriptionDetectionJob>();
+
+        Console.WriteLine("[detect-subscriptions] running...");
+        await job.ExecuteAsync();
+        Console.WriteLine("[detect-subscriptions] done.");
+    }
+}

--- a/backend/src/FinanceSentry.API/Program.cs
+++ b/backend/src/FinanceSentry.API/Program.cs
@@ -84,6 +84,12 @@ if (args.Length > 0 && args[0] == RecategorizationCommand.Verb)
     return;
 }
 
+if (args.Length > 0 && args[0] == SubscriptionDetectionCommand.Verb)
+{
+    await SubscriptionDetectionCommand.RunAsync(app.Services, args);
+    return;
+}
+
 app.UseSerilogRequestLogging();
 app.UseCors("Frontend");
 app.UseMiddleware<ErrorHandlingMiddleware>();


### PR DESCRIPTION
Adds a one-shot `detect-subscriptions` CLI verb (mirrors `recategorize`) to run the subscription-detection job on demand. Hangfire uses in-memory storage here, so the daily recurring job can't be triggered out of band — this lets us re-detect after the #313 logic fix. 🤖 Generated with [Claude Code](https://claude.com/claude-code)