### PR TITLE
fix(ui): institution logos via DuckDuckGo (direct 200, no redirect)

### DIFF
--- a/frontend/src/app/shared/utils/institution-logo.utils.spec.ts
+++ b/frontend/src/app/shared/utils/institution-logo.utils.spec.ts
@@ -2,9 +2,9 @@ import {InstitutionLogoUtils} from './institution-logo.utils';
 
 describe('InstitutionLogoUtils', () => {
   describe('faviconUrl', () => {
-    it('resolves a direct-connect provider code to its favicon URL', () => {
+    it('resolves a direct-connect provider code to a direct-200 favicon URL', () => {
       expect(InstitutionLogoUtils.faviconUrl('binance', 'Binance')).toBe(
-        'https://www.google.com/s2/favicons?domain=binance.com&sz=64'
+        'https://icons.duckduckgo.com/ip3/binance.com.ico'
       );
     });
 

--- a/frontend/src/app/shared/utils/institution-logo.utils.ts
+++ b/frontend/src/app/shared/utils/institution-logo.utils.ts
@@ -3,11 +3,13 @@ import {
   PROVIDER_DOMAINS,
 } from '../constants/institution/institution-domains.constants';
 
-const FAVICON_ENDPOINT = 'https://www.google.com/s2/favicons';
-const FAVICON_SIZE = 64;
+// DuckDuckGo's icon service returns the image directly (HTTP 200), unlike
+// Google's s2/favicons which 301-redirects — some image pipelines don't follow
+// the redirect, so provider logos silently failed to render.
+const FAVICON_ENDPOINT = 'https://icons.duckduckgo.com/ip3';
 
 /**
- * Resolves a connected institution to a public favicon URL (Google's favicon
+ * Resolves a connected institution to a public favicon URL (DuckDuckGo's icon
  * service) so we render real provider logos without hosting any images.
  * Returns null when the institution isn't recognised — callers fall back to the
  * initials avatar.
@@ -18,7 +20,7 @@ export class InstitutionLogoUtils {
     if (!domain) {
       return null;
     }
-    return `${FAVICON_ENDPOINT}?domain=${domain}&sz=${FAVICON_SIZE}`;
+    return `${FAVICON_ENDPOINT}/${domain}.ico`;
   }
 
   private static resolveDomain(


### PR DESCRIPTION
Institution favicons on the accounts page (IBKR, Binance, banks) weren't rendering. Root cause: Google's `s2/favicons` returns a **301 redirect**, whereas the working per-asset icons (CoinCap/FMP) return **200 directly** — same avatar component, only the redirect differs. Switched institution logos to **DuckDuckGo** (`icons.duckduckgo.com/ip3/<domain>.ico`), which serves the image directly (verified 200 for binance.com + interactivebrokers.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)