### PR TITLE
feat(installments): smarter detection + management layer

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/ISubscriptionDetectionResultService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/ISubscriptionDetectionResultService.cs
@@ -24,7 +24,8 @@ public record DetectedSubscriptionData(
     int OccurrenceCount,
     int ConfidenceScore,
     string? Category,
-    string Kind = SubscriptionKinds.Subscription);
+    string Kind = SubscriptionKinds.Subscription,
+    bool IsCompleted = false);
 
 /// <summary>
 /// Distinguishes an open-ended recurring service from a fixed-term installment

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
@@ -39,18 +39,32 @@ public sealed class SubscriptionDetectionJob(
     ];
 
     // Installment (розстрочка) repayments look exactly like a monthly subscription
-    // — fixed amount, monthly, repeated — but they are a fixed-term loan repayment,
-    // not a recurring service. Monobank labels them distinctively; match on the
-    // real descriptions (verified against live data), not a generic guess.
+    // — fixed amount, monthly, repeated — but they are a fixed-term repayment, not a
+    // recurring service. Monobank labels them distinctively (verified against live
+    // data): "Погашення наступного платежу RozetkaPay", "Щомісячний платіж telemart
+    // - monomarket", "Платіж Pandora", "Повне погашення RozetkaPay", etc.
+    private const int InstallmentMcc = 4829;
+
     private static readonly string[] InstallmentDescriptionMarkers =
     [
-        "погашення наступного платежу",   // "repayment of the next payment" (RozetkaPay)
-        "щомісячний платіж",              // "monthly payment" (telemart/monomarket)
+        "погашення наступного платежу",   // "repayment of the next payment"
+        "повне погашення",                // "full early payoff" — a finished-signal
+        "щомісячний платіж",              // "monthly payment"
+        "monomarket",                     // Monobank installment marketplace tag
         "розстроч",                       // розстрочка / у розстрочку
         "оплата частинами",
         "покупка частинами",
         "частинами",
         "installment",
+    ];
+
+    // Prefixes stripped to recover the merchant from an installment description.
+    private static readonly string[] InstallmentMerchantPrefixes =
+    [
+        "погашення наступного платежу",
+        "повне погашення",
+        "щомісячний платіж",
+        "платіж",
     ];
 
     public async Task ExecuteAsync(CancellationToken ct = default)
@@ -145,6 +159,10 @@ public sealed class SubscriptionDetectionJob(
         }
     }
 
+    private sealed record TxRow(
+        Guid UserId, string? MerchantName, string? Description, decimal Amount,
+        DateTime TransactionDate, string? MerchantCategory, int? Mcc, string? Currency);
+
     private async Task ProcessNonPlaidAccountsAsync(CancellationToken ct)
     {
         var cutoff = DateTime.UtcNow.AddMonths(-LookbackMonths);
@@ -156,100 +174,24 @@ public sealed class SubscriptionDetectionJob(
                      && t.TransactionDate >= cutoff
                      && (t.TransactionType == null || t.TransactionType == "debit"))
             .Join(db.BankAccounts.Where(a => a.IsActive && a.Provider != "plaid"),
-                t => t.AccountId, a => a.Id, (t, a) => new
-                {
-                    t.UserId,
-                    t.MerchantName,
-                    t.Description,
-                    t.Amount,
-                    t.TransactionDate,
-                    t.MerchantCategory,
-                    Currency = a.Currency,
-                })
+                t => t.AccountId, a => a.Id, (t, a) => new TxRow(
+                    t.UserId, t.MerchantName, t.Description, t.Amount,
+                    t.TransactionDate, t.MerchantCategory, t.Mcc, a.Currency))
             .ToListAsync(ct);
 
-        var byUser = transactions.GroupBy(t => t.UserId);
-
-        foreach (var userGroup in byUser)
+        foreach (var userGroup in transactions.GroupBy(t => t.UserId))
         {
             var userId = userGroup.Key.ToString();
 
             try
             {
-                var byMerchant = userGroup.GroupBy(t =>
-                    MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
+                var txs = userGroup.ToList();
+                var installmentTxs = txs.Where(t => IsInstallmentTransaction(t.Description, t.Mcc)).ToList();
+                var regularTxs = txs.Where(t => !IsInstallmentTransaction(t.Description, t.Mcc)).ToList();
 
                 var results = new List<DetectedSubscriptionData>();
-
-                foreach (var merchantGroup in byMerchant)
-                {
-                    var normalized = merchantGroup.Key;
-                    var sorted = merchantGroup.OrderBy(t => t.TransactionDate).ToList();
-
-                    if (sorted.Count < MinOccurrences) continue;
-                    if (IsUnidentifiableMerchant(normalized)) continue;
-
-                    var dates = sorted.Select(t => t.TransactionDate).ToList();
-                    var intervals = new List<int>();
-                    for (var i = 1; i < dates.Count; i++)
-                        intervals.Add((int)(dates[i] - dates[i - 1]).TotalDays);
-
-                    if (intervals.Count == 0) continue;
-
-                    var median = Median(intervals);
-
-                    string cadence;
-                    if (median >= MonthlyMinDays && median <= MonthlyMaxDays)
-                        cadence = "monthly";
-                    else if (median >= AnnualMinDays && median <= AnnualMaxDays)
-                        cadence = "annual";
-                    else
-                        continue;
-
-                    var amounts = sorted.Select(t => (double)t.Amount).ToList();
-                    var mean = amounts.Average();
-                    if (mean <= 0) continue;
-
-                    var stddev = Math.Sqrt(amounts.Sum(a => Math.Pow(a - mean, 2)) / amounts.Count);
-                    var cv = stddev / mean;
-                    if (cv > MaxAmountCv) continue;
-
-                    var lastTransaction = sorted.Last();
-                    var lastChargeDate = DateOnly.FromDateTime(lastTransaction.TransactionDate);
-                    var nextExpectedDate = lastChargeDate.AddDays((int)median);
-
-                    // Fixed-term installment (розстрочка) repayments recur exactly like a
-                    // subscription; tag them so they surface in their own section instead.
-                    var kind = sorted.Any(t => IsInstallmentDescription(t.Description))
-                        ? SubscriptionKinds.Installment
-                        : SubscriptionKinds.Subscription;
-
-                    // Fall back to the description for the display name too — TrueLayer (and other
-                    // open-banking) transactions carry the merchant only in the description, so using
-                    // MerchantName alone rendered every detected subscription as "unknown".
-                    var displayName = MerchantNameNormalizer.GetDisplayName(
-                        sorted.Select(t => t.MerchantName ?? t.Description));
-                    var topCategory = sorted
-                        .Select(t => t.MerchantCategory)
-                        .Where(c => c != null)
-                        .GroupBy(c => c)
-                        .OrderByDescending(g => g.Count())
-                        .FirstOrDefault()?.Key;
-
-                    results.Add(new DetectedSubscriptionData(
-                        MerchantNameNormalized: normalized,
-                        MerchantNameDisplay: displayName,
-                        Cadence: cadence,
-                        AverageAmount: (decimal)mean,
-                        LastKnownAmount: lastTransaction.Amount,
-                        Currency: lastTransaction.Currency ?? "USD",
-                        LastChargeDate: lastChargeDate,
-                        NextExpectedDate: nextExpectedDate,
-                        OccurrenceCount: sorted.Count,
-                        ConfidenceScore: sorted.Count,
-                        Category: topCategory,
-                        Kind: kind));
-                }
+                results.AddRange(DetectSubscriptions(regularTxs));
+                results.AddRange(DetectInstallments(installmentTxs));
 
                 await resultService.UpsertDetectedSubscriptionsAsync(userId, results, ct);
                 await resultService.MarkStaleAsPotentiallyCancelledAsync(userId, ct);
@@ -259,6 +201,126 @@ public sealed class SubscriptionDetectionJob(
                 logger.LogWarning(ex, "Heuristic subscription detection failed for user {UserId}", userId);
             }
         }
+    }
+
+    // Recurring-service detection: group by merchant, require a consistent monthly/annual
+    // cadence, a stable amount, and at least MinOccurrences charges.
+    private static IEnumerable<DetectedSubscriptionData> DetectSubscriptions(IReadOnlyList<TxRow> transactions)
+    {
+        var results = new List<DetectedSubscriptionData>();
+        var byMerchant = transactions.GroupBy(t => MerchantNameNormalizer.Normalize(t.MerchantName ?? t.Description));
+
+        foreach (var merchantGroup in byMerchant)
+        {
+            var normalized = merchantGroup.Key;
+            var sorted = merchantGroup.OrderBy(t => t.TransactionDate).ToList();
+
+            if (sorted.Count < MinOccurrences) continue;
+            if (IsUnidentifiableMerchant(normalized)) continue;
+
+            var dates = sorted.Select(t => t.TransactionDate).ToList();
+            var intervals = new List<int>();
+            for (var i = 1; i < dates.Count; i++)
+                intervals.Add((int)(dates[i] - dates[i - 1]).TotalDays);
+
+            if (intervals.Count == 0) continue;
+
+            var median = Median(intervals);
+
+            string cadence;
+            if (median >= MonthlyMinDays && median <= MonthlyMaxDays)
+                cadence = "monthly";
+            else if (median >= AnnualMinDays && median <= AnnualMaxDays)
+                cadence = "annual";
+            else
+                continue;
+
+            var amounts = sorted.Select(t => (double)t.Amount).ToList();
+            var mean = amounts.Average();
+            if (mean <= 0) continue;
+
+            var stddev = Math.Sqrt(amounts.Sum(a => Math.Pow(a - mean, 2)) / amounts.Count);
+            var cv = stddev / mean;
+            if (cv > MaxAmountCv) continue;
+
+            var lastTransaction = sorted.Last();
+            var lastChargeDate = DateOnly.FromDateTime(lastTransaction.TransactionDate);
+            var nextExpectedDate = lastChargeDate.AddDays((int)median);
+
+            var displayName = MerchantNameNormalizer.GetDisplayName(
+                sorted.Select(t => t.MerchantName ?? t.Description));
+            var topCategory = sorted
+                .Select(t => t.MerchantCategory)
+                .Where(c => c != null)
+                .GroupBy(c => c)
+                .OrderByDescending(g => g.Count())
+                .FirstOrDefault()?.Key;
+
+            results.Add(new DetectedSubscriptionData(
+                MerchantNameNormalized: normalized,
+                MerchantNameDisplay: displayName,
+                Cadence: cadence,
+                AverageAmount: (decimal)mean,
+                LastKnownAmount: lastTransaction.Amount,
+                Currency: lastTransaction.Currency ?? "USD",
+                LastChargeDate: lastChargeDate,
+                NextExpectedDate: nextExpectedDate,
+                OccurrenceCount: sorted.Count,
+                ConfidenceScore: sorted.Count,
+                Category: topCategory,
+                Kind: SubscriptionKinds.Subscription));
+        }
+
+        return results;
+    }
+
+    // Installment detection: group by the merchant recovered from Monobank's installment
+    // descriptions. No cadence/CV/min-count gates — a single "- monomarket" repayment is a
+    // real installment. Completed when a full-payoff row is the latest activity.
+    private static IEnumerable<DetectedSubscriptionData> DetectInstallments(IReadOnlyList<TxRow> transactions)
+    {
+        var results = new List<DetectedSubscriptionData>();
+        var byMerchant = transactions.GroupBy(t => ExtractInstallmentMerchant(t.Description ?? string.Empty));
+
+        foreach (var group in byMerchant)
+        {
+            var merchant = group.Key;
+            if (string.IsNullOrWhiteSpace(merchant)) continue;
+
+            var sorted = group.OrderBy(t => t.TransactionDate).ToList();
+            var payments = sorted.Where(t => !IsInstallmentPayoff(t.Description)).ToList();
+            if (payments.Count == 0) continue;
+
+            var lastPaymentDate = payments.Max(t => t.TransactionDate);
+            var lastPayoff = sorted
+                .Where(t => IsInstallmentPayoff(t.Description))
+                .Select(t => (DateTime?)t.TransactionDate)
+                .DefaultIfEmpty(null)
+                .Max();
+            // A payoff only means "finished" if it's the latest event — an early payoff
+            // followed by more monthly charges is a separate, still-active plan.
+            var completed = lastPayoff is DateTime payoff && payoff >= lastPaymentDate;
+
+            var lastPayment = payments.OrderBy(t => t.TransactionDate).Last();
+            var lastChargeDate = DateOnly.FromDateTime(lastPaymentDate);
+
+            results.Add(new DetectedSubscriptionData(
+                MerchantNameNormalized: "installment:" + merchant.ToLowerInvariant(),
+                MerchantNameDisplay: merchant,
+                Cadence: "monthly",
+                AverageAmount: Math.Round(payments.Average(t => t.Amount), 2),
+                LastKnownAmount: lastPayment.Amount,
+                Currency: lastPayment.Currency ?? "USD",
+                LastChargeDate: lastChargeDate,
+                NextExpectedDate: lastChargeDate.AddMonths(1),
+                OccurrenceCount: payments.Count,
+                ConfidenceScore: 100,
+                Category: null,
+                Kind: SubscriptionKinds.Installment,
+                IsCompleted: completed));
+        }
+
+        return results;
     }
 
     public static bool IsInstallmentDescription(string? description)
@@ -271,6 +333,51 @@ public sealed class SubscriptionDetectionJob(
             if (lowered.Contains(marker, StringComparison.Ordinal)) return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// True for a Monobank installment repayment: a strong description marker, or a
+    /// "Платіж &lt;merchant&gt;" on the internal-transfer MCC (catches merchant payoffs
+    /// like "Платіж Pandora" that carry no розстрочка keyword).
+    /// </summary>
+    public static bool IsInstallmentTransaction(string? description, int? mcc)
+    {
+        if (IsInstallmentDescription(description)) return true;
+        if (mcc == InstallmentMcc && description is not null &&
+            description.Trim().StartsWith("Платіж ", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static bool IsInstallmentPayoff(string? description) =>
+        description is not null &&
+        description.Contains("повне погашення", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Recovers the merchant from an installment description by stripping Monobank's
+    /// leading phrase ("Погашення наступного платежу", "Щомісячний платіж", "Платіж", …)
+    /// and the trailing "- monomarket" marketplace tag.
+    /// </summary>
+    public static string ExtractInstallmentMerchant(string description)
+    {
+        var text = description.Trim();
+
+        foreach (var prefix in InstallmentMerchantPrefixes)
+        {
+            if (text.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                text = text[prefix.Length..].Trim();
+                break;
+            }
+        }
+
+        var tagIdx = text.IndexOf("monomarket", StringComparison.OrdinalIgnoreCase);
+        if (tagIdx >= 0)
+            text = text[..tagIdx];
+
+        return text.Trim(' ', '-', '\t');
     }
 
     public static bool IsUnidentifiableMerchant(string normalized)

--- a/backend/src/FinanceSentry.Modules.Subscriptions/API/Controllers/SubscriptionsController.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/API/Controllers/SubscriptionsController.cs
@@ -13,7 +13,11 @@ public class SubscriptionsController(
     IQueryHandler<GetSubscriptionsQuery, SubscriptionsListResponse> getSubscriptions,
     IQueryHandler<GetSubscriptionSummaryQuery, SubscriptionSummaryResponse> getSummary,
     ICommandHandler<DismissSubscriptionCommand, bool> dismiss,
-    ICommandHandler<RestoreSubscriptionCommand, bool> restore) : ControllerBase
+    ICommandHandler<RestoreSubscriptionCommand, bool> restore,
+    ICommandHandler<SetInstallmentTermCommand, bool> setTerm,
+    ICommandHandler<CompleteInstallmentCommand, bool> completeInstallment,
+    ICommandHandler<DeleteInstallmentCommand, bool> deleteInstallment,
+    ICommandHandler<AddManualInstallmentCommand, Guid> addInstallment) : ControllerBase
 {
     [HttpGet]
     public async Task<IActionResult> GetSubscriptions(
@@ -46,4 +50,47 @@ public class SubscriptionsController(
         await restore.Handle(new RestoreSubscriptionCommand(User.RequireUserId().ToString(), id), ct);
         return NoContent();
     }
+
+    [HttpPatch("installments/{id:guid}/term")]
+    public async Task<IActionResult> SetTerm(Guid id, [FromBody] SetTermRequest body, CancellationToken ct = default)
+    {
+        await setTerm.Handle(new SetInstallmentTermCommand(User.RequireUserId().ToString(), id, body.TermCount), ct);
+        return NoContent();
+    }
+
+    [HttpPatch("installments/{id:guid}/complete")]
+    public async Task<IActionResult> Complete(Guid id, CancellationToken ct = default)
+    {
+        await completeInstallment.Handle(new CompleteInstallmentCommand(User.RequireUserId().ToString(), id), ct);
+        return NoContent();
+    }
+
+    [HttpDelete("installments/{id:guid}")]
+    public async Task<IActionResult> DeleteInstallment(Guid id, CancellationToken ct = default)
+    {
+        await deleteInstallment.Handle(new DeleteInstallmentCommand(User.RequireUserId().ToString(), id), ct);
+        return NoContent();
+    }
+
+    [HttpPost("installments")]
+    public async Task<IActionResult> AddInstallment([FromBody] AddInstallmentRequest body, CancellationToken ct = default)
+    {
+        var id = await addInstallment.Handle(new AddManualInstallmentCommand(
+            User.RequireUserId().ToString(),
+            body.Merchant,
+            body.MonthlyAmount,
+            body.Currency,
+            body.StartDate,
+            body.TermCount), ct);
+        return Ok(new { id });
+    }
 }
+
+public record SetTermRequest(int? TermCount);
+
+public record AddInstallmentRequest(
+    string Merchant,
+    decimal MonthlyAmount,
+    string Currency,
+    DateOnly StartDate,
+    int? TermCount);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/API/Responses/SubscriptionDto.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/API/Responses/SubscriptionDto.cs
@@ -14,4 +14,7 @@ public record SubscriptionDto(
     int OccurrenceCount,
     string? Category,
     DateTimeOffset DetectedAt,
-    string Kind);
+    string Kind,
+    int? TermCount,
+    int? RemainingPayments,
+    bool IsManual);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Commands/InstallmentCommands.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Commands/InstallmentCommands.cs
@@ -1,0 +1,98 @@
+namespace FinanceSentry.Modules.Subscriptions.Application.Commands;
+
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Modules.Subscriptions.Domain;
+using FinanceSentry.Modules.Subscriptions.Domain.Exceptions;
+using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
+
+// --- Set / clear the installment term (total number of payments) ---
+
+public record SetInstallmentTermCommand(string UserId, Guid Id, int? TermCount) : ICommand<bool>;
+
+public class SetInstallmentTermCommandHandler(IDetectedSubscriptionRepository repository)
+    : ICommandHandler<SetInstallmentTermCommand, bool>
+{
+    private readonly IDetectedSubscriptionRepository _repository = repository;
+
+    public async Task<bool> Handle(SetInstallmentTermCommand command, CancellationToken ct)
+    {
+        var item = await _repository.GetByIdAsync(command.Id, ct);
+        if (item is null || item.UserId != command.UserId)
+            throw new SubscriptionNotFoundException();
+
+        item.SetTerm(command.TermCount);
+        await _repository.UpsertAsync(item, ct);
+        return true;
+    }
+}
+
+// --- Mark an installment finished ---
+
+public record CompleteInstallmentCommand(string UserId, Guid Id) : ICommand<bool>;
+
+public class CompleteInstallmentCommandHandler(IDetectedSubscriptionRepository repository)
+    : ICommandHandler<CompleteInstallmentCommand, bool>
+{
+    private readonly IDetectedSubscriptionRepository _repository = repository;
+
+    public async Task<bool> Handle(CompleteInstallmentCommand command, CancellationToken ct)
+    {
+        var item = await _repository.GetByIdAsync(command.Id, ct);
+        if (item is null || item.UserId != command.UserId)
+            throw new SubscriptionNotFoundException();
+
+        item.MarkCompleted();
+        await _repository.UpsertAsync(item, ct);
+        return true;
+    }
+}
+
+// --- Delete an installment (primarily for manually-added ones) ---
+
+public record DeleteInstallmentCommand(string UserId, Guid Id) : ICommand<bool>;
+
+public class DeleteInstallmentCommandHandler(IDetectedSubscriptionRepository repository)
+    : ICommandHandler<DeleteInstallmentCommand, bool>
+{
+    private readonly IDetectedSubscriptionRepository _repository = repository;
+
+    public async Task<bool> Handle(DeleteInstallmentCommand command, CancellationToken ct)
+    {
+        var item = await _repository.GetByIdAsync(command.Id, ct);
+        if (item is null || item.UserId != command.UserId)
+            throw new SubscriptionNotFoundException();
+
+        await _repository.DeleteAsync(item, ct);
+        return true;
+    }
+}
+
+// --- Manually add an installment the detector missed ---
+
+public record AddManualInstallmentCommand(
+    string UserId,
+    string Merchant,
+    decimal MonthlyAmount,
+    string Currency,
+    DateOnly StartDate,
+    int? TermCount) : ICommand<Guid>;
+
+public class AddManualInstallmentCommandHandler(IDetectedSubscriptionRepository repository)
+    : ICommandHandler<AddManualInstallmentCommand, Guid>
+{
+    private readonly IDetectedSubscriptionRepository _repository = repository;
+
+    public async Task<Guid> Handle(AddManualInstallmentCommand command, CancellationToken ct)
+    {
+        var item = DetectedSubscription.CreateManual(
+            command.UserId,
+            command.Merchant.Trim(),
+            command.MonthlyAmount,
+            string.IsNullOrWhiteSpace(command.Currency) ? "USD" : command.Currency.Trim().ToUpperInvariant(),
+            command.StartDate,
+            command.TermCount is > 0 ? command.TermCount : null);
+
+        await _repository.UpsertAsync(item, ct);
+        return item.Id;
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Queries/GetSubscriptionsQuery.cs
@@ -34,7 +34,10 @@ public class GetSubscriptionsQueryHandler(IDetectedSubscriptionRepository reposi
             s.OccurrenceCount,
             s.Category,
             s.DetectedAt,
-            s.Kind)).ToList();
+            s.Kind,
+            s.TermCount,
+            s.RemainingPayments,
+            s.IsManual)).ToList();
 
         return new SubscriptionsListResponse(dtos, dtos.Count, hasInsufficientHistory);
     }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Services/SubscriptionDetectionResultService.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Services/SubscriptionDetectionResultService.cs
@@ -34,11 +34,12 @@ public class SubscriptionDetectionResultService(IDetectedSubscriptionRepository 
                     result.OccurrenceCount,
                     result.ConfidenceScore,
                     result.Category,
-                    result.Kind);
+                    result.Kind,
+                    result.IsCompleted);
 
                 await _repository.UpsertAsync(subscription, ct);
             }
-            else if (existing.Status != SubscriptionStatus.Dismissed)
+            else if (ShouldUpdate(existing, result))
             {
                 existing.UpdateFromDetection(
                     result.MerchantNameDisplay,
@@ -49,11 +50,28 @@ public class SubscriptionDetectionResultService(IDetectedSubscriptionRepository 
                     result.OccurrenceCount,
                     result.ConfidenceScore,
                     result.Category,
-                    result.Kind);
+                    result.Kind,
+                    result.IsCompleted);
 
                 await _repository.UpsertAsync(existing, ct);
             }
         }
+    }
+
+    private static bool ShouldUpdate(DetectedSubscription existing, DetectedSubscriptionData result)
+    {
+        // Never let detection touch a user-owned (manual) or dismissed record.
+        if (existing.IsManual || existing.Status == SubscriptionStatus.Dismissed)
+            return false;
+
+        // A completed installment stays completed unless a genuinely new payment arrived.
+        if (existing.Status == SubscriptionStatus.Completed &&
+            result.OccurrenceCount <= existing.OccurrenceCount)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public async Task MarkStaleAsPotentiallyCancelledAsync(
@@ -65,12 +83,20 @@ public class SubscriptionDetectionResultService(IDetectedSubscriptionRepository 
 
         foreach (var subscription in active)
         {
+            if (subscription.IsManual) continue;
+
             var averageIntervalDays = subscription.Cadence == "annual" ? 365 : 30;
             var staleThreshold = subscription.LastChargeDate.AddDays((int)(averageIntervalDays * 1.5));
 
             if (now > staleThreshold)
             {
-                subscription.MarkPotentiallyCancelled();
+                // A silent installment (payments simply stop, e.g. Telemart) has finished;
+                // a lapsed subscription is only "potentially cancelled".
+                if (subscription.Kind == SubscriptionKinds.Installment)
+                    subscription.MarkCompleted();
+                else
+                    subscription.MarkPotentiallyCancelled();
+
                 await _repository.UpsertAsync(subscription, ct);
             }
         }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
@@ -20,9 +20,16 @@ public class DetectedSubscription
     public int OccurrenceCount { get; private set; }
     public int ConfidenceScore { get; private set; }
     public string? Category { get; private set; }
+    /// <summary>Installment plan length in payments, if known (user-set). Enables remaining/auto-complete.</summary>
+    public int? TermCount { get; private set; }
+    /// <summary>True when the user added this by hand — detection never overwrites or auto-stales it.</summary>
+    public bool IsManual { get; private set; }
     public DateTimeOffset DetectedAt { get; private set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset UpdatedAt { get; private set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset? DismissedAt { get; private set; }
+
+    /// <summary>Payments remaining, or null when the term is unknown.</summary>
+    public int? RemainingPayments => TermCount is int term ? Math.Max(0, term - OccurrenceCount) : null;
 
     private DetectedSubscription() { }
 
@@ -39,9 +46,10 @@ public class DetectedSubscription
         int occurrenceCount,
         int confidenceScore,
         string? category,
-        string kind = SubscriptionKinds.Subscription)
+        string kind = SubscriptionKinds.Subscription,
+        bool isCompleted = false)
     {
-        return new DetectedSubscription
+        var entity = new DetectedSubscription
         {
             UserId = userId,
             MerchantNameNormalized = merchantNameNormalized,
@@ -57,7 +65,43 @@ public class DetectedSubscription
             Category = category,
             Kind = kind,
         };
+        entity.EvaluateCompletion(isCompleted);
+        return entity;
     }
+
+    /// <summary>Creates a user-entered installment (manual, never overwritten by detection).</summary>
+    public static DetectedSubscription CreateManual(
+        string userId,
+        string merchantNameDisplay,
+        decimal monthlyAmount,
+        string currency,
+        DateOnly startDate,
+        int? termCount)
+    {
+        var entity = new DetectedSubscription
+        {
+            UserId = userId,
+            MerchantNameNormalized = MerchantNameKey(merchantNameDisplay),
+            MerchantNameDisplay = merchantNameDisplay,
+            Cadence = "monthly",
+            AverageAmount = monthlyAmount,
+            LastKnownAmount = monthlyAmount,
+            Currency = currency,
+            LastChargeDate = startDate,
+            NextExpectedDate = startDate.AddMonths(1),
+            OccurrenceCount = 1,
+            ConfidenceScore = 100,
+            Category = null,
+            Kind = SubscriptionKinds.Installment,
+            TermCount = termCount,
+            IsManual = true,
+        };
+        entity.EvaluateCompletion(false);
+        return entity;
+    }
+
+    private static string MerchantNameKey(string display) =>
+        $"manual:{display.Trim().ToLowerInvariant()}";
 
     public void UpdateFromDetection(
         string merchantNameDisplay,
@@ -68,7 +112,8 @@ public class DetectedSubscription
         int occurrenceCount,
         int confidenceScore,
         string? category,
-        string kind = SubscriptionKinds.Subscription)
+        string kind = SubscriptionKinds.Subscription,
+        bool isCompleted = false)
     {
         MerchantNameDisplay = merchantNameDisplay;
         AverageAmount = averageAmount;
@@ -81,6 +126,28 @@ public class DetectedSubscription
         Kind = kind;
         Status = SubscriptionStatus.Active;
         UpdatedAt = DateTimeOffset.UtcNow;
+        EvaluateCompletion(isCompleted);
+    }
+
+    /// <summary>Sets the installment term and completes it if payments have already reached it.</summary>
+    public void SetTerm(int? termCount)
+    {
+        TermCount = termCount is > 0 ? termCount : null;
+        UpdatedAt = DateTimeOffset.UtcNow;
+        EvaluateCompletion(false);
+    }
+
+    public void MarkCompleted()
+    {
+        Status = SubscriptionStatus.Completed;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Completes the installment when a payoff was seen or the term has been reached.</summary>
+    private void EvaluateCompletion(bool payoffSeen)
+    {
+        if (payoffSeen || (TermCount is int term && OccurrenceCount >= term))
+            Status = SubscriptionStatus.Completed;
     }
 
     public void MarkDismissed()

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Domain/Repositories/IDetectedSubscriptionRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Domain/Repositories/IDetectedSubscriptionRepository.cs
@@ -12,6 +12,8 @@ public interface IDetectedSubscriptionRepository
 
     Task UpsertAsync(DetectedSubscription subscription, CancellationToken ct = default);
 
+    Task DeleteAsync(DetectedSubscription subscription, CancellationToken ct = default);
+
     Task UpdateStatusAsync(Guid id, string status, CancellationToken ct = default);
 
     Task<IReadOnlyList<DetectedSubscription>> GetActiveByUserIdAsync(

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Domain/SubscriptionStatus.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Domain/SubscriptionStatus.cs
@@ -5,4 +5,7 @@ public static class SubscriptionStatus
     public const string Active = "active";
     public const string Dismissed = "dismissed";
     public const string PotentiallyCancelled = "potentially_cancelled";
+
+    /// <summary>Installment fully paid off (term reached, payoff seen, or user-marked).</summary>
+    public const string Completed = "completed";
 }

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/Repositories/DetectedSubscriptionRepository.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/Repositories/DetectedSubscriptionRepository.cs
@@ -39,6 +39,12 @@ public class DetectedSubscriptionRepository(SubscriptionsDbContext db) : IDetect
         await _db.SaveChangesAsync(ct);
     }
 
+    public async Task DeleteAsync(DetectedSubscription subscription, CancellationToken ct = default)
+    {
+        _db.DetectedSubscriptions.Remove(subscription);
+        await _db.SaveChangesAsync(ct);
+    }
+
     public async Task UpdateStatusAsync(Guid id, string status, CancellationToken ct = default)
     {
         var subscription = await _db.DetectedSubscriptions.FirstOrDefaultAsync(s => s.Id == id, ct);

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/SubscriptionsDbContext.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Infrastructure/Persistence/SubscriptionsDbContext.cs
@@ -28,6 +28,9 @@ public class SubscriptionsDbContext(DbContextOptions<SubscriptionsDbContext> opt
         sb.Property(s => s.OccurrenceCount).HasDefaultValue(0);
         sb.Property(s => s.ConfidenceScore).HasDefaultValue(0);
         sb.Property(s => s.Category).HasMaxLength(50);
+        sb.Property(s => s.TermCount);
+        sb.Property(s => s.IsManual).HasDefaultValue(false);
+        sb.Ignore(s => s.RemainingPayments);
         sb.Property(s => s.DetectedAt).HasDefaultValueSql("now()");
         sb.Property(s => s.UpdatedAt).HasDefaultValueSql("now()");
 

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728133655_M003_AddInstallmentFields.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728133655_M003_AddInstallmentFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.Subscriptions.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.Subscriptions.Migrations
 {
     [DbContext(typeof(SubscriptionsDbContext))]
-    partial class SubscriptionsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728133655_M003_AddInstallmentFields")]
+    partial class M003_AddInstallmentFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728133655_M003_AddInstallmentFields.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Migrations/20260728133655_M003_AddInstallmentFields.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.Subscriptions.Migrations
+{
+    /// <inheritdoc />
+    public partial class M003_AddInstallmentFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsManual",
+                table: "detected_subscriptions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TermCount",
+                table: "detected_subscriptions",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsManual",
+                table: "detected_subscriptions");
+
+            migrationBuilder.DropColumn(
+                name: "TermCount",
+                table: "detected_subscriptions");
+        }
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/Subscriptions/SubscriptionDetectionAlgorithmTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/Subscriptions/SubscriptionDetectionAlgorithmTests.cs
@@ -71,6 +71,39 @@ public class SubscriptionDetectionAlgorithmTests
             .Should().Be(MerchantNameNormalizer.Normalize("Openai"));
     }
 
+    [Theory]
+    [InlineData("Погашення наступного платежу RozetkaPay", null, true)]
+    [InlineData("Щомісячний платіж telemart - monomarket", null, true)]
+    [InlineData("Погашення наступного платежу iSpace- monomarket", null, true)]
+    [InlineData("Платіж Pandora", 4829, true)] // "Платіж <merchant>" on the installment MCC
+    [InlineData("Платіж Pandora", 5262, false)] // same words, ordinary purchase MCC → not installment
+    [InlineData("Переказ на картку", 4829, false)] // a transfer, not an installment
+    [InlineData("Spotify", 5815, false)]
+    public void IsInstallmentTransaction_ClassifiesByDescriptionAndMcc(string desc, int? mcc, bool expected)
+    {
+        SubscriptionDetectionJob.IsInstallmentTransaction(desc, mcc).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Щомісячний платіж telemart - monomarket", "telemart")]
+    [InlineData("Погашення наступного платежу RozetkaPay", "RozetkaPay")]
+    [InlineData("Погашення наступного платежу iSpace- monomarket", "iSpace")]
+    [InlineData("Погашення наступного платежу ТОВ Алло - monomarket", "ТОВ Алло")]
+    [InlineData("Платіж Pandora", "Pandora")]
+    [InlineData("Повне погашення RozetkaPay", "RozetkaPay")]
+    public void ExtractInstallmentMerchant_RecoversMerchant(string desc, string expected)
+    {
+        SubscriptionDetectionJob.ExtractInstallmentMerchant(desc).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Повне погашення RozetkaPay", true)]
+    [InlineData("Погашення наступного платежу RozetkaPay", false)]
+    public void IsInstallmentPayoff_DetectsFullPayoff(string desc, bool expected)
+    {
+        SubscriptionDetectionJob.IsInstallmentPayoff(desc).Should().Be(expected);
+    }
+
     [Fact]
     public void TightenedCv_RejectsAmountsThatWouldPassLegacyThreshold()
     {

--- a/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
+++ b/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
@@ -1,4 +1,4 @@
-export type SubscriptionStatus = 'active' | 'dismissed' | 'potentially_cancelled';
+export type SubscriptionStatus = 'active' | 'dismissed' | 'potentially_cancelled' | 'completed';
 export type SubscriptionSort = 'date' | 'amount' | 'name';
 export type DismissedSubscription = Extract<SubscriptionStatus, 'dismissed'>;
 export type SubscriptionKind = 'subscription' | 'installment';
@@ -16,6 +16,17 @@ export interface Subscription {
   status: SubscriptionStatus;
   occurrenceCount: number;
   kind: SubscriptionKind;
+  termCount: Nullable<number>;
+  remainingPayments: Nullable<number>;
+  isManual: boolean;
+}
+
+export interface AddInstallmentRequest {
+  merchant: string;
+  monthlyAmount: number;
+  currency: string;
+  startDate: string;
+  termCount: Nullable<number>;
 }
 
 export interface SubscriptionSummary {

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -109,15 +109,42 @@
     </div>
 
     <!-- Installments -->
-    @if (store.activeInstallments().length > 0) {
-      <div>
-        <div class="mb-cmn-3">
-          <span
-            class="font-label text-cmn-xs font-semibold uppercase tracking-widest text-text-secondary"
+    <div>
+      <div class="mb-cmn-3 flex items-center justify-between">
+        <span
+          class="font-label text-cmn-xs font-semibold uppercase tracking-widest text-text-secondary"
+        >
+          Installments · {{ store.activeInstallments().length }}
+        </span>
+        <cmn-button (clicked)="toggleAddForm()" variant="secondary" size="sm">
+          {{ showAddForm() ? 'Cancel' : 'Add installment' }}
+        </cmn-button>
+      </div>
+
+      @if (showAddForm()) {
+        <cmn-card class="mb-cmn-3">
+          <form
+            [formGroup]="addForm"
+            (ngSubmit)="submitAdd()"
+            class="grid grid-cols-1 gap-cmn-3 sm:grid-cols-2"
           >
-            Installments · {{ store.activeInstallments().length }}
-          </span>
-        </div>
+            <cmn-input formControlName="merchant" placeholder="Merchant (e.g. Pandora)" />
+            <cmn-input formControlName="monthlyAmount" type="number" placeholder="Monthly amount" />
+            <cmn-input formControlName="currency" placeholder="Currency (e.g. UAH)" />
+            <cmn-input formControlName="startDate" placeholder="Start date (YYYY-MM-DD)" />
+            <cmn-input
+              formControlName="termCount"
+              type="number"
+              placeholder="Total payments (optional)"
+            />
+            <div class="flex items-center">
+              <cmn-button (clicked)="submitAdd()" variant="primary" size="sm">Add</cmn-button>
+            </div>
+          </form>
+        </cmn-card>
+      }
+
+      @if (store.activeInstallments().length > 0) {
         <cmn-card padding="none">
           @for (item of store.sortedInstallments(); track item.id) {
             <cmn-list-item-row [label]="item.merchantName || 'Unknown'">
@@ -128,13 +155,30 @@
               >
                 {{ item.merchantName || '?' | slice: 0 : 1 | uppercase }}
               </div>
-              <div meta class="min-w-[110px] text-center">
+              <div meta class="min-w-[170px] text-center">
                 <div class="text-cmn-xs text-text-secondary">
-                  {{ item.occurrenceCount }} payment{{ item.occurrenceCount !== 1 ? 's' : '' }} so
-                  far
+                  @if (item.termCount) {
+                    {{ item.occurrenceCount }} / {{ item.termCount }} paid
+                    @if (item.remainingPayments !== null) {
+                      · {{ item.remainingPayments }} left
+                    }
+                  } @else {
+                    {{ item.occurrenceCount }} payment{{ item.occurrenceCount !== 1 ? 's' : '' }}
+                  }
                 </div>
                 <div class="text-[11px] text-text-disabled">
                   next {{ item.nextExpectedDate | date: 'mediumDate' }}
+                </div>
+                <div class="mt-cmn-1 flex items-center justify-center gap-cmn-1">
+                  <cmn-input
+                    [formControl]="termControl(item)"
+                    type="number"
+                    size="sm"
+                    placeholder="term"
+                  />
+                  <cmn-button (clicked)="saveTerm(item.id)" variant="secondary" size="sm"
+                    >Set</cmn-button
+                  >
                 </div>
               </div>
               <div amount class="min-w-[72px] text-right">
@@ -143,11 +187,64 @@
                 </div>
                 <div class="text-[10px] text-text-disabled">/ mo</div>
               </div>
+              <div actions class="flex shrink-0 gap-cmn-1">
+                <cmn-button (clicked)="markInstallmentDone(item.id)" variant="secondary" size="sm"
+                  >Done</cmn-button
+                >
+                <cmn-button
+                  (clicked)="deleteInstallment(item)"
+                  variant="secondary"
+                  size="sm"
+                  icon="Trash2"
+                />
+              </div>
             </cmn-list-item-row>
           }
         </cmn-card>
-      </div>
-    }
+      }
+
+      @if (store.completedInstallments().length > 0) {
+        <div class="mt-cmn-3">
+          <div class="mb-cmn-2">
+            <span
+              class="font-label text-cmn-xs font-semibold uppercase tracking-widest text-text-disabled"
+            >
+              Completed · {{ store.completedInstallments().length }}
+            </span>
+          </div>
+          <cmn-card padding="none">
+            @for (item of store.completedInstallments(); track item.id) {
+              <cmn-list-item-row [label]="item.merchantName || 'Unknown'" [dimmed]="true">
+                <div
+                  [style.background]="item.merchantName | merchantColor"
+                  avatar
+                  class="flex h-10 w-10 shrink-0 items-center justify-center rounded-cmn-md font-bold text-white"
+                >
+                  {{ item.merchantName || '?' | slice: 0 : 1 | uppercase }}
+                </div>
+                <div meta class="min-w-[110px] text-center text-cmn-xs text-text-disabled">
+                  {{ item.occurrenceCount }} payments · done
+                </div>
+                <div amount class="min-w-[72px] text-right">
+                  <div class="font-mono text-cmn-sm font-semibold text-text-secondary">
+                    {{ item.monthlyEquivalent | appCurrency: item.currency }}
+                  </div>
+                  <div class="text-[10px] text-text-disabled">/ mo</div>
+                </div>
+                <div actions class="flex shrink-0 gap-cmn-1">
+                  <cmn-button
+                    (clicked)="deleteInstallment(item)"
+                    variant="secondary"
+                    size="sm"
+                    icon="Trash2"
+                  />
+                </div>
+              </cmn-list-item-row>
+            }
+          </cmn-card>
+        </div>
+      }
+    </div>
 
     <!-- Dismissed list -->
     @if (store.dismissedSubscriptions().length > 0) {

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
@@ -1,11 +1,13 @@
 import {DatePipe, SlicePipe, UpperCasePipe} from '@angular/common';
-import {ChangeDetectionStrategy, Component, inject, ViewContainerRef} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject, signal, ViewContainerRef} from '@angular/core';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {
   ButtonComponent,
   CardComponent,
   ChipComponent,
   CmnDialogService,
   ConfirmDialogComponent,
+  InputComponent,
   ListItemRowComponent,
   PageHeaderComponent,
   StatCardComponent,
@@ -21,6 +23,7 @@ import {MerchantColorPipe} from '../../pipes/merchant-color.pipe';
 import {SubscriptionsStore} from '../../store/subscriptions/subscriptions.store';
 
 const MS_PER_DAY = 86_400_000;
+const MIN_MONTHLY_AMOUNT = 0.01;
 
 const SORT_OPTIONS: {value: SubscriptionSort; label: string}[] = [
   {value: 'date', label: 'Next charge'},
@@ -36,9 +39,11 @@ const SORT_OPTIONS: {value: SubscriptionSort; label: string}[] = [
     CardComponent,
     ChipComponent,
     DatePipe,
+    InputComponent,
     ListItemRowComponent,
     MerchantColorPipe,
     PageHeaderComponent,
+    ReactiveFormsModule,
     SlicePipe,
     StatCardComponent,
     UpperCasePipe,
@@ -50,9 +55,23 @@ const SORT_OPTIONS: {value: SubscriptionSort; label: string}[] = [
 export class SubscriptionsComponent {
   private readonly dialog = inject(CmnDialogService);
   private readonly viewContainerRef = inject(ViewContainerRef);
+  // One reusable control for the inline "set term" editor per installment row.
+  private readonly termControls = new Map<string, FormControl<number | null>>();
 
   public readonly store = inject(SubscriptionsStore);
   public readonly sortOptions = SORT_OPTIONS;
+
+  public readonly showAddForm = signal(false);
+
+  public readonly addForm = new FormGroup({
+    merchant: new FormControl('', {nonNullable: true, validators: [Validators.required]}),
+    monthlyAmount: new FormControl<number | null>(null, {
+      validators: [Validators.required, Validators.min(MIN_MONTHLY_AMOUNT)],
+    }),
+    currency: new FormControl('UAH', {nonNullable: true, validators: [Validators.required]}),
+    startDate: new FormControl('', {nonNullable: true, validators: [Validators.required]}),
+    termCount: new FormControl<number | null>(null),
+  });
 
   public daysUntil(dateStr: string): number {
     return Math.ceil((new Date(dateStr).getTime() - Date.now()) / MS_PER_DAY);
@@ -78,14 +97,81 @@ export class SubscriptionsComponent {
       .afterClosed()
       .pipe(take(1))
       .subscribe(confirmed => {
-        if (confirmed !== true) {
-          return;
+        if (confirmed === true) {
+          this.store.dismiss(sub.id);
         }
-        this.store.dismiss(sub.id);
       });
   }
 
   public restore(id: string): void {
     this.store.restore(id);
+  }
+
+  public markInstallmentDone(id: string): void {
+    this.store.completeInstallment(id);
+  }
+
+  public deleteInstallment(sub: Pick<Subscription, 'id' | 'merchantName'>): void {
+    const ref = this.dialog.open<boolean>(ConfirmDialogComponent, {
+      data: {
+        title: `Delete ${sub.merchantName}?`,
+        message: 'Permanently remove this installment.',
+        confirmLabel: 'Delete',
+        cancelLabel: 'Keep',
+        confirmVariant: 'destructive',
+      },
+      size: 'sm',
+      viewContainerRef: this.viewContainerRef,
+    });
+    ref
+      .afterClosed()
+      .pipe(take(1))
+      .subscribe(confirmed => {
+        if (confirmed === true) {
+          this.store.deleteInstallment(sub.id);
+        }
+      });
+  }
+
+  public termControl(sub: Pick<Subscription, 'id' | 'termCount'>): FormControl<number | null> {
+    let control = this.termControls.get(sub.id);
+    if (!control) {
+      control = new FormControl<number | null>(sub.termCount ?? null);
+      this.termControls.set(sub.id, control);
+    }
+    return control;
+  }
+
+  public saveTerm(id: string): void {
+    const control = this.termControls.get(id);
+    const value = control?.value ?? null;
+    this.store.setInstallmentTerm({id, termCount: value && value > 0 ? value : null});
+  }
+
+  public toggleAddForm(): void {
+    this.showAddForm.update(open => !open);
+  }
+
+  public submitAdd(): void {
+    if (this.addForm.invalid) {
+      this.addForm.markAllAsTouched();
+      return;
+    }
+    const value = this.addForm.getRawValue();
+    this.store.addInstallment({
+      merchant: value.merchant,
+      monthlyAmount: value.monthlyAmount ?? 0,
+      currency: value.currency,
+      startDate: value.startDate,
+      termCount: value.termCount && value.termCount > 0 ? value.termCount : null,
+    });
+    this.addForm.reset({
+      merchant: '',
+      monthlyAmount: null,
+      currency: 'UAH',
+      startDate: '',
+      termCount: null,
+    });
+    this.showAddForm.set(false);
   }
 }

--- a/frontend/src/app/modules/subscriptions/services/subscriptions.service.ts
+++ b/frontend/src/app/modules/subscriptions/services/subscriptions.service.ts
@@ -3,6 +3,7 @@ import {ApiService} from '@dsdevq-common/core';
 import {type Observable} from 'rxjs';
 
 import {
+  type AddInstallmentRequest,
   type SubscriptionsListResponse,
   type SubscriptionSummary,
 } from '../models/subscription/subscription.model';
@@ -30,5 +31,21 @@ export class SubscriptionsService extends ApiService {
 
   public restore(id: string): Observable<void> {
     return this.patch<void>(`${id}/restore`);
+  }
+
+  public setInstallmentTerm(id: string, termCount: Nullable<number>): Observable<void> {
+    return this.patch<void>(`installments/${id}/term`, {termCount});
+  }
+
+  public completeInstallment(id: string): Observable<void> {
+    return this.patch<void>(`installments/${id}/complete`);
+  }
+
+  public deleteInstallment(id: string): Observable<void> {
+    return this.delete<void>(`installments/${id}`);
+  }
+
+  public addInstallment(payload: AddInstallmentRequest): Observable<{id: string}> {
+    return this.post<{id: string}>('installments', payload);
   }
 }

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
@@ -42,6 +42,9 @@ export function subscriptionsComputed(store: StateSignals) {
     activeInstallments: computed(() =>
       store.subscriptions().filter(s => s.status === 'active' && isInstallment(s))
     ),
+    completedInstallments: computed(() =>
+      store.subscriptions().filter(s => s.status === 'completed' && isInstallment(s))
+    ),
     dismissTarget: computed(
       () => store.subscriptions().find(s => s.id === store.dismissTargetId()) ?? null
     ),

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
@@ -1,8 +1,9 @@
 import {inject} from '@angular/core';
 import {rxMethod} from '@ngrx/signals/rxjs-interop';
-import {forkJoin, pipe, switchMap, tap} from 'rxjs';
+import {forkJoin, type Observable, pipe, switchMap, tap} from 'rxjs';
 
 import {
+  type AddInstallmentRequest,
   type Subscription,
   type SubscriptionSummary,
 } from '../../models/subscription/subscription.model';
@@ -18,26 +19,40 @@ interface EffectsStore {
 export function subscriptionsEffects(store: EffectsStore) {
   const service = inject(SubscriptionsService);
 
+  const refresh = (): Observable<unknown> =>
+    forkJoin({
+      list$: service.getSubscriptions(true),
+      summary$: service.getSummary(),
+    }).pipe(
+      tap(({list$, summary$}) => {
+        store.setData(list$.items, list$.hasInsufficientHistory);
+        store.setSummary(summary$);
+      })
+    );
+
   return {
-    load: rxMethod<void>(
-      pipe(
-        switchMap(() =>
-          forkJoin({
-            list$: service.getSubscriptions(true),
-            summary$: service.getSummary(),
-          })
-        ),
-        tap(({list$, summary$}) => {
-          store.setData(list$.items, list$.hasInsufficientHistory);
-          store.setSummary(summary$);
-        })
-      )
-    ),
+    load: rxMethod<void>(pipe(switchMap(() => refresh()))),
     dismiss: rxMethod<string>(
       pipe(switchMap(id => service.dismiss(id).pipe(tap(() => store.confirmDismiss()))))
     ),
     restore: rxMethod<string>(
       pipe(switchMap(id => service.restore(id).pipe(tap(() => store.restoreSubscription(id)))))
+    ),
+    setInstallmentTerm: rxMethod<{id: string; termCount: Nullable<number>}>(
+      pipe(
+        switchMap(({id, termCount}) =>
+          service.setInstallmentTerm(id, termCount).pipe(switchMap(() => refresh()))
+        )
+      )
+    ),
+    completeInstallment: rxMethod<string>(
+      pipe(switchMap(id => service.completeInstallment(id).pipe(switchMap(() => refresh()))))
+    ),
+    deleteInstallment: rxMethod<string>(
+      pipe(switchMap(id => service.deleteInstallment(id).pipe(switchMap(() => refresh()))))
+    ),
+    addInstallment: rxMethod<AddInstallmentRequest>(
+      pipe(switchMap(payload => service.addInstallment(payload).pipe(switchMap(() => refresh()))))
     ),
   };
 }


### PR DESCRIPTION
The "detect + manage" rework, grounded in real VPS data — makes installments accurate instead of a lossy heuristic.

## Smarter detection (backend)
- Installments now detected separately from subscriptions: MCC 4829 + Monobank phrasings (`Погашення…`, `Щомісячний платіж`, `- monomarket`, `Платіж <merchant>`), grouped by the merchant recovered from the description. **No 3-payment minimum** — surfaces the ones we were missing (iSpace, Алло, Pandora).
- **Auto-complete on `Повне погашення`** when it's the latest activity (an early payoff followed by more charges stays active — the RozetkaPay case).
- Silent installments (payments just stop, e.g. Telemart) complete on staleness instead of "potentially cancelled".

## Management layer (truth over inference)
- **Term** (`TermCount`) → `RemainingPayments` + auto-complete when reached.
- **Mark done**, **delete**, and **manual add** (for anything missed). Manual entries are never overwritten by detection.
- Status `completed`; migration **M003**. Commands + REST endpoints.

## Frontend
- Installments section: progress (paid / term · remaining), next date, amount; completed sub-section; per-row Done / Set-term / delete; add-installment form.

## Limitation
Monobank's API has no plan term, so "remaining" needs the user to set the term once — that's the one manual input the data can't provide.

Gates: 364 backend unit + 8 subscription integration + 149 frontend tests; lint + build clean. Migration EF-generated with Designer + snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)