### PR TITLE
test(crypto): fix Binance connect contract harness

### DIFF
--- a/backend/tests/FinanceSentry.Tests.Integration/Binance/CryptoControllerContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/Binance/CryptoControllerContractTests.cs
@@ -295,6 +295,9 @@ public class CryptoApiFactory : WebApplicationFactory<Program>
             .Setup(r => r.UpsertRangeAsync(It.IsAny<IReadOnlyList<CryptoHolding>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         HoldingRepoMock
+            .Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        HoldingRepoMock
             .Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
     }


### PR DESCRIPTION
## Summary
- fixes the Binance connect contract test harness so the mocked holding repository returns the same non-null empty collection as the EF repository
- documents the root cause as test-only: the production repository contract is non-null and the real implementation uses ToListAsync()

## Root cause
The failing contract was not a Companion registration or production Binance sync defect. The full API test host reached SyncBinanceHoldingsCommandHandler.UpdateCostBasisAsync after connect. That method asks ICryptoHoldingRepository.GetByUserIdAsync for persisted holdings. The test harness used a loose Moq repository and did not set up that method, so Moq returned null and the handler threw a NullReferenceException while iterating. The production CryptoHoldingRepository returns ToListAsync(), which is an empty list when no holdings exist.

## Verification
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/tests/FinanceSentry.Tests.Integration/FinanceSentry.Tests.Integration.csproj -c Release --filter "FullyQualifiedName=FinanceSentry.Tests.Integration.Binance.CryptoControllerConnectContractTests.Connect_ValidCredentials_Returns201WithShape" --logger "console;verbosity=minimal"
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/tests/FinanceSentry.Tests.Integration/FinanceSentry.Tests.Integration.csproj -c Release --no-build --filter "FullyQualifiedName~Binance" --logger "console;verbosity=minimal" (17 passed)
- /home/node/.openclaw/tools/dotnet9/dotnet restore backend/FinanceSentry.sln
- /home/node/.openclaw/tools/dotnet9/dotnet build backend/FinanceSentry.sln -c Release --no-restore (0 warnings)
- /home/node/.openclaw/tools/dotnet9/dotnet test backend/FinanceSentry.sln -c Release --no-build --filter "Category!=Integration" --logger "console;verbosity=minimal" (fails only the 3 pre-existing ToolParityTests on missing ISyncJobRepository while activating BankingAccountsReader)

## Production evidence
No live database or production Binance account was reached from this runtime. The not-a-production-bug verdict is code-level evidence from the repository interface and EF implementation, plus the passing API contract after the mock was corrected.