### PR TITLE
fix(holdings): keyless IBKR logos, centered icons, everywhere

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/institution-avatar/institution-avatar.component.ts
@@ -29,7 +29,7 @@ export type InstitutionAvatarSize = keyof typeof SIZE_CLASSES;
           (error)="onLogoError()"
           width="64"
           height="64"
-          class="h-full w-full object-contain"
+          class="m-auto max-h-full max-w-full object-contain"
         />
       } @else {
         {{ initials() }}

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -119,10 +119,21 @@
                     ) {
                       <tr class="border-t border-border-default">
                         <td class="py-2 pl-16 pr-4 w-full">
-                          <span class="text-text-primary">{{ account.accountType }}</span>
-                          <span class="block text-xs text-text-disabled"
-                            >&#8226;&#8226;{{ account.accountNumberLast4 }}</span
-                          >
+                          <span class="inline-flex items-center gap-cmn-2">
+                            @if (inst.category === 'crypto' || inst.category === 'brokerage') {
+                              <cmn-institution-avatar
+                                [name]="account.accountType"
+                                [logoUrl]="account.accountNumberLast4 | assetLogo: account.provider"
+                                size="sm"
+                              />
+                            }
+                            <span>
+                              <span class="text-text-primary">{{ account.accountType }}</span>
+                              <span class="block text-xs text-text-disabled"
+                                >&#8226;&#8226;{{ account.accountNumberLast4 }}</span
+                              >
+                            </span>
+                          </span>
                         </td>
                         <td class="py-2 pr-4 text-right font-mono tabular-nums text-text-primary">
                           {{ account.currentBalance | number: '1.2-2' }}

--- a/frontend/src/app/modules/holdings/utils/asset-logo.utils.spec.ts
+++ b/frontend/src/app/modules/holdings/utils/asset-logo.utils.spec.ts
@@ -1,4 +1,3 @@
-import {environment} from '../../../../environments/environment';
 import {AssetLogoUtils} from './asset-logo.utils';
 
 describe('AssetLogoUtils', () => {
@@ -9,26 +8,15 @@ describe('AssetLogoUtils', () => {
       );
     });
 
+    it('builds an FMP image-stock URL for an IBKR ticker (uppercased)', () => {
+      expect(AssetLogoUtils.logoUrl('aapl', 'ibkr')).toBe(
+        'https://financialmodelingprep.com/image-stock/AAPL.png'
+      );
+    });
+
     it('is provider-case-insensitive', () => {
       expect(AssetLogoUtils.logoUrl('XRP', 'Binance')).toContain('/xrp@2x.png');
-    });
-
-    it('returns null for an IBKR ticker when no logo.dev token is configured', () => {
-      // Default environment ships with an empty token.
-      expect(environment.logoDevToken).toBe('');
-      expect(AssetLogoUtils.logoUrl('AAPL', 'ibkr')).toBeNull();
-    });
-
-    it('builds a logo.dev URL for an IBKR ticker when a token is set', () => {
-      const original = environment.logoDevToken;
-      try {
-        (environment as {logoDevToken: string}).logoDevToken = 'pk_test';
-        const url = AssetLogoUtils.logoUrl('aapl', 'ibkr');
-        expect(url).toContain('https://img.logo.dev/ticker/AAPL');
-        expect(url).toContain('token=pk_test');
-      } finally {
-        (environment as {logoDevToken: string}).logoDevToken = original;
-      }
+      expect(AssetLogoUtils.logoUrl('NVDA', 'IBKR')).toContain('/NVDA.png');
     });
 
     it('returns null for an unknown provider', () => {

--- a/frontend/src/app/modules/holdings/utils/asset-logo.utils.ts
+++ b/frontend/src/app/modules/holdings/utils/asset-logo.utils.ts
@@ -1,16 +1,13 @@
-import {environment} from '../../../../environments/environment';
-
 const COINCAP_ICON_BASE = 'https://assets.coincap.io/assets/icons';
-const LOGO_DEV_TICKER_BASE = 'https://img.logo.dev/ticker';
-const LOGO_SIZE = 64;
+const FMP_STOCK_IMAGE_BASE = 'https://financialmodelingprep.com/image-stock';
 
 /**
  * Builds a public logo URL for a held asset without hosting any images:
- * - crypto (Binance) → CoinCap coin icon by symbol (keyless), e.g. sol@2x.png
- * - stock/ETF (IBKR) → logo.dev by ticker, requires a publishable token
- *   (environment.logoDevToken); returns null when the token is unset.
+ * - crypto (Binance) → CoinCap coin icon by symbol, e.g. sol@2x.png
+ * - stock/ETF (IBKR) → Financial Modeling Prep image-stock by ticker, e.g. AAPL.png
  *
- * Returns null for anything unrecognised — callers fall back to the initials avatar.
+ * Both sources are keyless. Returns null for anything unrecognised — callers
+ * fall back to the initials avatar.
  */
 export class AssetLogoUtils {
   public static logoUrl(symbol: Nullable<string>, provider: Nullable<string>): Nullable<string> {
@@ -22,13 +19,8 @@ export class AssetLogoUtils {
     switch (provider?.trim().toLowerCase()) {
       case 'binance':
         return `${COINCAP_ICON_BASE}/${sym.toLowerCase()}@2x.png`;
-      case 'ibkr': {
-        const token = environment.logoDevToken;
-        if (!token) {
-          return null;
-        }
-        return `${LOGO_DEV_TICKER_BASE}/${sym.toUpperCase()}?token=${token}&size=${LOGO_SIZE}&format=png`;
-      }
+      case 'ibkr':
+        return `${FMP_STOCK_IMAGE_BASE}/${sym.toUpperCase()}.png`;
       default:
         return null;
     }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -8,7 +8,4 @@ export const environment = {
   apiVersion: 'v1',
   wsUrl: '/ws',
   googleClientId: '687161855116-17f9guiugj8cdlat8h8c1vn5ji1irt8p.apps.googleusercontent.com',
-  // Publishable logo.dev token for stock/ETF ticker logos (client-side safe).
-  // Empty = stock logos disabled (falls back to the initials avatar).
-  logoDevToken: '',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -4,7 +4,4 @@ export const environment = {
   apiVersion: 'v1',
   wsUrl: 'ws://localhost:5001',
   googleClientId: '687161855116-17f9guiugj8cdlat8h8c1vn5ji1irt8p.apps.googleusercontent.com',
-  // Publishable logo.dev token for stock/ETF ticker logos (client-side safe).
-  // Empty = stock logos disabled (falls back to the initials avatar).
-  logoDevToken: '',
 };


### PR DESCRIPTION
Follow-up to the per-asset holding icons.

- **IBKR stock/ETF logos now work with no token** — switched from token-gated logo.dev to **Financial Modeling Prep** `image-stock` (keyless, verified across AAPL/NVDA/VOO/SPY/BRK.B). Dropped the unused `environment.logoDevToken`.
- **Centered the icon** robustly (`m-auto` + `max-h/max-w` + `object-contain`) — verified via screenshot across square coins and wide ETF wordmarks.
- **Icons everywhere holdings render** — added them to the by-institution Holdings-tab expanded rows (crypto + brokerage rows are per-coin/per-ticker), not just the Positions tab.

Crypto (Binance) stays keyless via CoinCap. All gates green (lint app+lib, build, 149 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)