### PR TITLE
fix(alerts): stop the alerts page crashing on unmapped alert types

### DIFF
--- a/frontend/src/app/modules/alerts/constants/alert-type-meta.constants.ts
+++ b/frontend/src/app/modules/alerts/constants/alert-type-meta.constants.ts
@@ -24,4 +24,24 @@ export const ALERT_TYPE_META_REGISTRY = {
     label: 'unusual spend',
     description: 'This category is spending faster than usual.',
   },
+  ['PolicyViolation']: {
+    icon: 'ShieldAlert',
+    label: 'policy violation',
+    description: 'A holding breached one of your risk-policy rules.',
+  },
+  ['Opportunity']: {
+    icon: 'Lightbulb',
+    label: 'opportunity',
+    description: 'A potential opportunity surfaced from the research scan.',
+  },
 } satisfies Record<AlertType, AlertTypeMeta>;
+
+/**
+ * Fallback for alert types the backend may add before the frontend registry catches up —
+ * keeps the alerts page from crashing on an unmapped type.
+ */
+export const DEFAULT_ALERT_TYPE_META: AlertTypeMeta = {
+  icon: 'Bell',
+  label: 'alert',
+  description: 'You have a new alert.',
+};

--- a/frontend/src/app/modules/alerts/models/alert/alert.model.ts
+++ b/frontend/src/app/modules/alerts/models/alert/alert.model.ts
@@ -1,4 +1,9 @@
-export type AlertType = 'LowBalance' | 'SyncFailure' | 'UnusualSpend';
+export type AlertType =
+  | 'LowBalance'
+  | 'SyncFailure'
+  | 'UnusualSpend'
+  | 'PolicyViolation'
+  | 'Opportunity';
 export type AlertSeverity = 'Error' | 'Warning' | 'Info';
 export type AlertFilter = 'all' | 'unread' | 'error' | 'warning' | 'info';
 

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -11,7 +11,11 @@ import {
 } from '@dsdevq-common/ui';
 
 import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
-import {ALERT_TYPE_META_REGISTRY} from '../../constants/alert-type-meta.constants';
+import {
+  ALERT_TYPE_META_REGISTRY,
+  type AlertTypeMeta,
+  DEFAULT_ALERT_TYPE_META,
+} from '../../constants/alert-type-meta.constants';
 import {
   type Alert,
   type AlertFilter,
@@ -86,15 +90,22 @@ export class AlertsComponent {
   ];
 
   public iconFor(type: AlertType): LucideIconName {
-    return ALERT_TYPE_META_REGISTRY[type].icon;
+    return this.metaFor(type).icon;
   }
 
   public typeLabel(type: AlertType): string {
-    return ALERT_TYPE_META_REGISTRY[type].label;
+    return this.metaFor(type).label;
   }
 
   public typeDescription(type: AlertType): string {
-    return ALERT_TYPE_META_REGISTRY[type].description;
+    return this.metaFor(type).description;
+  }
+
+  // Tolerate alert types the backend added before this registry did (e.g. PolicyViolation,
+  // Opportunity) — an unmapped type must not crash the whole alerts page.
+  private metaFor(type: AlertType): AlertTypeMeta {
+    const registry = ALERT_TYPE_META_REGISTRY as Record<string, AlertTypeMeta | undefined>;
+    return registry[type] ?? DEFAULT_ALERT_TYPE_META;
   }
 
   public severityFor(severity: AlertSeverity): AlertItemSeverity {


### PR DESCRIPTION
## Bug
`TypeError: Cannot read properties of undefined (reading 'icon')` in `iconFor` took down the whole alerts page at runtime. The backend emits **five** alert types (LowBalance, SyncFailure, UnusualSpend, **PolicyViolation**, **Opportunity**) but the frontend meta registry only had three — so `ALERT_TYPE_META_REGISTRY[type]` was `undefined` for the two new ones.

## Fix
- Added `PolicyViolation` (ShieldAlert) and `Opportunity` (Lightbulb) to the `AlertType` union + registry.
- Made `iconFor`/`typeLabel`/`typeDescription` fall back to a default meta (`DEFAULT_ALERT_TYPE_META`) so a future backend type can never crash the page again.

## Verified
Playwright against live data: 20 alerts render, "Policy violation: SOL" shows with its shield icon + label, **zero runtime errors** (was a hard crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)