### PR TITLE
feat(ui): show provider logos on institutions via favicons

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/disclosure-row/disclosure-row.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/disclosure-row/disclosure-row.component.ts
@@ -15,7 +15,7 @@ import {InstitutionAvatarComponent} from '../institution-avatar/institution-avat
       >
         <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
           @if (avatarName()) {
-            <cmn-institution-avatar [name]="avatarName()!" />
+            <cmn-institution-avatar [name]="avatarName()!" [logoUrl]="avatarLogoUrl()" />
           }
           <div class="min-w-0">
             <p class="font-medium text-text-primary">{{ label() }}</p>
@@ -59,5 +59,7 @@ export class DisclosureRowComponent {
   public readonly amount = input<number | null>(null);
   public readonly currency = input<string | null>(null);
   public readonly avatarName = input<string | null>(null);
+  /** Optional remote logo for the avatar; falls back to initials if absent/broken. */
+  public readonly avatarLogoUrl = input<string | null>(null);
   public readonly open = input<boolean>(true);
 }

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.spec.ts
@@ -68,4 +68,35 @@ describe('InstitutionAvatarComponent', () => {
     expect(span.className).toContain('h-9');
     expect(span.className).toContain('w-9');
   });
+
+  const setupWithLogo = (name: string, logoUrl: string | null): HTMLElement => {
+    fixture = TestBed.createComponent(InstitutionAvatarComponent);
+    fixture.componentRef.setInput('name', name);
+    fixture.componentRef.setInput('logoUrl', logoUrl);
+    fixture.detectChanges();
+    return fixture.nativeElement.querySelector('span');
+  };
+
+  it('renders the logo image when a logoUrl is provided', () => {
+    const span = setupWithLogo('Revolut', 'https://logo.example/revolut');
+    const img = span.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('https://logo.example/revolut');
+    expect(img?.getAttribute('alt')).toBe('Revolut logo');
+    expect(span.textContent?.trim()).toBe('');
+  });
+
+  it('renders initials (no image) when logoUrl is null', () => {
+    const span = setupWithLogo('Revolut', null);
+    expect(span.querySelector('img')).toBeNull();
+    expect(span.textContent?.trim()).toBe('RE');
+  });
+
+  it('falls back to initials when the logo image fails to load', () => {
+    const span = setupWithLogo('Revolut', 'https://logo.example/broken');
+    span.querySelector('img')?.dispatchEvent(new Event('error'));
+    fixture.detectChanges();
+    expect(span.querySelector('img')).toBeNull();
+    expect(span.textContent?.trim()).toBe('RE');
+  });
 });

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.ts
@@ -1,9 +1,10 @@
-import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
+import {NgOptimizedImage} from '@angular/common';
+import {ChangeDetectionStrategy, Component, computed, input, signal} from '@angular/core';
 
 const MAX_INITIALS = 2;
 
 const BASE_CLASSES =
-  'inline-flex flex-shrink-0 items-center justify-center rounded-cmn-md border ' +
+  'inline-flex flex-shrink-0 items-center justify-center overflow-hidden rounded-cmn-md border ' +
   'border-border-default bg-surface-card text-cmn-xs font-bold text-text-secondary ' +
   'shadow-sm';
 
@@ -18,13 +19,35 @@ export type InstitutionAvatarSize = keyof typeof SIZE_CLASSES;
 @Component({
   selector: 'cmn-institution-avatar',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: '<span [class]="classes()" [attr.aria-label]="name()">{{ initials() }}</span>',
+  imports: [NgOptimizedImage],
+  template: `
+    <span [class]="classes()" [attr.aria-label]="name()">
+      @if (showLogo()) {
+        <img
+          [ngSrc]="logoUrl()!"
+          [alt]="name() + ' logo'"
+          (error)="onLogoError()"
+          width="64"
+          height="64"
+          class="h-full w-full object-contain"
+        />
+      } @else {
+        {{ initials() }}
+      }
+    </span>
+  `,
 })
 export class InstitutionAvatarComponent {
+  private readonly logoFailed = signal(false);
+
   public readonly name = input.required<string>();
   public readonly size = input<InstitutionAvatarSize>('md');
+  /** Optional remote logo. Falls back to initials if absent or it fails to load. */
+  public readonly logoUrl = input<string | null>(null);
 
   public readonly initials = computed(() => InstitutionAvatarComponent.deriveInitials(this.name()));
+
+  public readonly showLogo = computed(() => !!this.logoUrl() && !this.logoFailed());
 
   public readonly classes = computed(() => `${BASE_CLASSES} ${SIZE_CLASSES[this.size()]}`);
 
@@ -42,5 +65,9 @@ export class InstitutionAvatarComponent {
       .map(word => word.charAt(0))
       .join('')
       .toUpperCase();
+  }
+
+  public onLogoError(): void {
+    this.logoFailed.set(true);
   }
 }

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -67,7 +67,10 @@
                 class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
                 <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
-                  <cmn-institution-avatar [name]="inst.name" />
+                  <cmn-institution-avatar
+                    [name]="inst.name"
+                    [logoUrl]="inst.name | institutionLogo: inst.provider"
+                  />
                   <div class="min-w-0">
                     <p class="font-medium text-text-primary">{{ inst.name }}</p>
                     <p class="text-cmn-xs text-text-secondary">
@@ -171,7 +174,10 @@
                 class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
                 <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
-                  <cmn-institution-avatar [name]="inst.name" />
+                  <cmn-institution-avatar
+                    [name]="inst.name"
+                    [logoUrl]="inst.name | institutionLogo: inst.provider"
+                  />
                   <div class="min-w-0">
                     <p class="font-medium text-text-primary">{{ inst.name }}</p>
                     <p class="text-cmn-xs text-text-secondary">
@@ -269,7 +275,10 @@
                 class="flex items-center justify-between gap-cmn-4 px-cmn-4 py-cmn-4 cursor-pointer hover:bg-surface-bg transition-colors"
               >
                 <div class="flex items-center gap-cmn-3 flex-1 min-w-0">
-                  <cmn-institution-avatar [name]="inst.name" />
+                  <cmn-institution-avatar
+                    [name]="inst.name"
+                    [logoUrl]="inst.name | institutionLogo: inst.provider"
+                  />
                   <div class="min-w-0">
                     <p class="font-medium text-text-primary">{{ inst.name }}</p>
                     <p class="text-cmn-xs text-text-secondary">

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.ts
@@ -16,6 +16,7 @@ import {
 import {take} from 'rxjs';
 
 import {type Institution} from '../../../../shared/models/wealth/wealth.model';
+import {InstitutionLogoPipe} from '../../../../shared/pipes/institution-logo.pipe';
 import {RelativeTimePipe} from '../../../../shared/pipes/relative-time.pipe';
 import {SyncStatusLabelPipe} from '../../../../shared/pipes/sync-status-label.pipe';
 import {SyncStatusVariantPipe} from '../../../../shared/pipes/sync-status-variant.pipe';
@@ -38,6 +39,7 @@ const SKELETON_ROWS = 5;
     DecimalPipe,
     EmptyStateComponent,
     InstitutionAvatarComponent,
+    InstitutionLogoPipe,
     PageHeaderComponent,
     RelativeTimePipe,
     SkeletonComponent,

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -93,6 +93,7 @@
                 [label]="inst.name"
                 [sublabel]="sublabel"
                 [avatarName]="inst.name"
+                [avatarLogoUrl]="inst.name | institutionLogo: inst.provider"
                 [amount]="inst.totalInBaseCurrency"
                 [currency]="store.baseCurrency()"
                 [open]="true"

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
@@ -16,6 +16,7 @@ import {
 import {take} from 'rxjs';
 
 import {type Provider} from '../../../../shared/models/provider/provider.model';
+import {InstitutionLogoPipe} from '../../../../shared/pipes/institution-logo.pipe';
 import {SyncStatusLabelPipe} from '../../../../shared/pipes/sync-status-label.pipe';
 import {SyncStatusVariantPipe} from '../../../../shared/pipes/sync-status-variant.pipe';
 import {DisconnectDialogComponent} from '../../../bank-sync/components/disconnect-dialog/disconnect-dialog.component';
@@ -47,6 +48,7 @@ export type HoldingsTab = 'holdings' | 'positions';
     DecimalPipe,
     DisclosureRowComponent,
     HoldingBalancePipe,
+    InstitutionLogoPipe,
     PageHeaderComponent,
     StatCardComponent,
     SyncStatusLabelPipe,

--- a/frontend/src/app/shared/constants/institution/institution-domains.constants.ts
+++ b/frontend/src/app/shared/constants/institution/institution-domains.constants.ts
@@ -1,0 +1,25 @@
+/**
+ * Institution logo domain hints. We never store logo images ourselves — a
+ * domain here is turned into a favicon URL by {@link InstitutionLogoUtils}.
+ *
+ * PROVIDER_DOMAINS: direct-connect providers where the provider code IS the
+ * institution (Monobank, IBKR, Binance).
+ *
+ * BANK_NAME_DOMAINS: aggregator-connected banks (e.g. TrueLayer) where the
+ * specific institution lives in the display name, not the provider code.
+ * Matched by case-insensitive substring, so keep keywords lowercase.
+ */
+export const PROVIDER_DOMAINS: Readonly<Record<string, string>> = {
+  monobank: 'monobank.ua',
+  ibkr: 'interactivebrokers.com',
+  binance: 'binance.com',
+};
+
+export const BANK_NAME_DOMAINS: readonly (readonly [string, string])[] = [
+  ['revolut', 'revolut.com'],
+  ['allied irish', 'aib.ie'],
+  ['aib', 'aib.ie'],
+  ['monzo', 'monzo.com'],
+  ['wise', 'wise.com'],
+  ['starling', 'starlingbank.com'],
+];

--- a/frontend/src/app/shared/pipes/institution-logo.pipe.ts
+++ b/frontend/src/app/shared/pipes/institution-logo.pipe.ts
@@ -1,0 +1,10 @@
+import {Pipe, type PipeTransform} from '@angular/core';
+
+import {InstitutionLogoUtils} from '../utils/institution-logo.utils';
+
+@Pipe({name: 'institutionLogo'})
+export class InstitutionLogoPipe implements PipeTransform {
+  public transform(name: Nullable<string>, provider?: Nullable<string>): Nullable<string> {
+    return InstitutionLogoUtils.faviconUrl(provider ?? null, name ?? null);
+  }
+}

--- a/frontend/src/app/shared/utils/institution-logo.utils.spec.ts
+++ b/frontend/src/app/shared/utils/institution-logo.utils.spec.ts
@@ -1,0 +1,47 @@
+import {InstitutionLogoUtils} from './institution-logo.utils';
+
+describe('InstitutionLogoUtils', () => {
+  describe('faviconUrl', () => {
+    it('resolves a direct-connect provider code to its favicon URL', () => {
+      expect(InstitutionLogoUtils.faviconUrl('binance', 'Binance')).toBe(
+        'https://www.google.com/s2/favicons?domain=binance.com&sz=64'
+      );
+    });
+
+    it('resolves IBKR and Monobank provider codes', () => {
+      expect(InstitutionLogoUtils.faviconUrl('ibkr', null)).toContain('interactivebrokers.com');
+      expect(InstitutionLogoUtils.faviconUrl('monobank', null)).toContain('monobank.ua');
+    });
+
+    it('is case-insensitive on the provider code', () => {
+      expect(InstitutionLogoUtils.faviconUrl('BINANCE', null)).toContain('binance.com');
+    });
+
+    it('resolves an aggregator-connected bank by name when the provider is generic', () => {
+      expect(InstitutionLogoUtils.faviconUrl('truelayer', 'Revolut')).toContain('revolut.com');
+    });
+
+    it('matches bank names by case-insensitive substring', () => {
+      expect(InstitutionLogoUtils.faviconUrl('truelayer', 'Allied Irish Banks (GB)')).toContain(
+        'aib.ie'
+      );
+    });
+
+    it('prefers the provider code over the name when both match', () => {
+      // provider binance wins even though the name mentions revolut
+      expect(InstitutionLogoUtils.faviconUrl('binance', 'revolut')).toContain('binance.com');
+    });
+
+    it('returns null for an unknown institution', () => {
+      expect(InstitutionLogoUtils.faviconUrl('plaid', 'Some Local Credit Union')).toBeNull();
+    });
+
+    it('returns null when both provider and name are null', () => {
+      expect(InstitutionLogoUtils.faviconUrl(null, null)).toBeNull();
+    });
+
+    it('returns null when both provider and name are blank', () => {
+      expect(InstitutionLogoUtils.faviconUrl('   ', '  ')).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/shared/utils/institution-logo.utils.ts
+++ b/frontend/src/app/shared/utils/institution-logo.utils.ts
@@ -1,0 +1,44 @@
+import {
+  BANK_NAME_DOMAINS,
+  PROVIDER_DOMAINS,
+} from '../constants/institution/institution-domains.constants';
+
+const FAVICON_ENDPOINT = 'https://www.google.com/s2/favicons';
+const FAVICON_SIZE = 64;
+
+/**
+ * Resolves a connected institution to a public favicon URL (Google's favicon
+ * service) so we render real provider logos without hosting any images.
+ * Returns null when the institution isn't recognised — callers fall back to the
+ * initials avatar.
+ */
+export class InstitutionLogoUtils {
+  public static faviconUrl(provider: Nullable<string>, name: Nullable<string>): Nullable<string> {
+    const domain = InstitutionLogoUtils.resolveDomain(provider, name);
+    if (!domain) {
+      return null;
+    }
+    return `${FAVICON_ENDPOINT}?domain=${domain}&sz=${FAVICON_SIZE}`;
+  }
+
+  private static resolveDomain(
+    provider: Nullable<string>,
+    name: Nullable<string>
+  ): Nullable<string> {
+    const providerKey = provider?.trim().toLowerCase() ?? '';
+    if (providerKey && PROVIDER_DOMAINS[providerKey]) {
+      return PROVIDER_DOMAINS[providerKey];
+    }
+
+    const nameKey = name?.trim().toLowerCase() ?? '';
+    if (!nameKey) {
+      return null;
+    }
+    for (const [keyword, domain] of BANK_NAME_DOMAINS) {
+      if (nameKey.includes(keyword)) {
+        return domain;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## What
Render real institution logos (Monobank, Revolut, AIB, IBKR, Binance, …) **without hosting any images**: map a connected institution to a domain and build a Google favicon URL. Falls back to the initials avatar when the institution is unknown or the image fails to load.

- `cmn-institution-avatar`: optional `logoUrl` input; renders `NgOptimizedImage` with graceful `onError` fallback to initials.
- `cmn-disclosure-row`: pass-through `avatarLogoUrl`.
- `shared/`: `InstitutionLogoUtils` + `institutionLogo` pipe + domain-hint constants.
- Wired into accounts-list and holdings institution rows.

Note: uses the same external-favicon approach TrueLayer bank logos already use; app sends no CSP header so external images load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)