### PR TITLE
fix(research): harden ledger source coverage

### DIFF
--- a/backend/src/FinanceSentry.Mcp/Tools/GetAnalystActionsTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/GetAnalystActionsTool.cs
@@ -20,6 +20,7 @@ public sealed class GetAnalystActionsTool(
         [Description("Optional ticker filter (e.g. MU). Omit for a whole-universe query.")] string? ticker = null,
         [Description("Optional ISO-8601 cutoff date. Only actions on/after this date are returned. Default: 30 days ago.")] DateTimeOffset? since = null,
         [Description("Optional action-type filter: Upgrade | Downgrade | Initiate | TargetChange | Reiterate | TopIdea.")] string? actionType = null,
+        [Description("Optional companion-event reference id. When provided, resolves the exact analyst action row and ignores ticker/since/actionType filters.")] Guid? referenceId = null,
         [Description("Max results, default 50, max 200.")] int limit = DefaultLimit,
         CancellationToken cancellationToken = default)
     {
@@ -30,6 +31,6 @@ public sealed class GetAnalystActionsTool(
         var effectiveLimit = limit <= 0 ? DefaultLimit : Math.Min(limit, MaxLimit);
 
         return await handler.Handle(
-            new GetAnalystActionsQuery(ticker, sinceDate, actionType, effectiveLimit), cancellationToken);
+            new GetAnalystActionsQuery(ticker, sinceDate, actionType, effectiveLimit, referenceId), cancellationToken);
     }
 }

--- a/backend/src/FinanceSentry.Mcp/Tools/SearchMarketNewsTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/SearchMarketNewsTool.cs
@@ -8,11 +8,11 @@ namespace FinanceSentry.Mcp.Tools;
 
 [McpServerToolType]
 public sealed class SearchMarketNewsTool(
-    IQueryHandler<SearchMarketNewsQuery, IReadOnlyList<NewsArticleDto>> handler)
+    IQueryHandler<SearchMarketNewsQuery, SearchMarketNewsResult> handler)
 {
     [McpServerTool(Name = "search_market_news")]
     [Description("Search ingested market news (Yahoo Finance RSS per ticker + Fed press releases + registered market-wide and thesis sources). Filter by keyword, tickers, thesis, and cutoff date. Returns most-recent-first. Ticker/market-wide sources are ingested every 30 minutes; Fed press every 6 hours. Pass thesisId to see only articles tagged to a specific thesis (e.g. TrendForce DRAM coverage).")]
-    public async Task<IReadOnlyList<NewsArticleDto>> ExecuteAsync(
+    public async Task<SearchMarketNewsResult> ExecuteAsync(
         [Description("Optional free-text query — matched against title + summary (case-insensitive).")] string? query = null,
         [Description("Optional list of tickers to filter by (e.g. NVDA, AAPL). Matches articles tagged with any of them.")] IReadOnlyList<string>? tickers = null,
         [Description("Optional thesis GUID. Returns only articles tagged with that thesis (via a registered thesis source or keyword match).")] Guid? thesisId = null,

--- a/backend/src/FinanceSentry.Modules.Research/API/Controllers/NewsController.cs
+++ b/backend/src/FinanceSentry.Modules.Research/API/Controllers/NewsController.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 [ApiController]
 [Route("research/news")]
 public class NewsController(
-    IQueryHandler<SearchMarketNewsQuery, IReadOnlyList<NewsArticleDto>> search,
+    IQueryHandler<SearchMarketNewsQuery, SearchMarketNewsResult> search,
     IQueryHandler<GetNewsForTickerQuery, IReadOnlyList<NewsArticleDto>> forTicker) : ControllerBase
 {
     [HttpGet]
@@ -25,7 +25,7 @@ public class NewsController(
             : tickers.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
 
         var result = await search.Handle(new SearchMarketNewsQuery(q, tickerList, thesisId, since, limit), ct);
-        return Ok(result);
+        return Ok(result.Articles);
     }
 
     [HttpGet("{ticker}")]

--- a/backend/src/FinanceSentry.Modules.Research/API/Responses/NewsArticleDto.cs
+++ b/backend/src/FinanceSentry.Modules.Research/API/Responses/NewsArticleDto.cs
@@ -9,3 +9,18 @@ public record NewsArticleDto(
     IReadOnlyList<string> Tickers,
     IReadOnlyList<string> Categories,
     DateTimeOffset PublishedAt);
+
+public record NewsSourceHealthDto(
+    Guid SourceId,
+    string Name,
+    string Url,
+    int ConsecutiveFailures,
+    DateTimeOffset? LastSuccessAt,
+    string? LastFailureReason,
+    string Status);
+
+public record SearchMarketNewsResult(
+    IReadOnlyList<NewsArticleDto> Articles,
+    IReadOnlyList<NewsSourceHealthDto> SourceHealth,
+    string Coverage,
+    DateTimeOffset RetrievedAt);

--- a/backend/src/FinanceSentry.Modules.Research/Application/Queries/GetAnalystActionsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Queries/GetAnalystActionsQuery.cs
@@ -13,7 +13,8 @@ public record GetAnalystActionsQuery(
     string? Ticker,
     DateOnly Since,
     string? ActionType,
-    int Limit) : IQuery<AnalystActionsResult>;
+    int Limit,
+    Guid? ReferenceId = null) : IQuery<AnalystActionsResult>;
 
 public class GetAnalystActionsQueryHandler(
     IAnalystActionRepository actions,
@@ -22,6 +23,13 @@ public class GetAnalystActionsQueryHandler(
 {
     public async Task<AnalystActionsResult> Handle(GetAnalystActionsQuery query, CancellationToken ct)
     {
+        if (query.ReferenceId is { } referenceId)
+        {
+            var action = await actions.GetByIdAsync(referenceId, ct);
+            var referenceRows = action is null ? [] : new[] { action };
+            return new AnalystActionsResult(Project(referenceRows), "reference", DateTimeOffset.UtcNow);
+        }
+
         AnalystActionType? typeFilter = null;
         if (!string.IsNullOrWhiteSpace(query.ActionType)
             && Enum.TryParse<AnalystActionType>(query.ActionType, ignoreCase: true, out var parsed))
@@ -37,13 +45,16 @@ public class GetAnalystActionsQueryHandler(
             coverage = await universe.IsInUniverseAsync(query.Ticker, ct) ? "inUniverse" : "notInUniverse";
         }
 
-        var dtos = rows
+        return new AnalystActionsResult(Project(rows), coverage, DateTimeOffset.UtcNow);
+    }
+
+    private static List<AnalystActionDto> Project(IEnumerable<AnalystAction> rows)
+    {
+        return rows
             .Select(a => new AnalystActionDto(
                 a.Ticker, a.Firm, a.ActionType.ToString(),
                 a.PriorRating, a.NewRating, a.PriorTarget, a.NewTarget,
                 a.ActionDate, a.Source, a.SourceUrl, a.IngestedAt))
             .ToList();
-
-        return new AnalystActionsResult(dtos, coverage, DateTimeOffset.UtcNow);
     }
 }

--- a/backend/src/FinanceSentry.Modules.Research/Application/Queries/SearchMarketNewsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Queries/SearchMarketNewsQuery.cs
@@ -9,12 +9,12 @@ public record SearchMarketNewsQuery(
     IReadOnlyList<string>? Tickers,
     Guid? ThesisId,
     DateTimeOffset? Since,
-    int Limit) : IQuery<IReadOnlyList<NewsArticleDto>>;
+    int Limit) : IQuery<SearchMarketNewsResult>;
 
-public class SearchMarketNewsQueryHandler(INewsRepository repo)
-    : IQueryHandler<SearchMarketNewsQuery, IReadOnlyList<NewsArticleDto>>
+public class SearchMarketNewsQueryHandler(INewsRepository repo, INewsSourceRepository sources)
+    : IQueryHandler<SearchMarketNewsQuery, SearchMarketNewsResult>
 {
-    public async Task<IReadOnlyList<NewsArticleDto>> Handle(SearchMarketNewsQuery query, CancellationToken ct)
+    public async Task<SearchMarketNewsResult> Handle(SearchMarketNewsQuery query, CancellationToken ct)
     {
         var items = await repo.SearchAsync(
             query.Query,
@@ -24,10 +24,41 @@ public class SearchMarketNewsQueryHandler(INewsRepository repo)
             query.Limit <= 0 ? 25 : query.Limit,
             ct);
 
-        return items
+        var articles = items
             .Select(a => new NewsArticleDto(
                 a.Id, a.Source, a.Title, a.Url, a.Summary,
                 a.Tickers, a.Categories, a.PublishedAt))
+            .ToList();
+
+        var health = await GetSourceHealthAsync(query.ThesisId, ct);
+        var coverage = health.Any(h => h.ConsecutiveFailures > 0) ? "degraded" : "ok";
+
+        return new SearchMarketNewsResult(articles, health, coverage, DateTimeOffset.UtcNow);
+    }
+
+    private async Task<IReadOnlyList<NewsSourceHealthDto>> GetSourceHealthAsync(Guid? thesisId, CancellationToken ct)
+    {
+        if (thesisId is null)
+        {
+            return [];
+        }
+
+        var all = await sources.ListAllAsync(ct);
+        return all
+            .Where(s => s.ThesisId == thesisId)
+            .Select(s => new NewsSourceHealthDto(
+                s.Id,
+                s.Name,
+                s.Url,
+                s.ConsecutiveFailures,
+                s.LastSuccessAt,
+                s.LastFailureReason,
+                s.ConsecutiveFailures switch
+                {
+                    0 => "ok",
+                    1 => "degraded",
+                    _ => "down",
+                }))
             .ToList();
     }
 }

--- a/backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IAnalystActionRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Domain/Repositories/IAnalystActionRepository.cs
@@ -20,4 +20,7 @@ public interface IAnalystActionRepository
         AnalystActionType? actionType,
         int limit,
         CancellationToken ct = default);
+
+    /// <summary>Resolve a companion event reference back to its exact source-carrying action row.</summary>
+    Task<AnalystAction?> GetByIdAsync(Guid id, CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/NewsSourceSeedJob.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/NewsSourceSeedJob.cs
@@ -17,7 +17,7 @@ public sealed class NewsSourceSeedJob(
     ResearchDbContext research,
     ILogger<NewsSourceSeedJob> logger)
 {
-    private const string TrendForceUrl = "https://www.trendforce.com/presscenter/";
+    private const string TrendForceUrl = "https://www.trendforce.com/presscenter/news";
 
     private static readonly (string Name, string Url)[] MarketWideRssDefaults =
     [

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/AnalystActionRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Persistence/Repositories/AnalystActionRepository.cs
@@ -84,6 +84,9 @@ public class AnalystActionRepository(ResearchDbContext db) : IAnalystActionRepos
             .ToListAsync(ct);
     }
 
+    public async Task<AnalystAction?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => await db.AnalystActions.AsNoTracking().FirstOrDefaultAsync(a => a.Id == id, ct);
+
     // Fill NULL target/rating fields on <paramref name="target"/> from <paramref name="source"/>;
     // never overwrite an already-populated field (keep the richer record — FR-003).
     private static void Merge(AnalystAction target, AnalystAction source)

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/TrendForcePageSource.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/TrendForcePageSource.cs
@@ -19,7 +19,12 @@ public sealed class TrendForcePageSource(
     private const string Host = "trendforce.com";
 
     private static readonly string[] ArticleSelectors =
-        ["article", ".press-item", "li.item", "div.item", ".list li"];
+    [
+        ".press-news-list .list-items > .list-item",
+        ".list-items > .list-item",
+        "article",
+        ".press-item"
+    ];
 
     public bool CanHandle(string url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
@@ -61,7 +66,7 @@ public sealed class TrendForcePageSource(
 
         foreach (var node in nodes)
         {
-            var anchor = node.QuerySelector("a[href]");
+            var anchor = node.QuerySelector("a.title-link[href], h3 a[href], a[href]");
             if (anchor is null)
             {
                 continue;
@@ -108,7 +113,7 @@ public sealed class TrendForcePageSource(
 
     private static string? ExtractTitle(IElement node, IElement anchor)
     {
-        var heading = node.QuerySelector("h1, h2, h3, h4, .title");
+        var heading = node.QuerySelector("h1, h2, h3, .title, a.title-link");
         var text = heading?.TextContent ?? anchor.TextContent;
         return string.IsNullOrWhiteSpace(text) ? null : text.Trim();
     }
@@ -117,7 +122,7 @@ public sealed class TrendForcePageSource(
     {
         var timeEl = node.QuerySelector("time[datetime]");
         var raw = timeEl?.GetAttribute("datetime")
-            ?? node.QuerySelector("time, .date, .time")?.TextContent;
+            ?? node.QuerySelector("time, .date, .time, h4.color-green")?.TextContent;
 
         return DateTimeOffset.TryParse(raw, out var parsed) ? parsed : DateTimeOffset.UtcNow;
     }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/CompanionFakes.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/CompanionFakes.cs
@@ -94,6 +94,9 @@ internal sealed class FakeAnalystActionRepository : IAnalystActionRepository
         return Task.FromResult<IReadOnlyList<AnalystAction>>(
             q.OrderByDescending(a => a.ActionDate).Take(limit).ToList());
     }
+
+    public Task<AnalystAction?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => Task.FromResult(Actions.FirstOrDefault(a => a.Id == id));
 }
 
 internal sealed class FakeBankingTotalsReader(params Guid[] userIds) : IBankingTotalsReader

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/GetAnalystActionsQueryTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/GetAnalystActionsQueryTests.cs
@@ -75,4 +75,30 @@ public sealed class GetAnalystActionsQueryTests
         result.Actions[0].ActionType.Should().Be("Upgrade");
         result.Actions[0].Source.Should().Be("marketbeat");
     }
+
+    [Fact]
+    public async Task ReferenceId_resolves_exact_source_row()
+    {
+        var id = Guid.NewGuid();
+        var actions = new FakeAnalystActionRepository();
+        actions.Actions.Add(new AnalystAction
+        {
+            Id = id,
+            Ticker = "GRAB",
+            Firm = "Barclays",
+            ActionType = AnalystActionType.Reiterate,
+            NewRating = "Overweight",
+            ActionDate = new DateOnly(2026, 7, 23),
+            Source = "marketbeat",
+            SourceUrl = "https://www.marketbeat.com/ratings/",
+        });
+
+        var result = await new GetAnalystActionsQueryHandler(actions, new FakeAnalystUniverseRepository())
+            .Handle(new GetAnalystActionsQuery("NVDA", Since, null, 50, id), default);
+
+        result.Coverage.Should().Be("reference");
+        result.Actions.Should().ContainSingle();
+        result.Actions[0].Ticker.Should().Be("GRAB");
+        result.Actions[0].SourceUrl.Should().Be("https://www.marketbeat.com/ratings/");
+    }
 }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/SearchMarketNewsQueryTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/SearchMarketNewsQueryTests.cs
@@ -1,0 +1,78 @@
+namespace FinanceSentry.Modules.Research.Tests.Companion;
+
+using FinanceSentry.Modules.Research.Application.Queries;
+using FinanceSentry.Modules.Research.Domain;
+using FinanceSentry.Modules.Research.Domain.Repositories;
+using FluentAssertions;
+using Xunit;
+
+public sealed class SearchMarketNewsQueryTests
+{
+    [Fact]
+    public async Task Thesis_search_reports_degraded_coverage_when_attached_source_is_failing()
+    {
+        var thesisId = Guid.NewGuid();
+        var sourceId = Guid.NewGuid();
+        var sources = new FakeNewsSourceRepository();
+        sources.Sources.Add(new NewsSource
+        {
+            Id = sourceId,
+            Name = "TrendForce Press Center",
+            Kind = NewsSourceKind.Page,
+            Url = "https://www.trendforce.com/presscenter/news",
+            ThesisId = thesisId,
+            ConsecutiveFailures = 18,
+            LastFailureReason = "article list not found",
+        });
+
+        var result = await new SearchMarketNewsQueryHandler(new FakeNewsRepository(), sources)
+            .Handle(new SearchMarketNewsQuery(null, null, thesisId, null, 25), default);
+
+        result.Coverage.Should().Be("degraded");
+        result.SourceHealth.Should().ContainSingle();
+        result.SourceHealth[0].Status.Should().Be("down");
+        result.SourceHealth[0].ConsecutiveFailures.Should().Be(18);
+    }
+
+    private sealed class FakeNewsRepository : INewsRepository
+    {
+        public Task<IReadOnlyList<NewsArticle>> SearchAsync(
+            string? query,
+            IReadOnlyCollection<string>? tickers,
+            Guid? thesisId,
+            DateTimeOffset? since,
+            int limit,
+            CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<NewsArticle>>([]);
+
+        public Task<IReadOnlyList<NewsArticle>> GetForTickerAsync(
+            string ticker, DateTimeOffset? since, int limit, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<NewsArticle>>([]);
+
+        public Task<int> InsertNewAsync(IReadOnlyCollection<NewsArticle> articles, CancellationToken ct = default)
+            => Task.FromResult(articles.Count);
+    }
+
+    private sealed class FakeNewsSourceRepository : INewsSourceRepository
+    {
+        public List<NewsSource> Sources { get; } = [];
+
+        public Task<IReadOnlyList<NewsSource>> ListEnabledAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<NewsSource>>(Sources.Where(s => s.Enabled).ToList());
+
+        public Task<IReadOnlyList<NewsSource>> ListAllAsync(CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<NewsSource>>(Sources.ToList());
+
+        public Task<NewsSource?> GetByUrlAsync(string url, CancellationToken ct = default)
+            => Task.FromResult(Sources.FirstOrDefault(s => s.Url == url));
+
+        public Task<Guid> AddAsync(NewsSource source, CancellationToken ct = default)
+        {
+            Sources.Add(source);
+            return Task.FromResult(source.Id);
+        }
+
+        public Task UpdateAsync(NewsSource source, CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+}

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/TrendForcePageContractTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/TrendForcePageContractTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 /// </summary>
 public sealed class TrendForcePageContractTests
 {
-    private const string PageUrl = "https://www.trendforce.com/presscenter/";
+    private const string PageUrl = "https://www.trendforce.com/presscenter/news";
 
     private const string Fixture = """
     <html><body>
@@ -26,6 +26,25 @@ public sealed class TrendForcePageContractTests
           <time datetime="2026-07-20">Jul 20, 2026</time>
         </article>
       </div>
+    </body></html>
+    """;
+
+    private const string CurrentShapeFixture = """
+    <html><body>
+      <div class="navbar navbar-inner press-news-list">
+        <div class="list-items text-left">
+          <div class="list-item">
+            <div class="row">
+              <div class="col-md-12 margin-t-20 padding-l-r-15">
+                <h3 class="font-size-18"><a class="title-link" href="/presscenter/news/20260709-13140.html"><strong>Long-Term Agreements Cap Price Increases; Server DRAM Contract Prices Expected to Rise 13-18% QoQ in 3Q26, Says TrendForce</strong></a></h3>
+                <h4 class="font-size-16 color-green margin-t-10"><strong>9 July 2026</strong></h4>
+                <p class="font-size-16">TrendForce's latest memory pricing survey indicates expected price hikes.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <ul class="list"><li><a href="/presscenter/news/Semiconductors">Semiconductors</a></li></ul>
     </body></html>
     """;
 
@@ -55,6 +74,18 @@ public sealed class TrendForcePageContractTests
         var act = async () => await TrendForcePageSource.ParseAsync(drifted, PageUrl);
 
         await act.Should().ThrowAsync<NewsSourceParseException>();
+    }
+
+    [Fact]
+    public async Task Parse_extracts_current_press_news_list_shape()
+    {
+        var articles = await TrendForcePageSource.ParseAsync(CurrentShapeFixture, PageUrl);
+
+        articles.Should().ContainSingle();
+        articles[0].Title.Should().Contain("Server DRAM Contract Prices");
+        articles[0].Url.Should().Be("https://www.trendforce.com/presscenter/news/20260709-13140.html");
+        articles[0].PublishedAt.Should().Be(DateTimeOffset.Parse("9 July 2026"));
+        articles[0].Summary.Should().Contain("memory pricing");
     }
 
     [Fact(Skip = "Live network smoke test — run manually to confirm TrendForce markup still parses.")]

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRCredentialSyncStateTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/IBKRCredentialSyncStateTests.cs
@@ -1,0 +1,53 @@
+using FinanceSentry.Modules.BrokerageSync.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace FinanceSentry.Tests.Unit.BrokerageSync;
+
+public sealed class IBKRCredentialSyncStateTests
+{
+    [Fact]
+    public void RecordSyncError_DoesNotAdvanceLastSyncAt()
+    {
+        var credential = MakeCredential();
+
+        credential.RecordSyncError("timeout");
+
+        credential.LastSyncAt.Should().BeNull();
+        credential.LastSyncError.Should().Be("timeout");
+    }
+
+    [Fact]
+    public async Task RecordSyncSuccess_ClearsPriorErrorAndAdvancesLastSyncAt()
+    {
+        var credential = MakeCredential();
+        credential.RecordSyncError("timeout");
+
+        await Task.Delay(1);
+        credential.RecordSyncSuccess();
+
+        credential.LastSyncAt.Should().NotBeNull();
+        credential.LastSyncError.Should().BeNull();
+    }
+
+    private static IBKRCredential MakeCredential()
+    {
+        var credential = new IBKRCredential(
+            Guid.NewGuid(),
+            "FINSENTRY",
+            "access-token",
+            "dh-pem",
+            [1],
+            [2],
+            [3],
+            [4],
+            [5],
+            [6],
+            [7],
+            [8],
+            [9],
+            keyVersion: 1);
+        credential.UpdateAccountId("U1234567");
+        return credential;
+    }
+}


### PR DESCRIPTION
## Summary
- update TrendForce Press Center ingestion to use the current /presscenter/news source and parse the live list-item/title-link markup without ingesting nav/category links
- expose thesis-attached registered source health in search_market_news so Ledger can see degraded/down source coverage instead of trusting an empty result
- add referenceId resolution to get_analyst_actions so Companion AnalystAction events can be resolved directly to source/sourceUrl rows
- add IBKR sync-state regression coverage proving failures record LastSyncError without advancing LastSyncAt and later success clears the error

## Root-cause read
- TrendForce: real bug. Seeded URL/parser assumptions drifted from the current Press Center page, and source failures were only alert-level state; dependent thesis/news queries had no coverage-confidence signal.
- Analyst actions: real contract gap. Companion emitted ReferenceId for Research rows, but the resolver tool only accepted ticker/date/action filters, leaving Ledger no guaranteed source lookup path.
- IBKR: likely benign retry, not a stale-price hole. Existing command code records LastSyncError on failure and only records LastSyncAt on success; this PR adds regression coverage for that state transition.

## Verification
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/tests/FinanceSentry.Modules.Research.Tests/FinanceSentry.Modules.Research.Tests.csproj --filter 'FullyQualifiedName~TrendForcePageContractTests|FullyQualifiedName~GetAnalystActionsQueryTests|FullyQualifiedName~SearchMarketNewsQueryTests'
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj --filter 'FullyQualifiedName~IBKRCredentialSyncStateTests|FullyQualifiedName~IBKRSyncJobTests'
- /home/node/.openclaw/tools/dotnet9/dotnet build backend/FinanceSentry.sln --no-restore
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/tests/FinanceSentry.Mcp.Tests/FinanceSentry.Mcp.Tests.csproj --no-build --filter 'FullyQualifiedName~ToolNameContractTests|FullyQualifiedName~ToolRegistryTests|FullyQualifiedName~ToolResolutionTests'

Full solution test note: /home/node/.openclaw/tools/dotnet9/dotnet test backend/FinanceSentry.sln --no-build still has unrelated existing failures: three FinanceSentry.Mcp.Tests ToolParityTests fail on missing ISyncJobRepository while activating BankingAccountsReader, and one Binance integration contract returns 500 instead of 201. The changed Research/Unit/MCP contract slices are green, and the full solution build is zero-warning green.