### PR TITLE
feat(subscriptions): skip €0 charges + manual-add a subscription

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/SubscriptionDetectionJob.cs
@@ -171,6 +171,7 @@ public sealed class SubscriptionDetectionJob(
             .AsNoTracking()
             .Where(t => t.IsActive
                      && !t.IsPending
+                     && t.Amount != 0m   // skip €0.00 auth holds / reversals that skew amount stability
                      && t.TransactionDate >= cutoff
                      && (t.TransactionType == null || t.TransactionType == "debit"))
             .Join(db.BankAccounts.Where(a => a.IsActive && a.Provider != "plaid"),

--- a/backend/src/FinanceSentry.Modules.Subscriptions/API/Controllers/SubscriptionsController.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/API/Controllers/SubscriptionsController.cs
@@ -17,7 +17,8 @@ public class SubscriptionsController(
     ICommandHandler<SetInstallmentTermCommand, bool> setTerm,
     ICommandHandler<CompleteInstallmentCommand, bool> completeInstallment,
     ICommandHandler<DeleteInstallmentCommand, bool> deleteInstallment,
-    ICommandHandler<AddManualInstallmentCommand, Guid> addInstallment) : ControllerBase
+    ICommandHandler<AddManualInstallmentCommand, Guid> addInstallment,
+    ICommandHandler<AddManualSubscriptionCommand, Guid> addSubscription) : ControllerBase
 {
     [HttpGet]
     public async Task<IActionResult> GetSubscriptions(
@@ -84,9 +85,27 @@ public class SubscriptionsController(
             body.TermCount), ct);
         return Ok(new { id });
     }
+
+    [HttpPost("manual-subscription")]
+    public async Task<IActionResult> AddSubscription([FromBody] AddSubscriptionRequest body, CancellationToken ct = default)
+    {
+        var id = await addSubscription.Handle(new AddManualSubscriptionCommand(
+            User.RequireUserId().ToString(),
+            body.Merchant,
+            body.MonthlyAmount,
+            body.Currency,
+            body.StartDate), ct);
+        return Ok(new { id });
+    }
 }
 
 public record SetTermRequest(int? TermCount);
+
+public record AddSubscriptionRequest(
+    string Merchant,
+    decimal MonthlyAmount,
+    string Currency,
+    DateOnly StartDate);
 
 public record AddInstallmentRequest(
     string Merchant,

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Application/Commands/InstallmentCommands.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Application/Commands/InstallmentCommands.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.Subscriptions.Application.Commands;
 
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Modules.Subscriptions.Domain;
 using FinanceSentry.Modules.Subscriptions.Domain.Exceptions;
 using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
@@ -91,6 +92,36 @@ public class AddManualInstallmentCommandHandler(IDetectedSubscriptionRepository 
             string.IsNullOrWhiteSpace(command.Currency) ? "USD" : command.Currency.Trim().ToUpperInvariant(),
             command.StartDate,
             command.TermCount is > 0 ? command.TermCount : null);
+
+        await _repository.UpsertAsync(item, ct);
+        return item.Id;
+    }
+}
+
+// --- Manually add a subscription detection can't reliably find (e.g. an irregular Claude plan) ---
+
+public record AddManualSubscriptionCommand(
+    string UserId,
+    string Merchant,
+    decimal MonthlyAmount,
+    string Currency,
+    DateOnly StartDate) : ICommand<Guid>;
+
+public class AddManualSubscriptionCommandHandler(IDetectedSubscriptionRepository repository)
+    : ICommandHandler<AddManualSubscriptionCommand, Guid>
+{
+    private readonly IDetectedSubscriptionRepository _repository = repository;
+
+    public async Task<Guid> Handle(AddManualSubscriptionCommand command, CancellationToken ct)
+    {
+        var item = DetectedSubscription.CreateManual(
+            command.UserId,
+            command.Merchant.Trim(),
+            command.MonthlyAmount,
+            string.IsNullOrWhiteSpace(command.Currency) ? "USD" : command.Currency.Trim().ToUpperInvariant(),
+            command.StartDate,
+            termCount: null,
+            kind: SubscriptionKinds.Subscription);
 
         await _repository.UpsertAsync(item, ct);
         return item.Id;

--- a/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
+++ b/backend/src/FinanceSentry.Modules.Subscriptions/Domain/DetectedSubscription.cs
@@ -69,19 +69,24 @@ public class DetectedSubscription
         return entity;
     }
 
-    /// <summary>Creates a user-entered installment (manual, never overwritten by detection).</summary>
+    /// <summary>
+    /// Creates a user-entered recurring item (manual, never overwritten by detection).
+    /// Use for a subscription detection can't reliably find (e.g. an irregular Claude
+    /// plan) or an installment it missed.
+    /// </summary>
     public static DetectedSubscription CreateManual(
         string userId,
         string merchantNameDisplay,
         decimal monthlyAmount,
         string currency,
         DateOnly startDate,
-        int? termCount)
+        int? termCount,
+        string kind = SubscriptionKinds.Installment)
     {
         var entity = new DetectedSubscription
         {
             UserId = userId,
-            MerchantNameNormalized = MerchantNameKey(merchantNameDisplay),
+            MerchantNameNormalized = MerchantNameKey(merchantNameDisplay, kind),
             MerchantNameDisplay = merchantNameDisplay,
             Cadence = "monthly",
             AverageAmount = monthlyAmount,
@@ -92,16 +97,16 @@ public class DetectedSubscription
             OccurrenceCount = 1,
             ConfidenceScore = 100,
             Category = null,
-            Kind = SubscriptionKinds.Installment,
-            TermCount = termCount,
+            Kind = kind,
+            TermCount = kind == SubscriptionKinds.Installment ? termCount : null,
             IsManual = true,
         };
         entity.EvaluateCompletion(false);
         return entity;
     }
 
-    private static string MerchantNameKey(string display) =>
-        $"manual:{display.Trim().ToLowerInvariant()}";
+    private static string MerchantNameKey(string display, string kind) =>
+        $"manual:{kind}:{display.Trim().ToLowerInvariant()}";
 
     public void UpdateFromDetection(
         string merchantNameDisplay,

--- a/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
+++ b/frontend/src/app/modules/subscriptions/models/subscription/subscription.model.ts
@@ -29,6 +29,13 @@ export interface AddInstallmentRequest {
   termCount: Nullable<number>;
 }
 
+export interface AddSubscriptionRequest {
+  merchant: string;
+  monthlyAmount: number;
+  currency: string;
+  startDate: string;
+}
+
 export interface SubscriptionSummary {
   totalMonthlyEstimate: number;
   totalAnnualEstimate: number;

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.html
@@ -50,14 +50,37 @@
         >
           Active · {{ store.activeSubscriptions().length }}
         </span>
-        <div class="flex gap-cmn-1">
+        <div class="flex items-center gap-cmn-1">
           @for (opt of sortOptions; track opt.value) {
             <cmn-chip [selected]="store.sort() === opt.value" (clicked)="setSort(opt.value)">
               {{ opt.label }}
             </cmn-chip>
           }
+          <cmn-button (clicked)="toggleSubForm()" variant="secondary" size="sm">
+            {{ showSubForm() ? 'Cancel' : 'Add' }}
+          </cmn-button>
         </div>
       </div>
+
+      @if (showSubForm()) {
+        <cmn-card class="mb-cmn-3">
+          <form
+            [formGroup]="subForm"
+            (ngSubmit)="submitSubscription()"
+            class="grid grid-cols-1 gap-cmn-3 sm:grid-cols-2"
+          >
+            <cmn-input formControlName="merchant" placeholder="Merchant (e.g. Claude)" />
+            <cmn-input formControlName="monthlyAmount" type="number" placeholder="Monthly amount" />
+            <cmn-input formControlName="currency" placeholder="Currency (e.g. EUR)" />
+            <cmn-input formControlName="startDate" placeholder="Start date (YYYY-MM-DD)" />
+            <div class="flex items-center">
+              <cmn-button (clicked)="submitSubscription()" variant="primary" size="sm"
+                >Add</cmn-button
+              >
+            </div>
+          </form>
+        </cmn-card>
+      }
 
       <cmn-card padding="none">
         @for (sub of store.sortedActive(); track sub.id) {

--- a/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
+++ b/frontend/src/app/modules/subscriptions/pages/subscriptions/subscriptions.component.ts
@@ -62,6 +62,16 @@ export class SubscriptionsComponent {
   public readonly sortOptions = SORT_OPTIONS;
 
   public readonly showAddForm = signal(false);
+  public readonly showSubForm = signal(false);
+
+  public readonly subForm = new FormGroup({
+    merchant: new FormControl('', {nonNullable: true, validators: [Validators.required]}),
+    monthlyAmount: new FormControl<number | null>(null, {
+      validators: [Validators.required, Validators.min(MIN_MONTHLY_AMOUNT)],
+    }),
+    currency: new FormControl('EUR', {nonNullable: true, validators: [Validators.required]}),
+    startDate: new FormControl('', {nonNullable: true, validators: [Validators.required]}),
+  });
 
   public readonly addForm = new FormGroup({
     merchant: new FormControl('', {nonNullable: true, validators: [Validators.required]}),
@@ -150,6 +160,26 @@ export class SubscriptionsComponent {
 
   public toggleAddForm(): void {
     this.showAddForm.update(open => !open);
+  }
+
+  public toggleSubForm(): void {
+    this.showSubForm.update(open => !open);
+  }
+
+  public submitSubscription(): void {
+    if (this.subForm.invalid) {
+      this.subForm.markAllAsTouched();
+      return;
+    }
+    const value = this.subForm.getRawValue();
+    this.store.addSubscription({
+      merchant: value.merchant,
+      monthlyAmount: value.monthlyAmount ?? 0,
+      currency: value.currency,
+      startDate: value.startDate,
+    });
+    this.subForm.reset({merchant: '', monthlyAmount: null, currency: 'EUR', startDate: ''});
+    this.showSubForm.set(false);
   }
 
   public submitAdd(): void {

--- a/frontend/src/app/modules/subscriptions/services/subscriptions.service.ts
+++ b/frontend/src/app/modules/subscriptions/services/subscriptions.service.ts
@@ -4,6 +4,7 @@ import {type Observable} from 'rxjs';
 
 import {
   type AddInstallmentRequest,
+  type AddSubscriptionRequest,
   type SubscriptionsListResponse,
   type SubscriptionSummary,
 } from '../models/subscription/subscription.model';
@@ -47,5 +48,9 @@ export class SubscriptionsService extends ApiService {
 
   public addInstallment(payload: AddInstallmentRequest): Observable<{id: string}> {
     return this.post<{id: string}>('installments', payload);
+  }
+
+  public addSubscription(payload: AddSubscriptionRequest): Observable<{id: string}> {
+    return this.post<{id: string}>('manual-subscription', payload);
   }
 }

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
@@ -4,6 +4,7 @@ import {forkJoin, type Observable, pipe, switchMap, tap} from 'rxjs';
 
 import {
   type AddInstallmentRequest,
+  type AddSubscriptionRequest,
   type Subscription,
   type SubscriptionSummary,
 } from '../../models/subscription/subscription.model';
@@ -53,6 +54,9 @@ export function subscriptionsEffects(store: EffectsStore) {
     ),
     addInstallment: rxMethod<AddInstallmentRequest>(
       pipe(switchMap(payload => service.addInstallment(payload).pipe(switchMap(() => refresh()))))
+    ),
+    addSubscription: rxMethod<AddSubscriptionRequest>(
+      pipe(switchMap(payload => service.addSubscription(payload).pipe(switchMap(() => refresh()))))
     ),
   };
 }


### PR DESCRIPTION
Makes ChatGPT auto-detect and lets Claude be added by hand.

- **ChatGPT** — its three clean €23 charges were rejected because a **€0.00 auth hold** dragged the amount-stability (CV) check over the limit. Detection now **ignores zero-amount transactions**, so ChatGPT detects cleanly.
- **Claude** — genuinely can't be auto-detected: it's a **Pro→Max upgrade** (€22.14 → €110.70, a prorated €98.38, irregular 44-day gaps) — two price points, not one stable recurring amount. So it needs a **manual entry**: `CreateManual` now takes a kind, new `AddManualSubscriptionCommand` + endpoint, and an **Add** form in the Active subscriptions section.

No migration (reuses schema). Gates: 66 backend subscription unit + 149 frontend tests, lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)