### PR TITLE
fix(bank-sync): treat provider 429s as transient, no false SyncFailure alert

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -67,6 +67,17 @@ public class ScheduledSyncService(
     private readonly IAlertGeneratorService _alerts = alerts;
     private readonly IUserAlertPreferencesReader _userPreferences = userPreferences;
 
+    /// <summary>
+    /// Error codes that represent a transient, self-healing condition (provider rate-limit /
+    /// 429). These must not mark the account failed or fire a SyncFailure alert — the next
+    /// scheduled cycle retries and clears the state on its own.
+    /// </summary>
+    private static readonly HashSet<string> TransientErrorCodes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "MONOBANK_RATE_LIMITED",
+        "RATE_LIMIT_EXCEEDED",
+    };
+
     /// <inheritdoc />
     public async Task<SyncResult> PerformFullSyncAsync(
           Guid accountId,
@@ -110,6 +121,7 @@ public class ScheduledSyncService(
         catch (Exception ex)
         {
             var errorCode = ExtractErrorCode(ex.Message, account.Provider);
+            var isTransient = errorCode is not null && TransientErrorCodes.Contains(errorCode);
 
             job.MarkFailed(ex.Message, errorCode);
             await _syncJobs.UpdateAsync(job, ct);
@@ -121,6 +133,8 @@ public class ScheduledSyncService(
                 {
                     if (errorCode is "ITEM_LOGIN_REQUIRED" or "MONOBANK_TOKEN_INVALID")
                         freshAccount.MarkReauthRequired();
+                    else if (isTransient && freshAccount.SyncStatus == "syncing")
+                        freshAccount.MarkTransientRetry();
                     else if (freshAccount.SyncStatus == "syncing")
                         freshAccount.MarkFailed(errorCode);
 
@@ -135,7 +149,11 @@ public class ScheduledSyncService(
             _logger.SyncFailed(job.CorrelationId ?? job.Id.ToString(), accountId,
                 errorCode ?? "UNKNOWN", ex.Message, job.RetryCount);
 
-            await EvaluateSyncFailureAlertAsync(account, errorCode, ct);
+            // Transient throttling (provider 429) is self-healing — the next scheduled
+            // cycle retries. Surfacing a "reconnect your credentials" alert here would be
+            // a false alarm, so we skip it. A genuine failure still alerts the user.
+            if (!isTransient)
+                await EvaluateSyncFailureAlertAsync(account, errorCode, ct);
 
             return new SyncResult(false, 0, 0, errorCode, ex.Message);
         }

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
@@ -90,6 +90,22 @@ public class BankAccount : Entity
         UpdatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Restores a syncing account to active after a transient, self-healing failure
+    /// (e.g. a provider rate-limit / 429). Unlike <see cref="MarkFailed"/> this leaves
+    /// no error state and raises no user-facing alert — the connection is valid and the
+    /// next scheduled cycle will retry. Balance is left untouched.
+    /// </summary>
+    public void MarkTransientRetry()
+    {
+        if (SyncStatus != "syncing")
+            throw new InvalidOperationException(
+                $"Cannot mark account transient-retry from status '{SyncStatus}'.");
+        SyncStatus = "active";
+        LastSyncError = null;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     public void BeginSync()
     {
         if (SyncStatus == "syncing")

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
@@ -47,7 +47,9 @@ public class ScheduledSyncServiceTests
              Mock<ICredentialEncryptionService> encryption,
              Mock<IPlaidAdapterInterface> plaid,
              Mock<ITransactionDeduplicationService> dedup,
-             Mock<IBankSyncLogger> logger) BuildSut()
+             Mock<IBankSyncLogger> logger) BuildSut(
+        Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>? alertGen = null,
+        Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>? userPrefs = null)
     {
         var accountRepo = new Mock<IBankAccountRepository>();
         var txRepo = new Mock<ITransactionRepository>();
@@ -63,8 +65,8 @@ public class ScheduledSyncServiceTests
         var truelayerConnections = new Mock<ITrueLayerConnectionRepository>();
         var truelayerClient = new Mock<FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer.ITrueLayerClient>();
         var monobankBalanceCache = new FinanceSentry.Modules.BankSync.Infrastructure.Monobank.MonobankBalanceCache();
-        var alertGen = new Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>();
-        var userPrefs = new Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>();
+        alertGen ??= new Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>();
+        userPrefs ??= new Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>();
 
         var sut = new ScheduledSyncService(
             accountRepo.Object, txRepo.Object, jobRepo.Object, credRepo.Object,
@@ -228,12 +230,64 @@ public class ScheduledSyncServiceTests
         result.TransactionCountDeduped.Should().Be(1);  // 1 new after dedup
     }
 
-    // ── T313-4: Exception during sync marks job failed ──────────────────────
+    // ── T313-4: Hard failure during sync marks job + account failed and alerts ──
 
     [Fact]
-    public async Task PerformFullSyncAsync_PlaidThrows_MarksJobAndAccountFailed()
+    public async Task PerformFullSyncAsync_PlaidThrowsHardError_MarksFailedAndFiresAlert()
     {
-        var (sut, accountRepo, txRepo, jobRepo, credRepo, encryption, plaid, dedup, logger) = BuildSut();
+        var alertGen = new Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>();
+        var userPrefs = new Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>();
+        userPrefs.Setup(p => p.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(new FinanceSentry.Core.Interfaces.UserAlertPreferences(false, 0m, true));
+
+        var (sut, accountRepo, txRepo, jobRepo, credRepo, encryption, plaid, _, _) =
+            BuildSut(alertGen, userPrefs);
+
+        var account = MakeActiveAccount();
+        var credential = MakeCredential(AccountId);
+
+        accountRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(account);
+        accountRepo.Setup(r => r.UpdateAsync(It.IsAny<BankAccount>(), default)).ReturnsAsync(account);
+        jobRepo.Setup(r => r.AddAsync(It.IsAny<SyncJob>(), default))
+               .ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.UpdateAsync(It.IsAny<SyncJob>(), default))
+               .ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.GetLatestByAccountIdAsync(It.IsAny<Guid>(), default))
+               .ReturnsAsync((SyncJob?)null);
+        credRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(credential);
+        encryption.Setup(e => e.Decrypt(It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<int>()))
+                  .Returns("access-sandbox-token");
+        txRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default))
+              .ReturnsAsync([]);
+
+        plaid.Setup(p => p.SyncTransactionsAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<string?>(), default))
+             .ThrowsAsync(new HttpRequestException("INVALID_CREDENTIALS: bad token"));
+
+        var result = await sut.PerformFullSyncAsync(AccountId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorCode.Should().Be("INVALID_CREDENTIALS");
+        jobRepo.Verify(r => r.UpdateAsync(It.Is<SyncJob>(j => j.Status == "failed"), default), Times.Once);
+        account.SyncStatus.Should().Be("failed");
+        alertGen.Verify(a => a.GenerateSyncFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── T313-4b: Transient throttle (429) does not fail the account or alert ────
+
+    [Fact]
+    public async Task PerformFullSyncAsync_RateLimited_KeepsAccountActiveAndSkipsAlert()
+    {
+        var alertGen = new Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>();
+        var userPrefs = new Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>();
+        userPrefs.Setup(p => p.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                 .ReturnsAsync(new FinanceSentry.Core.Interfaces.UserAlertPreferences(false, 0m, true));
+
+        var (sut, accountRepo, txRepo, jobRepo, credRepo, encryption, plaid, _, _) =
+            BuildSut(alertGen, userPrefs);
 
         var account = MakeActiveAccount();
         var credential = MakeCredential(AccountId);
@@ -261,7 +315,14 @@ public class ScheduledSyncServiceTests
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("RATE_LIMIT_EXCEEDED");
+        // Job still records the failure for observability...
         jobRepo.Verify(r => r.UpdateAsync(It.Is<SyncJob>(j => j.Status == "failed"), default), Times.Once);
+        // ...but the account self-heals to active and no false alarm is raised.
+        account.SyncStatus.Should().Be("active");
+        account.LastSyncError.Should().BeNull();
+        alertGen.Verify(a => a.GenerateSyncFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<Guid?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // ── T313-5: Idempotency — coordinator blocks concurrent runs ────────────


### PR DESCRIPTION
## Problem
Ledger alerted Denys that "Monobank sync is failing." Traced to Finance Sentry's own `SyncFailure` alerts — 6 fired between 19:30–19:32 UTC on 2026-07-24, all reading "reconnect or check your credentials."

Root cause: Monobank rate-limits at 1 req/60s per token. The hourly sync fires `client-info` + `statement` for several card-accounts near-simultaneously and periodically trips a 429. On retry-exhaustion the sync threw `MONOBANK_RATE_LIMITED`, which (1) marked the account `failed` and (2) fired a `SyncFailure` alert telling the user to reconnect — both false alarms: the token is valid, it's pure throttling. Every 2-hour Ledger scan then re-relayed the stale alert.

## Fix
Classify rate-limit codes (`MONOBANK_RATE_LIMITED`, `RATE_LIMIT_EXCEEDED`) as transient: still record the SyncJob failure (observability), restore the account to `active` via new `BankAccount.MarkTransientRetry()`, and skip the user-facing alert. Next cycle retries and self-heals. Genuine failures alert as before.

## Auto-resolve (the "(b)" ask)
Already implemented and working (`EvaluateAlertsAfterSuccessAsync → ResolveSyncFailureAlertAsync`). Verified against live data: all 6 alerts auto-resolved on the next successful sync (~20:00). This PR removes the false firing upstream so there's nothing to resolve.

## Tests
New `PerformFullSyncAsync_RateLimited_KeepsAccountActiveAndSkipsAlert` (account stays active, no alert). Reworked hard-failure test asserts failed + alert. Unit suite 24/24 green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)