### PR TITLE
feat(installments): dedicated Installments section

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/ISubscriptionDetectionResultService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/ISubscriptionDetectionResultService.cs
@@ -23,4 +23,16 @@ public record DetectedSubscriptionData(
     DateOnly NextExpectedDate,
     int OccurrenceCount,
     int ConfidenceScore,
-    string? Category);
+    string? Category,
+    string Kind = SubscriptionKinds.Subscription);
+
+/// <summary>
+/// Distinguishes an open-ended recurring service from a fixed-term installment
+/// (розстрочка) repayment. Both are detected by the same recurrence heuristic
+/// but surfaced in separate UI sections.
+/// </summary>
+public static class SubscriptionKinds
+{
+    public const string Subscription = "subscription";
+    public const string Installment = "installment";
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
@@ -176,9 +176,8 @@ public sealed class SubscriptionDetectionJob(
 
             try
             {
-                var byMerchant = userGroup
-                    .Where(t => !IsInstallmentDescription(t.Description))
-                    .GroupBy(t => MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
+                var byMerchant = userGroup.GroupBy(t =>
+                    MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
 
                 var results = new List<DetectedSubscriptionData>();
 
@@ -219,6 +218,12 @@ public sealed class SubscriptionDetectionJob(
                     var lastChargeDate = DateOnly.FromDateTime(lastTransaction.TransactionDate);
                     var nextExpectedDate = lastChargeDate.AddDays((int)median);
 
+                    // Fixed-term installment (розстрочка) repayments recur exactly like a
+                    // subscription; tag them so they surface in their own section instead.
+                    var kind = sorted.Any(t => IsInstallmentDescription(t.Description))
+                        ? SubscriptionKinds.Installment
+                        : SubscriptionKinds.Subscription;
+
                     // Fall back to the description for the display name too — TrueLayer (and other
                     // open-banking) transactions carry the merchant only in the description, so using
                     // MerchantName alone rendered every detected subscription as "unknown".
@@ -242,7 +247,8 @@ public sealed class SubscriptionDetectionJob(
                         NextExpectedDate: nextExpectedDate,
                         OccurrenceCount: sorted.Count,
                         ConfidenceScore: sorted.Count,
-                        Category: topCategory));
+                        Category: topCategory,
+                        Kind: kind));
                 }
 
                 await resultService.UpsertDetectedSubscriptionsAsync(userId, results, ct);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/API/Responses/SubscriptionDto.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/API/Responses/SubscriptionDto.cs
@@ -13,4 +13,5 @@ public record SubscriptionDto(
     string Status,
     int OccurrenceCount,
     string? Category,
-    DateTimeOffset DetectedAt);
+    DateTimeOffset DetectedAt,
+    string Kind);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionSummaryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionSummaryQuery.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.Subscriptions.Application.Queries;
 
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.Subscriptions.API.Responses;
 using FinanceSentry.Modules.Subscriptions.Domain;
@@ -16,10 +17,15 @@ public class GetSubscriptionSummaryQueryHandler(IDetectedSubscriptionRepository 
     public async Task<SubscriptionSummaryResponse> Handle(
         GetSubscriptionSummaryQuery request, CancellationToken cancellationToken)
     {
-        var active = await _repository.GetActiveByUserIdAsync(request.UserId, cancellationToken);
+        // Installments are a separate concept (fixed-term repayments) — never count
+        // them toward the recurring subscription spend summary.
+        var active = (await _repository.GetActiveByUserIdAsync(request.UserId, cancellationToken))
+            .Where(s => s.Kind == SubscriptionKinds.Subscription)
+            .ToList();
         var all = await _repository.GetByUserIdAsync(request.UserId, false, cancellationToken);
 
-        var potentiallyCancelled = all.Count(s => s.Status == SubscriptionStatus.PotentiallyCancelled);
+        var potentiallyCancelled = all.Count(s =>
+            s.Kind == SubscriptionKinds.Subscription && s.Status == SubscriptionStatus.PotentiallyCancelled);
 
         // Subscriptions can span multiple currencies (e.g. Monobank UAH + Revolut EUR).
         // Normalize every amount to USD before summing so the total is meaningful.

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionsQuery.cs
@@ -33,7 +33,8 @@ public class GetSubscriptionsQueryHandler(IDetectedSubscriptionRepository reposi
             s.Status,
             s.OccurrenceCount,
             s.Category,
-            s.DetectedAt)).ToList();
+            s.DetectedAt,
+            s.Kind)).ToList();
 
         return new SubscriptionsListResponse(dtos, dtos.Count, hasInsufficientHistory);
     }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Services/SubscriptionDetectionResultService.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Services/SubscriptionDetectionResultService.cs
@@ -33,7 +33,8 @@ public class SubscriptionDetectionResultService(IDetectedSubscriptionRepository 
                     result.NextExpectedDate,
                     result.OccurrenceCount,
                     result.ConfidenceScore,
-                    result.Category);
+                    result.Category,
+                    result.Kind);
 
                 await _repository.UpsertAsync(subscription, ct);
             }
@@ -47,7 +48,8 @@ public class SubscriptionDetectionResultService(IDetectedSubscriptionRepository 
                     result.NextExpectedDate,
                     result.OccurrenceCount,
                     result.ConfidenceScore,
-                    result.Category);
+                    result.Category,
+                    result.Kind);
 
                 await _repository.UpsertAsync(existing, ct);
             }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
@@ -1,5 +1,7 @@
 namespace FinanceSentry.Modules.Subscriptions.Domain;
 
+using FinanceSentry.Core.Interfaces;
+
 public class DetectedSubscription
 {
     public Guid Id { get; private set; } = Guid.NewGuid();
@@ -10,6 +12,8 @@ public class DetectedSubscription
     public decimal AverageAmount { get; private set; }
     public decimal LastKnownAmount { get; private set; }
     public string Currency { get; private set; } = string.Empty;
+    /// <summary>"subscription" (open-ended service) or "installment" (fixed-term розстрочка).</summary>
+    public string Kind { get; private set; } = SubscriptionKinds.Subscription;
     public DateOnly LastChargeDate { get; private set; }
     public DateOnly NextExpectedDate { get; private set; }
     public string Status { get; private set; } = SubscriptionStatus.Active;
@@ -34,7 +38,8 @@ public class DetectedSubscription
         DateOnly nextExpectedDate,
         int occurrenceCount,
         int confidenceScore,
-        string? category)
+        string? category,
+        string kind = SubscriptionKinds.Subscription)
     {
         return new DetectedSubscription
         {
@@ -50,6 +55,7 @@ public class DetectedSubscription
             OccurrenceCount = occurrenceCount,
             ConfidenceScore = confidenceScore,
             Category = category,
+            Kind = kind,
         };
     }
 
@@ -61,7 +67,8 @@ public class DetectedSubscription
         DateOnly nextExpectedDate,
         int occurrenceCount,
         int confidenceScore,
-        string? category)
+        string? category,
+        string kind = SubscriptionKinds.Subscription)
     {
         MerchantNameDisplay = merchantNameDisplay;
         AverageAmount = averageAmount;
@@ -71,6 +78,7 @@ public class DetectedSubscription
         OccurrenceCount = occurrenceCount;
         ConfidenceScore = confidenceScore;
         Category = category;
+        Kind = kind;
         Status = SubscriptionStatus.Active;
         UpdatedAt = DateTimeOffset.UtcNow;
     }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/SubscriptionsDbContext.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/SubscriptionsDbContext.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.Subscriptions.Infrastructure.Persistence;
 
+using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Modules.Subscriptions.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,6 +23,7 @@ public class SubscriptionsDbContext(DbContextOptions<SubscriptionsDbContext> opt
         sb.Property(s => s.AverageAmount).HasColumnType("numeric(15,2)").IsRequired();
         sb.Property(s => s.LastKnownAmount).HasColumnType("numeric(15,2)").IsRequired();
         sb.Property(s => s.Currency).IsRequired().HasMaxLength(3);
+        sb.Property(s => s.Kind).IsRequired().HasMaxLength(20).HasDefaultValue(SubscriptionKinds.Subscription);
         sb.Property(s => s.Status).IsRequired().HasMaxLength(25).HasDefaultValue(SubscriptionStatus.Active);
         sb.Property(s => s.OccurrenceCount).HasDefaultValue(0);
         sb.Property(s => s.ConfidenceScore).HasDefaultValue(0);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728130132_M002_AddKind.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728130132_M002_AddKind.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.Subscriptions.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.Subscriptions.Migrations
 {
     [DbContext(typeof(SubscriptionsDbContext))]
-    partial class SubscriptionsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728130132_M002_AddKind")]
+    partial class M002_AddKind
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728130132_M002_AddKind.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728130132_M002_AddKind.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.Subscriptions.Migrations
+{
+    /// <inheritdoc />
+    public partial class M002_AddKind : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Kind",
+                table: "detected_subscriptions",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "subscription");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Kind",
+                table: "detected_subscriptions");
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/Subscriptions/GetSubscriptionSummaryQueryHandlerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Subscriptions/GetSubscriptionSummaryQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Tests.Unit.Subscriptions;
 
+using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Modules.Subscriptions.Application.Queries;
 using FinanceSentry.Modules.Subscriptions.Domain;
 using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
@@ -26,6 +27,22 @@ public class GetSubscriptionSummaryQueryHandlerTests
             confidenceScore: 90,
             category: null);
 
+    private static DetectedSubscription ActiveInstallment(decimal averageAmount, string currency) =>
+        DetectedSubscription.Create(
+            UserId,
+            merchantNameNormalized: "rozetka",
+            merchantNameDisplay: "Rozetka",
+            cadence: "monthly",
+            averageAmount: averageAmount,
+            lastKnownAmount: averageAmount,
+            currency: currency,
+            lastChargeDate: new DateOnly(2026, 7, 1),
+            nextExpectedDate: new DateOnly(2026, 8, 1),
+            occurrenceCount: 3,
+            confidenceScore: 90,
+            category: null,
+            kind: SubscriptionKinds.Installment);
+
     private static GetSubscriptionSummaryQueryHandler BuildHandler(params DetectedSubscription[] active)
     {
         var repo = new Mock<IDetectedSubscriptionRepository>(MockBehavior.Strict);
@@ -34,6 +51,20 @@ public class GetSubscriptionSummaryQueryHandlerTests
         repo.Setup(r => r.GetByUserIdAsync(UserId, false, It.IsAny<CancellationToken>()))
             .ReturnsAsync(active);
         return new GetSubscriptionSummaryQueryHandler(repo.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesInstallments_FromTotalAndCount()
+    {
+        // 10 USD subscription + a 100 USD installment — only the subscription counts.
+        var handler = BuildHandler(
+            ActiveSub(10m, "USD"),
+            ActiveInstallment(100m, "USD"));
+
+        var result = await handler.Handle(new GetSubscriptionSummaryQuery(UserId), CancellationToken.None);
+
+        result.TotalMonthlyEstimate.Should().Be(10m);
+        result.ActiveCount.Should().Be(1);
     }
 
     [Fact]

--- a/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
+++ b/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
@@ -1,6 +1,7 @@
 export type SubscriptionStatus = 'active' | 'dismissed' | 'potentially_cancelled';
 export type SubscriptionSort = 'date' | 'amount' | 'name';
 export type DismissedSubscription = Extract<SubscriptionStatus, 'dismissed'>;
+export type SubscriptionKind = 'subscription' | 'installment';
 
 export interface Subscription {
   id: string;
@@ -14,6 +15,7 @@ export interface Subscription {
   nextExpectedDate: string;
   status: SubscriptionStatus;
   occurrenceCount: number;
+  kind: SubscriptionKind;
 }
 
 export interface SubscriptionSummary {

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -108,6 +108,47 @@
       </cmn-card>
     </div>
 
+    <!-- Installments -->
+    @if (store.activeInstallments().length > 0) {
+      <div>
+        <div class="mb-cmn-3">
+          <span
+            class="font-label text-cmn-xs font-semibold uppercase tracking-widest text-text-secondary"
+          >
+            Installments · {{ store.activeInstallments().length }}
+          </span>
+        </div>
+        <cmn-card padding="none">
+          @for (item of store.sortedInstallments(); track item.id) {
+            <cmn-list-item-row [label]="item.merchantName || 'Unknown'">
+              <div
+                [style.background]="item.merchantName | merchantColor"
+                avatar
+                class="flex h-10 w-10 shrink-0 items-center justify-center rounded-cmn-md font-bold text-white"
+              >
+                {{ item.merchantName || '?' | slice: 0 : 1 | uppercase }}
+              </div>
+              <div meta class="min-w-[110px] text-center">
+                <div class="text-cmn-xs text-text-secondary">
+                  {{ item.occurrenceCount }} payment{{ item.occurrenceCount !== 1 ? 's' : '' }} so
+                  far
+                </div>
+                <div class="text-[11px] text-text-disabled">
+                  next {{ item.nextExpectedDate | date: 'mediumDate' }}
+                </div>
+              </div>
+              <div amount class="min-w-[72px] text-right">
+                <div class="font-mono text-cmn-sm font-semibold text-text-primary">
+                  {{ item.monthlyEquivalent | appCurrency: item.currency }}
+                </div>
+                <div class="text-[10px] text-text-disabled">/ mo</div>
+              </div>
+            </cmn-list-item-row>
+          }
+        </cmn-card>
+      </div>
+    }
+
     <!-- Dismissed list -->
     @if (store.dismissedSubscriptions().length > 0) {
       <div>

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
@@ -13,43 +13,55 @@ interface StateSignals {
   summary: Signal<Nullable<SubscriptionSummary>>;
 }
 
+function sortBy(items: Subscription[], sort: SubscriptionSort): Subscription[] {
+  return [...items].sort((a, b) => {
+    if (sort === 'amount') {
+      return b.monthlyEquivalent - a.monthlyEquivalent;
+    }
+    if (sort === 'name') {
+      return a.merchantName.localeCompare(b.merchantName);
+    }
+    return a.nextExpectedDate.localeCompare(b.nextExpectedDate);
+  });
+}
+
+const isSubscription = (s: Subscription): boolean => s.kind === 'subscription';
+const isInstallment = (s: Subscription): boolean => s.kind === 'installment';
+
 export function subscriptionsComputed(store: StateSignals) {
   return {
-    activeSubscriptions: computed(() => store.subscriptions().filter(s => s.status === 'active')),
+    activeSubscriptions: computed(() =>
+      store.subscriptions().filter(s => s.status === 'active' && isSubscription(s))
+    ),
     dismissedSubscriptions: computed(() =>
-      store.subscriptions().filter(s => s.status === 'dismissed')
+      store.subscriptions().filter(s => s.status === 'dismissed' && isSubscription(s))
     ),
     potentiallyCancelledSubscriptions: computed(() =>
-      store.subscriptions().filter(s => s.status === 'potentially_cancelled')
+      store.subscriptions().filter(s => s.status === 'potentially_cancelled' && isSubscription(s))
+    ),
+    activeInstallments: computed(() =>
+      store.subscriptions().filter(s => s.status === 'active' && isInstallment(s))
     ),
     dismissTarget: computed(
       () => store.subscriptions().find(s => s.id === store.dismissTargetId()) ?? null
     ),
-    sortedActive: computed((): Subscription[] => {
-      const active = store.subscriptions().filter(s => s.status === 'active');
-      const sort = store.sort();
-      return [...active].sort((a, b) => {
-        if (sort === 'amount') {
-          return b.monthlyEquivalent - a.monthlyEquivalent;
-        }
-        if (sort === 'name') {
-          return a.merchantName.localeCompare(b.merchantName);
-        }
-        return a.nextExpectedDate.localeCompare(b.nextExpectedDate);
-      });
-    }),
-    sortedDismissed: computed((): Subscription[] => {
-      const dismissed = store.subscriptions().filter(s => s.status === 'dismissed');
-      const sort = store.sort();
-      return [...dismissed].sort((a, b) => {
-        if (sort === 'amount') {
-          return b.monthlyEquivalent - a.monthlyEquivalent;
-        }
-        if (sort === 'name') {
-          return a.merchantName.localeCompare(b.merchantName);
-        }
-        return a.nextExpectedDate.localeCompare(b.nextExpectedDate);
-      });
-    }),
+    sortedActive: computed((): Subscription[] =>
+      sortBy(
+        store.subscriptions().filter(s => s.status === 'active' && isSubscription(s)),
+        store.sort()
+      )
+    ),
+    sortedInstallments: computed((): Subscription[] =>
+      sortBy(
+        store.subscriptions().filter(s => s.status === 'active' && isInstallment(s)),
+        'amount'
+      )
+    ),
+    sortedDismissed: computed((): Subscription[] =>
+      sortBy(
+        store.subscriptions().filter(s => s.status === 'dismissed' && isSubscription(s)),
+        store.sort()
+      )
+    ),
   };
 }


### PR DESCRIPTION
Splits fixed-term installment (розстрочка) repayments out of Subscriptions into their own section (Rozetka / telemart installments were showing as subscriptions).

## Backend
- `DetectedSubscription` gains a `Kind` discriminator (`subscription` | `installment`); shared `SubscriptionKinds` in Core.
- Detection tags installment-description groups as `installment` instead of excluding them.
- Migration **M002_AddKind** — `Kind` column, non-null, defaults `subscription` (existing rows backfill). EF-generated with Designer + snapshot.
- Summary query excludes installments from the subscription spend total/count.

## Frontend
- `kind` on the `Subscription` model; store splits subscriptions vs installments.
- New **Installments** section: merchant, payments-made-so-far, next payment date, monthly amount in its own currency.

## Known limitation
"Remaining payments" isn't in Monobank's statement data, so we show payments made + next date (future enhancement).

Gates: 364 backend unit + 8 subscription integration + 149 frontend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)