### PR TITLE
fix(subscriptions): sum monthly cost in USD across currencies

### DIFF
--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionSummaryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionSummaryQuery.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.Subscriptions.Application.Queries;
 
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.Subscriptions.API.Responses;
 using FinanceSentry.Modules.Subscriptions.Domain;
 using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
@@ -20,18 +21,21 @@ public class GetSubscriptionSummaryQueryHandler(IDetectedSubscriptionRepository 
 
         var potentiallyCancelled = all.Count(s => s.Status == SubscriptionStatus.PotentiallyCancelled);
 
+        // Subscriptions can span multiple currencies (e.g. Monobank UAH + Revolut EUR).
+        // Normalize every amount to USD before summing so the total is meaningful.
         var totalMonthly = active.Sum(s =>
-            s.Cadence == "annual" ? s.AverageAmount / 12m : s.AverageAmount);
+        {
+            var monthly = s.Cadence == "annual" ? s.AverageAmount / 12m : s.AverageAmount;
+            return CurrencyConverter.ToUsd(monthly, s.Currency);
+        });
 
         var totalAnnual = totalMonthly * 12m;
-
-        var currency = active.FirstOrDefault()?.Currency ?? "USD";
 
         return new SubscriptionSummaryResponse(
             Math.Round(totalMonthly, 2),
             Math.Round(totalAnnual, 2),
             active.Count,
             potentiallyCancelled,
-            currency);
+            "USD");
     }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj
+++ b/backend/tests/FinanceSentry.Tests.Unit/FinanceSentry.Tests.Unit.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\src\FinanceSentry.Modules.Alerts\FinanceSentry.Modules.Alerts.csproj" />
     <ProjectReference Include="..\..\src\FinanceSentry.Modules.Budgets\FinanceSentry.Modules.Budgets.csproj" />
     <ProjectReference Include="..\..\src\FinanceSentry.Modules.Wealth\FinanceSentry.Modules.Wealth.csproj" />
+    <ProjectReference Include="..\..\src\FinanceSentry.Modules.Subscriptions\FinanceSentry.Modules.Subscriptions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/tests/FinanceSentry.Tests.Unit/Subscriptions/GetSubscriptionSummaryQueryHandlerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Subscriptions/GetSubscriptionSummaryQueryHandlerTests.cs
@@ -1,0 +1,77 @@
+namespace FinanceSentry.Tests.Unit.Subscriptions;
+
+using FinanceSentry.Modules.Subscriptions.Application.Queries;
+using FinanceSentry.Modules.Subscriptions.Domain;
+using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+public class GetSubscriptionSummaryQueryHandlerTests
+{
+    private const string UserId = "user-1";
+
+    private static DetectedSubscription ActiveSub(decimal averageAmount, string currency, string cadence = "monthly") =>
+        DetectedSubscription.Create(
+            UserId,
+            merchantNameNormalized: "svc",
+            merchantNameDisplay: "Svc",
+            cadence: cadence,
+            averageAmount: averageAmount,
+            lastKnownAmount: averageAmount,
+            currency: currency,
+            lastChargeDate: new DateOnly(2026, 7, 1),
+            nextExpectedDate: new DateOnly(2026, 8, 1),
+            occurrenceCount: 3,
+            confidenceScore: 90,
+            category: null);
+
+    private static GetSubscriptionSummaryQueryHandler BuildHandler(params DetectedSubscription[] active)
+    {
+        var repo = new Mock<IDetectedSubscriptionRepository>(MockBehavior.Strict);
+        repo.Setup(r => r.GetActiveByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(active);
+        repo.Setup(r => r.GetByUserIdAsync(UserId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(active);
+        return new GetSubscriptionSummaryQueryHandler(repo.Object);
+    }
+
+    [Fact]
+    public async Task Handle_MixedCurrencies_NormalizesToUsdBeforeSumming()
+    {
+        // 500 UAH (~$12) + 10 EUR (~$10.80) must NOT be summed as bare 510.
+        var handler = BuildHandler(
+            ActiveSub(500m, "UAH"),
+            ActiveSub(10m, "EUR"));
+
+        var result = await handler.Handle(new GetSubscriptionSummaryQuery(UserId), CancellationToken.None);
+
+        // 500 * 0.024 + 10 * 1.08 = 12.00 + 10.80 = 22.80
+        result.TotalMonthlyEstimate.Should().Be(22.80m);
+        result.TotalAnnualEstimate.Should().Be(273.60m);
+        result.Currency.Should().Be("USD");
+    }
+
+    [Fact]
+    public async Task Handle_AnnualCadence_DividesByTwelveThenConverts()
+    {
+        var handler = BuildHandler(ActiveSub(120m, "EUR", cadence: "annual"));
+
+        var result = await handler.Handle(new GetSubscriptionSummaryQuery(UserId), CancellationToken.None);
+
+        // (120 / 12) * 1.08 = 10 * 1.08 = 10.80
+        result.TotalMonthlyEstimate.Should().Be(10.80m);
+    }
+
+    [Fact]
+    public async Task Handle_NoActiveSubscriptions_ReturnsZeroInUsd()
+    {
+        var handler = BuildHandler();
+
+        var result = await handler.Handle(new GetSubscriptionSummaryQuery(UserId), CancellationToken.None);
+
+        result.TotalMonthlyEstimate.Should().Be(0m);
+        result.ActiveCount.Should().Be(0);
+        result.Currency.Should().Be("USD");
+    }
+}

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -89,8 +89,9 @@
               </div>
             </div>
             <div amount class="min-w-[72px] text-right">
+              <!-- Render each row in its own currency (UAH/EUR/USD) — not the default $ -->
               <div class="font-mono text-cmn-sm font-semibold text-text-primary">
-                {{ sub.monthlyEquivalent | appCurrency }}
+                {{ sub.monthlyEquivalent | appCurrency: sub.currency }}
               </div>
               <div class="text-[10px] text-text-disabled">/ mo</div>
             </div>
@@ -129,7 +130,7 @@
               </div>
               <div amount class="min-w-[72px] text-right">
                 <div class="font-mono text-cmn-sm font-semibold text-text-primary">
-                  {{ sub.monthlyEquivalent | appCurrency }}
+                  {{ sub.monthlyEquivalent | appCurrency: sub.currency }}
                 </div>
                 <div class="text-[10px] text-text-disabled">/ mo</div>
               </div>


### PR DESCRIPTION
## Problem
The subscriptions summary summed every subscription's `AverageAmount` with **no currency conversion**, then labeled the total with whatever currency the *first* subscription had. UAH (Monobank) subs were counted 1:1 as dollars — a real bill inflated ~41×, producing a bogus "~$8,300 monthly cost".

## Fix
- Backend: normalize each subscription to USD via the existing `CurrencyConverter` (same one BankSync uses) before summing; report `USD`.
- Frontend: per-row amounts rendered `appCurrency` with no currency arg → every UAH/EUR row showed `$`. Now passes `sub.currency`.
- Tests: mixed-currency sum, annual cadence, empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)