### PR TITLE
fix(holdings): drop zero-quantity and sold-out positions on sync

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/SyncIBKRHoldingsCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Commands/SyncIBKRHoldingsCommand.cs
@@ -47,7 +47,13 @@ public sealed class SyncIBKRHoldingsCommandHandler : ICommandHandler<SyncIBKRHol
 
             var syncedAt = DateTime.UtcNow;
 
-            var holdings = positions
+            // Ignore zero-quantity positions — IBKR keeps returning sold-out symbols
+            // at qty 0, which we must not surface (or persist) as $0 holdings.
+            var activePositions = positions
+                .Where(p => p.Quantity != 0m)
+                .ToList();
+
+            var holdings = activePositions
                 .Select(p => new BrokerageHolding(
                     request.UserId,
                     p.Symbol,
@@ -62,8 +68,19 @@ public sealed class SyncIBKRHoldingsCommandHandler : ICommandHandler<SyncIBKRHol
             await _holdingRepository.UpsertRangeAsync(holdings, ct);
             await _holdingRepository.SaveChangesAsync(ct);
 
-            var positionByKey = positions.ToDictionary(p => p.Symbol, StringComparer.Ordinal);
+            var positionByKey = activePositions.ToDictionary(p => p.Symbol, StringComparer.Ordinal);
             var persisted = await _holdingRepository.GetByUserIdAsync(request.UserId, ct);
+
+            // Reconcile: drop persisted holdings the user no longer holds (sold out /
+            // no longer returned or now zero) so they leave the DB instead of lingering.
+            var stale = persisted
+                .Where(h => h.Provider == "ibkr" && !positionByKey.ContainsKey(h.Symbol))
+                .ToList();
+            if (stale.Count > 0)
+            {
+                _holdingRepository.RemoveRange(stale);
+            }
+
             foreach (var h in persisted)
             {
                 if (positionByKey.TryGetValue(h.Symbol, out var pos))

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Queries/GetBrokerageHoldingsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Application/Queries/GetBrokerageHoldingsQuery.cs
@@ -35,7 +35,10 @@ public sealed class GetBrokerageHoldingsQueryHandler
     public async Task<BrokerageHoldingsResponse> Handle(
         GetBrokerageHoldingsQuery request, CancellationToken ct)
     {
-        var holdings = await _holdingRepository.GetByUserIdAsync(request.UserId, ct);
+        // Guard against any zero-quantity rows still in the DB from before reconcile ran.
+        var holdings = (await _holdingRepository.GetByUserIdAsync(request.UserId, ct))
+            .Where(h => h.Quantity != 0m)
+            .ToList();
 
         if (holdings.Count == 0)
         {

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/Repositories/IRepositories.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Domain/Repositories/IRepositories.cs
@@ -15,6 +15,10 @@ public interface IBrokerageHoldingRepository
 {
     Task UpsertRangeAsync(IEnumerable<BrokerageHolding> holdings, CancellationToken ct = default);
     Task<IReadOnlyList<BrokerageHolding>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>Marks the given tracked holdings for deletion (used to reconcile sold-out positions).</summary>
+    void RemoveRange(IEnumerable<BrokerageHolding> holdings);
+
     Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/Persistence/Repositories/Repositories.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/Persistence/Repositories/Repositories.cs
@@ -92,6 +92,11 @@ public sealed class BrokerageHoldingRepository : IBrokerageHoldingRepository
             .ToListAsync(ct);
     }
 
+    public void RemoveRange(IEnumerable<BrokerageHolding> holdings)
+    {
+        _context.BrokerageHoldings.RemoveRange(holdings);
+    }
+
     public async Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default)
     {
         await _context.BrokerageHoldings

--- a/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/SyncBinanceHoldingsCommand.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Application/Commands/SyncBinanceHoldingsCommand.cs
@@ -87,6 +87,22 @@ public sealed class SyncBinanceHoldingsCommandHandler : ICommandHandler<SyncBina
             await _holdingRepository.UpsertRangeAsync(holdings, ct);
             await _holdingRepository.SaveChangesAsync(ct);
 
+            // Reconcile: the aggregator only returns assets the user still holds (dust
+            // and zero balances are already dropped), so anything persisted but missing
+            // here was sold out — delete it instead of leaving a stale $0 holding.
+            var freshAssets = holdings
+                .Select(h => h.Asset)
+                .ToHashSet(StringComparer.Ordinal);
+            var persisted = await _holdingRepository.GetByUserIdAsync(request.UserId, ct);
+            var stale = persisted
+                .Where(h => !freshAssets.Contains(h.Asset))
+                .ToList();
+            if (stale.Count > 0)
+            {
+                _holdingRepository.RemoveRange(stale);
+                await _holdingRepository.SaveChangesAsync(ct);
+            }
+
             await UpdateCostBasisAsync(request.UserId, apiKey, apiSecret, ct);
 
             var syncedAt = DateTime.UtcNow;

--- a/backend/src/FinanceSentry.Modules.CryptoSync/Application/Queries/GetCryptoHoldingsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Application/Queries/GetCryptoHoldingsQuery.cs
@@ -33,7 +33,10 @@ public sealed class GetCryptoHoldingsQueryHandler : IQueryHandler<GetCryptoHoldi
 
     public async Task<CryptoHoldingsResponse> Handle(GetCryptoHoldingsQuery request, CancellationToken ct)
     {
-        var holdings = await _holdingRepository.GetByUserIdAsync(request.UserId, ct);
+        // Guard against any zero-balance rows still in the DB from before reconcile ran.
+        var holdings = (await _holdingRepository.GetByUserIdAsync(request.UserId, ct))
+            .Where(h => h.FreeQuantity + h.LockedQuantity != 0m)
+            .ToList();
 
         if (holdings.Count == 0)
         {

--- a/backend/src/FinanceSentry.Modules.CryptoSync/Domain/Repositories/IRepositories.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Domain/Repositories/IRepositories.cs
@@ -14,6 +14,10 @@ public interface ICryptoHoldingRepository
 {
     Task UpsertRangeAsync(IReadOnlyList<CryptoHolding> holdings, CancellationToken ct = default);
     Task<IReadOnlyList<CryptoHolding>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>Marks the given tracked holdings for deletion (used to reconcile sold-out assets).</summary>
+    void RemoveRange(IEnumerable<CryptoHolding> holdings);
+
     Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.CryptoSync/Infrastructure/Persistence/Repositories/Repositories.cs
+++ b/backend/src/FinanceSentry.Modules.CryptoSync/Infrastructure/Persistence/Repositories/Repositories.cs
@@ -82,6 +82,11 @@ public sealed class CryptoHoldingRepository : ICryptoHoldingRepository
             .ToListAsync(ct);
     }
 
+    public void RemoveRange(IEnumerable<CryptoHolding> holdings)
+    {
+        _context.CryptoHoldings.RemoveRange(holdings);
+    }
+
     public async Task DeleteByUserIdAsync(Guid userId, CancellationToken ct = default)
     {
         await _context.CryptoHoldings

--- a/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/SyncIBKRHoldingsReconcileTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BrokerageSync/SyncIBKRHoldingsReconcileTests.cs
@@ -1,0 +1,89 @@
+namespace FinanceSentry.Tests.Unit.BrokerageSync;
+
+using FinanceSentry.Modules.BrokerageSync.Application.Commands;
+using FinanceSentry.Modules.BrokerageSync.Domain;
+using FinanceSentry.Modules.BrokerageSync.Domain.Interfaces;
+using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+public class SyncIBKRHoldingsReconcileTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private static IBKRCredential CredentialWithAccount()
+    {
+        var credential = new IBKRCredential(
+            UserId,
+            consumerKey: "ck",
+            accessToken: "at",
+            dhParam: "dh",
+            encryptedAccessTokenSecret: [1],
+            accessTokenSecretIv: [1],
+            accessTokenSecretAuthTag: [1],
+            encryptedSignatureKey: [1],
+            signatureKeyIv: [1],
+            signatureKeyAuthTag: [1],
+            encryptedEncryptionKey: [1],
+            encryptionKeyIv: [1],
+            encryptionKeyAuthTag: [1],
+            keyVersion: 1);
+        credential.UpdateAccountId("acct-1"); // skip the GetAccountIdAsync path
+        return credential;
+    }
+
+    private static BrokerageHolding Holding(string symbol, decimal quantity) =>
+        new(UserId, symbol, "STK", quantity, quantity * 10m, "ibkr");
+
+    [Fact]
+    public async Task Handle_DropsZeroQuantityAndSoldOutHoldings()
+    {
+        var credential = CredentialWithAccount();
+
+        var credentialRepo = new Mock<IIBKRCredentialRepository>(MockBehavior.Loose);
+        credentialRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(credential);
+
+        var adapter = new Mock<IBrokerAdapter>(MockBehavior.Loose);
+        // AAPL comes back at qty 0 (sold out but still reported); MSFT is a real position.
+        adapter.Setup(a => a.GetPositionsAsync(credential.Id, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<BrokerPosition>
+            {
+                new("AAPL", "STK", 0m, 0m),
+                new("MSFT", "STK", 10m, 1000m),
+            });
+
+        // Persisted holdings include TSLA, which is no longer returned at all (fully sold).
+        var persisted = new List<BrokerageHolding>
+        {
+            Holding("MSFT", 10m),
+            Holding("TSLA", 5m),
+            Holding("AAPL", 3m),
+        };
+        var holdingRepo = new Mock<IBrokerageHoldingRepository>(MockBehavior.Loose);
+        holdingRepo.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(persisted);
+
+        List<BrokerageHolding>? upserted = null;
+        holdingRepo.Setup(r => r.UpsertRangeAsync(It.IsAny<IEnumerable<BrokerageHolding>>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BrokerageHolding>, CancellationToken>((h, _) => upserted = h.ToList())
+            .Returns(Task.CompletedTask);
+
+        List<BrokerageHolding>? removed = null;
+        holdingRepo.Setup(r => r.RemoveRange(It.IsAny<IEnumerable<BrokerageHolding>>()))
+            .Callback<IEnumerable<BrokerageHolding>>(h => removed = h.ToList());
+
+        var handler = new SyncIBKRHoldingsCommandHandler(credentialRepo.Object, holdingRepo.Object, adapter.Object);
+
+        var result = await handler.Handle(new SyncIBKRHoldingsCommand(UserId), CancellationToken.None);
+
+        // Zero-qty AAPL is never persisted; only MSFT is upserted.
+        upserted.Should().ContainSingle().Which.Symbol.Should().Be("MSFT");
+        result.HoldingsCount.Should().Be(1);
+
+        // TSLA (gone) and AAPL (now zero) are reconciled out of the DB.
+        removed.Should().NotBeNull();
+        removed!.Select(h => h.Symbol).Should().BeEquivalentTo(["TSLA", "AAPL"]);
+    }
+}


### PR DESCRIPTION
## Problem
IBKR and Binance sync only ever upserted holdings and never removed positions that fell to zero or disappeared, so a sold-out position lingered forever (IBKR kept returning it at qty 0 → shown as $0).

## Fix
- IBKR sync: skip zero-quantity positions + reconcile-delete persisted holdings no longer in the fresh set.
- Binance sync: reconcile-delete persisted assets missing from the fresh (dust/zero-filtered) balance set.
- Add `RemoveRange` to both holding repositories.
- Safety net: holdings queries filter out any zero-quantity rows still in the DB until the next sync reconciles.
- Unit test covering zero-skip + sold-out reconcile for IBKR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)