### PR TITLE
fix(subscriptions): drop misleading raw mixed-currency total fallback

### DIFF
--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -18,24 +18,24 @@
 
     <!-- Summary cards -->
     <div class="grid grid-cols-1 gap-cmn-4 sm:grid-cols-3">
+      @let summary = store.summary();
       <cmn-stat-card
         [value]="
-          (store.summary()?.totalMonthlyEstimate ?? store.monthlyTotal() | appCurrency) ?? ''
+          summary ? ((summary.totalMonthlyEstimate | appCurrency: summary.currency) ?? '—') : '—'
         "
         label="Monthly Cost"
         icon="Zap"
       />
       <cmn-stat-card
         [value]="
-          (store.summary()?.totalAnnualEstimate ?? store.monthlyTotal() * 12 | appCurrency) ?? ''
+          summary ? ((summary.totalAnnualEstimate | appCurrency: summary.currency) ?? '—') : '—'
         "
         label="Annual Cost"
         icon="TrendingUp"
       />
       <cmn-stat-card
         [value]="
-          (store.summary()?.activeCount ?? store.activeSubscriptions().length).toString() +
-          ' subscriptions'
+          (summary?.activeCount ?? store.activeSubscriptions().length).toString() + ' subscriptions'
         "
         label="Active"
         icon="CheckCheck"

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
@@ -22,12 +22,6 @@ export function subscriptionsComputed(store: StateSignals) {
     potentiallyCancelledSubscriptions: computed(() =>
       store.subscriptions().filter(s => s.status === 'potentially_cancelled')
     ),
-    monthlyTotal: computed(() =>
-      store
-        .subscriptions()
-        .filter(s => s.status === 'active')
-        .reduce((sum, s) => sum + s.monthlyEquivalent, 0)
-    ),
     dismissTarget: computed(
       () => store.subscriptions().find(s => s.id === store.dismissTargetId()) ?? null
     ),


### PR DESCRIPTION
Follow-up to #330. The summary cards fell back to a client-side `monthlyTotal` that summed each subscription's `monthlyEquivalent` **raw across currencies** — a wrong number that only surfaced when the summary API returned null.

- Remove the `monthlyTotal` computed.
- Money cards render `—` when the summary is absent (no fabricated total); use `summary.currency`.
- The **Active** card keeps its legitimate client-side count fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)