### PR TITLE
docs: repoint README badges/links to the lifekit-hq org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Finance Sentry
 
-[![Release](https://img.shields.io/github/v/release/dsdevq/finance-sentry?sort=semver)](https://github.com/dsdevq/finance-sentry/releases)
-[![Backend CI](https://github.com/dsdevq/finance-sentry/actions/workflows/backend-ci.yml/badge.svg)](https://github.com/dsdevq/finance-sentry/actions/workflows/backend-ci.yml)
-[![Frontend CI](https://github.com/dsdevq/finance-sentry/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/dsdevq/finance-sentry/actions/workflows/frontend-ci.yml)
-[![Deploy](https://github.com/dsdevq/finance-sentry/actions/workflows/deploy.yml/badge.svg)](https://github.com/dsdevq/finance-sentry/actions/workflows/deploy.yml)
+[![Release](https://img.shields.io/github/v/release/lifekit-hq/finance-sentry?sort=semver)](https://github.com/lifekit-hq/finance-sentry/releases)
+[![Backend CI](https://github.com/lifekit-hq/finance-sentry/actions/workflows/backend-ci.yml/badge.svg)](https://github.com/lifekit-hq/finance-sentry/actions/workflows/backend-ci.yml)
+[![Frontend CI](https://github.com/lifekit-hq/finance-sentry/actions/workflows/frontend-ci.yml/badge.svg)](https://github.com/lifekit-hq/finance-sentry/actions/workflows/frontend-ci.yml)
+[![Deploy](https://github.com/lifekit-hq/finance-sentry/actions/workflows/deploy.yml/badge.svg)](https://github.com/lifekit-hq/finance-sentry/actions/workflows/deploy.yml)
 
 Personal finance aggregation platform — bank accounts, crypto, brokerage, budgets, subscriptions, and alerts in one place.
 
@@ -146,7 +146,7 @@ Finance Sentry ships as a single product with one [SemVer](https://semver.org/) 
 - release-please maintains an open **release PR** that accumulates commits into a draft [CHANGELOG](CHANGELOG.md) entry. Merging it cuts the release: tag `vX.Y.Z`, GitHub Release with notes, and version bumps in `version.txt`, `frontend/package.json`, and `FinanceSentry.API.csproj` — all in one automated commit.
 - Deploys are continuous; releases are milestones. Cut one whenever a meaningful increment is complete (typically after each feature spec lands).
 
-The current version lives in [`version.txt`](version.txt). Release history: [GitHub Releases](https://github.com/dsdevq/finance-sentry/releases) · [CHANGELOG.md](CHANGELOG.md).
+The current version lives in [`version.txt`](version.txt). Release history: [GitHub Releases](https://github.com/lifekit-hq/finance-sentry/releases) · [CHANGELOG.md](CHANGELOG.md).
 
 ## Development Workflow
 


### PR DESCRIPTION
## What

`finance-sentry` moved from `dsdevq/*` to the **`lifekit-hq`** GitHub org. This repoints the README release/CI/deploy badges and release links to the canonical org slug.

## Scope / safety

- **README only** — 5 badge/link references.
- CI workflows use the dynamic `github.repository` context, not a hardcoded slug — **unaffected**.
- GitHub redirects the old `dsdevq/*` paths (badges kept rendering), so this is tidiness, not a fix.
- The `@dsdevq-common` npm **package scope** (not a repo path) is intentionally left alone.

## Why it's in the org

finance-sentry is the **finance-domain service on the MCP bus** — consumed by the ledger/finance agent, the same membership signature as devclaw for the software domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)