### PR TITLE
fix(subscriptions): exclude installments + canonicalize noisy merchant brands

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantNameNormalizer.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantNameNormalizer.cs
@@ -8,6 +8,19 @@ public static class MerchantNameNormalizer
     private static readonly Regex TrailingNumericPattern = new(@"[\s\-_*#]+\d[\d\s\-_]*$", RegexOptions.Compiled);
     private static readonly Regex CollapseSpacesPattern = new(@"\s+", RegexOptions.Compiled);
 
+    // Bank statements spell the same recurring merchant differently every month
+    // (e.g. "Anthropic* Claude Sub", "Claude.ai Subscription", "Anthropic Ireland"),
+    // which fragments them below the recurrence threshold. Collapse known brands to
+    // one canonical key so their charges group together. Keep this list narrow —
+    // only brands whose descriptions actually vary — to avoid over-merging.
+    private static readonly (string Keyword, string Canonical)[] BrandAliases =
+    [
+        ("anthropic", "claude"),
+        ("claude", "claude"),
+        ("openai", "openai"),
+        ("chatgpt", "openai"),
+    ];
+
     public static string Normalize(string? input)
     {
         if (string.IsNullOrWhiteSpace(input))
@@ -33,7 +46,16 @@ public static class MerchantNameNormalizer
 
         result = CollapseSpacesPattern.Replace(result, " ").Trim();
 
-        return string.IsNullOrWhiteSpace(result) ? "unknown" : result;
+        if (string.IsNullOrWhiteSpace(result))
+            return "unknown";
+
+        foreach (var (keyword, canonical) in BrandAliases)
+        {
+            if (result.Contains(keyword, StringComparison.Ordinal))
+                return canonical;
+        }
+
+        return result;
     }
 
     public static string GetDisplayName(IEnumerable<string?> rawNames)

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
@@ -38,6 +38,21 @@ public sealed class SubscriptionDetectionJob(
         "cash",
     ];
 
+    // Installment (розстрочка) repayments look exactly like a monthly subscription
+    // — fixed amount, monthly, repeated — but they are a fixed-term loan repayment,
+    // not a recurring service. Monobank labels them distinctively; match on the
+    // real descriptions (verified against live data), not a generic guess.
+    private static readonly string[] InstallmentDescriptionMarkers =
+    [
+        "погашення наступного платежу",   // "repayment of the next payment" (RozetkaPay)
+        "щомісячний платіж",              // "monthly payment" (telemart/monomarket)
+        "розстроч",                       // розстрочка / у розстрочку
+        "оплата частинами",
+        "покупка частинами",
+        "частинами",
+        "installment",
+    ];
+
     public async Task ExecuteAsync(CancellationToken ct = default)
     {
         await ProcessPlaidAccountsAsync(ct);
@@ -161,8 +176,9 @@ public sealed class SubscriptionDetectionJob(
 
             try
             {
-                var byMerchant = userGroup.GroupBy(t =>
-                    MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
+                var byMerchant = userGroup
+                    .Where(t => !IsInstallmentDescription(t.Description))
+                    .GroupBy(t => MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
 
                 var results = new List<DetectedSubscriptionData>();
 
@@ -237,6 +253,18 @@ public sealed class SubscriptionDetectionJob(
                 logger.LogWarning(ex, "Heuristic subscription detection failed for user {UserId}", userId);
             }
         }
+    }
+
+    public static bool IsInstallmentDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description)) return false;
+
+        var lowered = description.ToLowerInvariant();
+        foreach (var marker in InstallmentDescriptionMarkers)
+        {
+            if (lowered.Contains(marker, StringComparison.Ordinal)) return true;
+        }
+        return false;
     }
 
     public static bool IsUnidentifiableMerchant(string normalized)

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/Subscriptions/SubscriptionDetectionAlgorithmTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/Subscriptions/SubscriptionDetectionAlgorithmTests.cs
@@ -29,6 +29,48 @@ public class SubscriptionDetectionAlgorithmTests
         SubscriptionDetectionJob.IsUnidentifiableMerchant(normalized).Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData("Погашення наступного платежу RozetkaPay")]
+    [InlineData("Щомісячний платіж telemart - monomarket")]
+    [InlineData("Оплата частинами Rozetka")]
+    [InlineData("Купівля у розстрочку")]
+    [InlineData("Installment payment 3/6")]
+    public void InstallmentDescription_IsDetected(string description)
+    {
+        SubscriptionDetectionJob.IsInstallmentDescription(description).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Spotify")]
+    [InlineData("Anthropic* Claude Sub")]
+    [InlineData("Netflix.com")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NonInstallmentDescription_IsNotDetected(string? description)
+    {
+        SubscriptionDetectionJob.IsInstallmentDescription(description).Should().BeFalse();
+    }
+
+    [Fact]
+    public void BrandCanonicalization_UnifiesVaryingClaudeDescriptions()
+    {
+        var keys = new[]
+        {
+            "Anthropic* Claude Sub",
+            "Claude.ai Subscription",
+            "Anthropic Ireland",
+        }.Select(MerchantNameNormalizer.Normalize).Distinct().ToList();
+
+        keys.Should().ContainSingle().Which.Should().Be("claude");
+    }
+
+    [Fact]
+    public void BrandCanonicalization_UnifiesVaryingChatgptDescriptions()
+    {
+        MerchantNameNormalizer.Normalize("Openai *chatgpt Subscr")
+            .Should().Be(MerchantNameNormalizer.Normalize("Openai"));
+    }
+
     [Fact]
     public void TightenedCv_RejectsAmountsThatWouldPassLegacyThreshold()
     {


### PR DESCRIPTION
Verified against live Monobank/TrueLayer data on the VPS.

## Installments no longer show as subscriptions
Monobank розстрочка repayments are shape-identical to a monthly sub (fixed amount, monthly, ≥3×). Excluded by their **real** descriptions — `Погашення наступного платежу RozetkaPay`, `Щомісячний платіж telemart - monomarket`, plus `розстроч`/`частинами`/`installment`. (There's no "частинами/розстрочка" literal in the data — inspecting real rows beat guessing.)

## Missing TrueLayer subs (Claude, ChatGPT) now group
They were fragmented because the bank description changes monthly (`Anthropic* Claude Sub` / `Claude.ai Subscription` / `Anthropic Ireland`), so each variant fell below the 3-charge threshold. A narrow brand-alias step in `MerchantNameNormalizer` collapses them to one key (`anthropic/claude → claude`, `openai/chatgpt → openai`). ChatGPT (stable €23) will now detect.

**Follow-up:** Claude carries two genuinely different charge sizes (~€22 vs ~€110), so it still won't collapse into one stable amount — needs per-amount clustering within a merchant.

Tests: installment detection, brand unification, and all existing normalizer cases green (47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)