### PR TITLE
fix(reliability): stop silent cron-failure loops (TrueLayer, TrendForce, Yahoo)

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -385,6 +385,17 @@ public class ScheduledSyncService(
             return null;
         }
 
+        if (provider == "truelayer")
+        {
+            // Expired/revoked consent is a re-consent condition, not a transient failure. Map it to the
+            // canonical reauth code so the account is flagged for reconnection and the scheduler stops
+            // retrying it every cycle (instead of logging errorCode=UNKNOWN forever).
+            if (message.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("consent has expired", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("has been revoked", StringComparison.OrdinalIgnoreCase))
+                return "ITEM_LOGIN_REQUIRED";
+        }
+
         string[] knownCodes =
         [
             "ITEM_LOGIN_REQUIRED",

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransactionSyncCoordinator.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransactionSyncCoordinator.cs
@@ -21,9 +21,11 @@ public interface ITransactionSyncCoordinator
 /// <inheritdoc />
 public class TransactionSyncCoordinator(
     ISyncJobRepository syncJobs,
+    IBankAccountRepository accounts,
     IScheduledSyncService syncService) : ITransactionSyncCoordinator
 {
     private readonly ISyncJobRepository _syncJobs = syncJobs;
+    private readonly IBankAccountRepository _accounts = accounts;
     private readonly IScheduledSyncService _syncService = syncService;
 
     /// <inheritdoc />
@@ -40,6 +42,13 @@ public class TransactionSyncCoordinator(
     {
         if (await _syncJobs.HasRunningJobAsync(accountId, ct))
             return new SyncResult(false, 0, 0, "SYNC_IN_PROGRESS", "A sync is already in progress for this account.");
+
+        // An account whose provider consent has expired/been revoked cannot sync until the user
+        // reconnects. Skip it in the recurring scheduler so it stops failing every cycle; the reconnect
+        // flow (manual/webhook path) clears the state via MarkActive. Manual syncs are unaffected.
+        var account = await _accounts.GetByIdAsync(accountId, ct);
+        if (account?.SyncStatus == "reauth_required")
+            return new SyncResult(false, 0, 0, "ITEM_LOGIN_REQUIRED", "Account requires reconnection; scheduled sync skipped.");
 
         return await _syncService.PerformFullSyncAsync(accountId, webhookTriggered: false, ct: ct);
     }

--- a/backend/src/FinanceSentry.Modules.Research/Application/Services/NewsSourceHealthTracker.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Application/Services/NewsSourceHealthTracker.cs
@@ -5,12 +5,16 @@ using FinanceSentry.Modules.Research.Domain;
 /// <summary>
 /// Per-source durable failure counters for registered news sources (feature 030, FR-009). Unlike the
 /// analyst-source in-memory counters, these live on the <see cref="NewsSource"/> row and survive
-/// restarts. A sync-failure alert fires once the count reaches <see cref="AlertThreshold"/> consecutive
-/// failures; success resets the counter.
+/// restarts. A sync-failure alert fires once when the count reaches <see cref="AlertThreshold"/>
+/// consecutive failures; a source that keeps failing to <see cref="DisableThreshold"/> is auto-disabled
+/// so it stops retrying (and log-spamming) every run. Success resets the counter.
 /// </summary>
 public static class NewsSourceHealthTracker
 {
     public const int AlertThreshold = 2;
+
+    /// <summary>Consecutive failures before a source is retired. ~6h at the 30-min ingestion cadence.</summary>
+    public const int DisableThreshold = 12;
 
     public static void RecordSuccess(NewsSource source)
     {
@@ -19,11 +23,38 @@ public static class NewsSourceHealthTracker
         source.LastFailureReason = null;
     }
 
-    /// <summary>Records a failure and returns <c>true</c> when the alert threshold is reached.</summary>
-    public static bool RecordFailure(NewsSource source, string reason)
+    /// <summary>
+    /// Records a failure and reports what follow-up action the caller should take. <see cref="NewsSourceFailureOutcome.Alert"/>
+    /// fires exactly once (at the threshold) so a stuck source does not re-alert every run;
+    /// <see cref="NewsSourceFailureOutcome.Disable"/> flips <see cref="NewsSource.Enabled"/> off so the
+    /// source drops out of the ingestion loop entirely.
+    /// </summary>
+    public static NewsSourceFailureOutcome RecordFailure(NewsSource source, string reason)
     {
         source.ConsecutiveFailures++;
         source.LastFailureReason = reason;
-        return source.ConsecutiveFailures >= AlertThreshold;
+
+        if (source.Enabled && source.ConsecutiveFailures >= DisableThreshold)
+        {
+            source.Enabled = false;
+            return NewsSourceFailureOutcome.Disable;
+        }
+
+        return source.ConsecutiveFailures == AlertThreshold
+            ? NewsSourceFailureOutcome.Alert
+            : NewsSourceFailureOutcome.None;
     }
+}
+
+/// <summary>Follow-up action a caller should take after recording a news-source failure.</summary>
+public enum NewsSourceFailureOutcome
+{
+    /// <summary>Nothing to do — failure recorded, below the alert threshold or already alerted.</summary>
+    None,
+
+    /// <summary>The source just reached the consecutive-failure alert threshold; notify once.</summary>
+    Alert,
+
+    /// <summary>The source was auto-disabled after sustained failures; notify and stop retrying it.</summary>
+    Disable,
 }

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/NewsIngestionJob.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Jobs/NewsIngestionJob.cs
@@ -114,14 +114,30 @@ public sealed class NewsIngestionJob(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            var shouldAlert = NewsSourceHealthTracker.RecordFailure(source, ex.Message);
+            var outcome = NewsSourceHealthTracker.RecordFailure(source, ex.Message);
             await sourceRepo.UpdateAsync(source, ct);
-            logger.LogError(ex,
-                "News source {Source} failed ({Consecutive} consecutive)", source.Name, source.ConsecutiveFailures);
 
-            if (shouldAlert)
+            if (outcome == NewsSourceFailureOutcome.Disable)
             {
-                await RaiseFailureAlertAsync(source.Name, ex.Message, ct);
+                logger.LogError(ex,
+                    "News source {Source} auto-disabled after {Consecutive} consecutive failures",
+                    source.Name, source.ConsecutiveFailures);
+                await RaiseFailureAlertAsync(
+                    source.Name,
+                    $"Auto-disabled after {source.ConsecutiveFailures} consecutive failures: {ex.Message}",
+                    ct);
+            }
+            else
+            {
+                // Ongoing failures below the disable threshold are logged at Warning to avoid flooding the
+                // error stream; the one-time alert still fires when the alert threshold is first crossed.
+                logger.LogWarning(
+                    "News source {Source} failed ({Consecutive} consecutive)", source.Name, source.ConsecutiveFailures);
+
+                if (outcome == NewsSourceFailureOutcome.Alert)
+                {
+                    await RaiseFailureAlertAsync(source.Name, ex.Message, ct);
+                }
             }
         }
     }

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/TrendForcePageSource.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/TrendForcePageSource.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.Research.Infrastructure.Sources;
 
+using System.Text.RegularExpressions;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using FinanceSentry.Modules.Research.Application.Services;
@@ -18,13 +19,23 @@ public sealed class TrendForcePageSource(
 
     private const string Host = "trendforce.com";
 
+    // Known card container shapes, most-specific first. TrendForce has restyled the press list twice
+    // (list-item -> niche-box-post), so class selectors are treated as a fast path only: when none
+    // match, ParseAsync falls back to the stable article-href pattern below (FindArticleNodesByHref),
+    // which survives CSS churn.
     private static readonly string[] ArticleSelectors =
     [
+        ".niche-box-post",
         ".press-news-list .list-items > .list-item",
         ".list-items > .list-item",
         "article",
         ".press-item"
     ];
+
+    // TrendForce article permalinks: /presscenter/news/<8-digit-date>-<id>.html. Category/index links
+    // (e.g. /presscenter/news/Semiconductors) do not match, so this cleanly isolates real articles.
+    private static readonly Regex ArticleHrefPattern =
+        new(@"/presscenter/news/\d{6,}-\d+\.html$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public bool CanHandle(string url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
@@ -108,7 +119,45 @@ public sealed class TrendForcePageSource(
             }
         }
 
-        return [];
+        // Fallback: recover article cards from the stable permalink pattern when the card classes have
+        // drifted. Each matching anchor is climbed to its nearest card ancestor; duplicates (multiple
+        // anchors per card, e.g. image + headline) collapse via reference equality.
+        var byHref = doc.QuerySelectorAll("a[href]")
+            .Where(a => ArticleHrefPattern.IsMatch(a.GetAttribute("href") ?? string.Empty))
+            .Select(FindCardByAnchor)
+            .Distinct()
+            .ToList();
+
+        return byHref;
+    }
+
+    /// <summary>
+    /// Climbs from an article anchor to the smallest ancestor that looks like a self-contained card —
+    /// one carrying a heading and at least one sibling element (date/summary). Falls back to the direct
+    /// parent so extraction still has a scope to query.
+    /// </summary>
+    private static IElement FindCardByAnchor(IElement anchor)
+    {
+        const int MaxDepth = 5;
+        var current = anchor;
+        for (var depth = 0; depth < MaxDepth; depth++)
+        {
+            var parent = current.ParentElement;
+            if (parent is null)
+            {
+                break;
+            }
+
+            var hasHeading = parent.QuerySelector("h1, h2, h3, h4") is not null;
+            if (hasHeading && parent.Children.Length >= 2)
+            {
+                return parent;
+            }
+
+            current = parent;
+        }
+
+        return anchor.ParentElement ?? anchor;
     }
 
     private static string? ExtractTitle(IElement node, IElement anchor)
@@ -122,15 +171,30 @@ public sealed class TrendForcePageSource(
     {
         var timeEl = node.QuerySelector("time[datetime]");
         var raw = timeEl?.GetAttribute("datetime")
-            ?? node.QuerySelector("time, .date, .time, h4.color-green")?.TextContent;
+            ?? node.QuerySelector("time, .date, .time, h4.color-green, .bd-month, .block-data")?.TextContent;
 
-        return DateTimeOffset.TryParse(raw, out var parsed) ? parsed : DateTimeOffset.UtcNow;
+        return DateTimeOffset.TryParse(raw?.Trim(), out var parsed) ? parsed : DateTimeOffset.UtcNow;
     }
 
     private static string? ExtractSummary(IElement node)
     {
-        var summary = node.QuerySelector("p, .summary, .desc")?.TextContent?.Trim();
-        return string.IsNullOrWhiteSpace(summary) ? null : summary;
+        // Prefer an explicit summary element; otherwise the first paragraph that isn't the date block
+        // (TrendForce renders the date inside <p class="bd-day/bd-month">, which must not become the body).
+        foreach (var el in node.QuerySelectorAll(".summary, .desc, p"))
+        {
+            if (el.ClassList.Contains("bd-day") || el.ClassList.Contains("bd-month"))
+            {
+                continue;
+            }
+
+            var text = el.TextContent?.Trim();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+        }
+
+        return null;
     }
 
     private static string Resolve(Uri? baseUri, string href)

--- a/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/YahooAnalystActionsSource.cs
+++ b/backend/src/FinanceSentry.Modules.Research/Infrastructure/Sources/YahooAnalystActionsSource.cs
@@ -78,7 +78,10 @@ public sealed class YahooAnalystActionsSource(
     private async Task<IReadOnlyList<AnalystActionRecord>> FetchTickerAsync(
         HttpClient client, string ticker, string crumbValue, DateOnly cutoff, CancellationToken ct)
     {
-        var url = $"https://query1.finance.yahoo.com/v10/finance/quoteSummary/{Uri.EscapeDataString(ticker)}"
+        // Yahoo uses '-' where symbols carry a class suffix (e.g. BRK.B -> BRK-B); querying the dotted
+        // form 404s. Normalize for the request but keep the caller's canonical symbol on the record.
+        var yahooSymbol = ticker.Replace('.', '-');
+        var url = $"https://query1.finance.yahoo.com/v10/finance/quoteSummary/{Uri.EscapeDataString(yahooSymbol)}"
             + $"?modules=upgradeDowngradeHistory&crumb={Uri.EscapeDataString(crumbValue)}";
 
         try
@@ -93,6 +96,14 @@ public sealed class YahooAnalystActionsSource(
                 }
 
                 return await FetchTickerAsync(client, ticker, refreshed, cutoff, ct);
+            }
+
+            // Delisted, unknown, or coverage-less symbols (and Yahoo's intermittent anti-scrape 404s)
+            // are expected for a broad universe — skip quietly rather than logging a warning per ticker.
+            if (response.StatusCode is System.Net.HttpStatusCode.NotFound or System.Net.HttpStatusCode.TooManyRequests)
+            {
+                logger.LogDebug("Yahoo analyst-actions returned {Status} for {Ticker} — no data", (int)response.StatusCode, ticker);
+                return [];
             }
 
             response.EnsureSuccessStatusCode();

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/NewsSourceFailureCounterTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/NewsSourceFailureCounterTests.cs
@@ -16,12 +16,40 @@ public sealed class NewsSourceFailureCounterTests
     {
         var source = new NewsSource();
 
-        NewsSourceHealthTracker.RecordFailure(source, "timeout").Should().BeFalse();
+        NewsSourceHealthTracker.RecordFailure(source, "timeout").Should().Be(NewsSourceFailureOutcome.None);
         source.ConsecutiveFailures.Should().Be(1);
 
-        NewsSourceHealthTracker.RecordFailure(source, "timeout again").Should().BeTrue();
+        NewsSourceHealthTracker.RecordFailure(source, "timeout again").Should().Be(NewsSourceFailureOutcome.Alert);
         source.ConsecutiveFailures.Should().Be(2);
         source.LastFailureReason.Should().Be("timeout again");
+    }
+
+    [Fact]
+    public void Alert_fires_only_once_not_every_subsequent_failure()
+    {
+        var source = new NewsSource();
+
+        NewsSourceHealthTracker.RecordFailure(source, "1");
+        NewsSourceHealthTracker.RecordFailure(source, "2").Should().Be(NewsSourceFailureOutcome.Alert);
+        // Failures past the alert threshold must not re-alert every run (this was the 600+ alert bug).
+        NewsSourceHealthTracker.RecordFailure(source, "3").Should().Be(NewsSourceFailureOutcome.None);
+        NewsSourceHealthTracker.RecordFailure(source, "4").Should().Be(NewsSourceFailureOutcome.None);
+    }
+
+    [Fact]
+    public void Sustained_failures_auto_disable_the_source_once()
+    {
+        var source = new NewsSource();
+
+        NewsSourceFailureOutcome? disableOutcome = null;
+        for (var i = 0; i < NewsSourceHealthTracker.DisableThreshold; i++)
+        {
+            disableOutcome = NewsSourceHealthTracker.RecordFailure(source, $"fail {i}");
+        }
+
+        disableOutcome.Should().Be(NewsSourceFailureOutcome.Disable);
+        source.Enabled.Should().BeFalse("a source that fails to the disable threshold is retired");
+        source.ConsecutiveFailures.Should().Be(NewsSourceHealthTracker.DisableThreshold);
     }
 
     [Fact]
@@ -41,8 +69,8 @@ public sealed class NewsSourceFailureCounterTests
     {
         var source = new NewsSource();
 
-        NewsSourceHealthTracker.RecordFailure(source, "one").Should().BeFalse();
+        NewsSourceHealthTracker.RecordFailure(source, "one").Should().Be(NewsSourceFailureOutcome.None);
         NewsSourceHealthTracker.RecordSuccess(source);
-        NewsSourceHealthTracker.RecordFailure(source, "two").Should().BeFalse("the counter reset on success");
+        NewsSourceHealthTracker.RecordFailure(source, "two").Should().Be(NewsSourceFailureOutcome.None, "the counter reset on success");
     }
 }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/TrendForcePageContractTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/TrendForcePageContractTests.cs
@@ -66,6 +66,59 @@ public sealed class TrendForcePageContractTests
         articles[1].Url.Should().Be("https://www.trendforce.com/presscenter/news/20260720-99999.html");
     }
 
+    // Current live markup (2026-08): the press list restyled from .list-item to
+    // .advs-box.niche-box-post, with the date rendered inside <p class="bd-month">.
+    private const string AdvsBoxFixture = """
+    <html><body>
+      <div class="press-list-wrapper">
+        <div class="advs-box advs-box-top-icon-img niche-box-post boxed-inverse">
+          <div class="block-infos"><div class="block-data"><p class="bd-day"></p><p class="bd-month">4 August 2026</p></div></div>
+          <a class="img-box" href="/presscenter/news/20260804-13166.html"><img src="/images/news-01.jpg" alt=""></a>
+          <div class="advs-box-content">
+            <h2><a class="text-m text-ellipsis-2" href="/presscenter/news/20260804-13166.html"><strong>DRAM Supply to Remain Tight in 2027, Prompting NVIDIA to Lower HBM Configurations</strong></a></h2>
+            <p class="text-m">Memory supply stays constrained through 2027 as HBM absorbs wafer capacity.</p>
+          </div>
+        </div>
+      </div>
+    </body></html>
+    """;
+
+    // Classes we've never seen, but the /presscenter/news/<date>-<id>.html permalink is unchanged. The
+    // parser must recover the article from the href pattern rather than throwing on class drift.
+    private const string DriftedClassesFixture = """
+    <html><body>
+      <section class="brand-new-layout-v3">
+        <div class="whatever-card">
+          <h3 class="totally-renamed"><a href="/presscenter/news/20260801-10001.html">Server DRAM contract prices climb 15% QoQ</a></h3>
+          <span class="posted">1 August 2026</span>
+        </div>
+      </section>
+      <nav><a href="/presscenter/news/Semiconductors">Semiconductors</a></nav>
+    </body></html>
+    """;
+
+    [Fact]
+    public async Task Parse_extracts_current_advs_box_shape()
+    {
+        var articles = await TrendForcePageSource.ParseAsync(AdvsBoxFixture, PageUrl);
+
+        articles.Should().ContainSingle("the hero/list duplicate for one permalink must collapse by URL");
+        articles[0].Title.Should().Contain("DRAM Supply to Remain Tight");
+        articles[0].Url.Should().Be("https://www.trendforce.com/presscenter/news/20260804-13166.html");
+        articles[0].PublishedAt.Should().Be(DateTimeOffset.Parse("4 August 2026"));
+        articles[0].Summary.Should().Contain("HBM absorbs wafer capacity");
+    }
+
+    [Fact]
+    public async Task Parse_recovers_articles_from_href_pattern_when_classes_drift()
+    {
+        var articles = await TrendForcePageSource.ParseAsync(DriftedClassesFixture, PageUrl);
+
+        articles.Should().ContainSingle("only the permalink matches — the category nav link must be ignored");
+        articles[0].Title.Should().Contain("Server DRAM contract prices");
+        articles[0].Url.Should().Be("https://www.trendforce.com/presscenter/news/20260801-10001.html");
+    }
+
     [Fact]
     public async Task Parse_throws_when_article_list_is_missing()
     {

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/API/WebhookHandlerTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/API/WebhookHandlerTests.cs
@@ -88,7 +88,9 @@ public class WebhookHandlerTests
         syncJobRepo.Setup(r => r.HasRunningJobAsync(accountId, default)).ReturnsAsync(true);
 
         var coordinator = new Modules.BankSync.Application.Services.TransactionSyncCoordinator(
-            syncJobRepo.Object, syncService.Object);
+            syncJobRepo.Object,
+            new Mock<Modules.BankSync.Domain.Repositories.IBankAccountRepository>().Object,
+            syncService.Object);
 
         var result = await coordinator.TriggerWebhookSyncAsync(accountId);
 
@@ -111,7 +113,9 @@ public class WebhookHandlerTests
                    .ReturnsAsync(new Modules.BankSync.Application.Services.SyncResult(true, 5, 3, null, null));
 
         var coordinator = new Modules.BankSync.Application.Services.TransactionSyncCoordinator(
-            syncJobRepo.Object, syncService.Object);
+            syncJobRepo.Object,
+            new Mock<Modules.BankSync.Domain.Repositories.IBankAccountRepository>().Object,
+            syncService.Object);
 
         var result = await coordinator.TriggerWebhookSyncAsync(accountId);
 
@@ -131,7 +135,9 @@ public class WebhookHandlerTests
                    .ReturnsAsync(new Modules.BankSync.Application.Services.SyncResult(true, 10, 10, null, null));
 
         var coordinator = new Modules.BankSync.Application.Services.TransactionSyncCoordinator(
-            syncJobRepo.Object, syncService.Object);
+            syncJobRepo.Object,
+            new Mock<Modules.BankSync.Domain.Repositories.IBankAccountRepository>().Object,
+            syncService.Object);
 
         var result = await coordinator.TriggerManualSyncAsync(accountId);
 

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
@@ -335,12 +335,39 @@ public class ScheduledSyncServiceTests
 
         syncJobRepo.Setup(r => r.HasRunningJobAsync(AccountId, default)).ReturnsAsync(true);
 
-        var coordinator = new TransactionSyncCoordinator(syncJobRepo.Object, syncService.Object);
+        var coordinator = new TransactionSyncCoordinator(
+            syncJobRepo.Object, new Mock<IBankAccountRepository>().Object, syncService.Object);
 
         var result = await coordinator.TriggerScheduledSyncAsync(AccountId);
 
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be("SYNC_IN_PROGRESS");
         syncService.Verify(s => s.PerformFullSyncAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // A consent-expired account (reauth_required) must be skipped by the recurring scheduler so it stops
+    // failing every cycle — the loop that logged errorCode=UNKNOWN ~48x/day for an expired TrueLayer consent.
+    [Fact]
+    public async Task TriggerScheduledSyncAsync_ReauthRequiredAccount_SkipsWithoutSyncing()
+    {
+        var syncJobRepo = new Mock<ISyncJobRepository>();
+        var accountRepo = new Mock<IBankAccountRepository>();
+        var syncService = new Mock<IScheduledSyncService>();
+
+        syncJobRepo.Setup(r => r.HasRunningJobAsync(AccountId, default)).ReturnsAsync(false);
+        var account = new BankAccount { Provider = "truelayer" };
+        account.BeginSync();
+        account.MarkReauthRequired();
+        accountRepo.Setup(r => r.GetByIdAsync(AccountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+
+        var coordinator = new TransactionSyncCoordinator(
+            syncJobRepo.Object, accountRepo.Object, syncService.Object);
+
+        var result = await coordinator.TriggerScheduledSyncAsync(AccountId);
+
+        result.ErrorCode.Should().Be("ITEM_LOGIN_REQUIRED");
+        syncService.Verify(
+            s => s.PerformFullSyncAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/specs/023-observability-stack/spec.md
+++ b/specs/023-observability-stack/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `023-observability-stack`
 **Created**: 2026-07-09
-**Status**: Roadmap — spec only, not yet planned or implemented
+**Status**: Planning — alerting slice pulled into v1 (2026-08-05); prerequisites added from live-log investigation
 **Input**: User description: "Observability stack: OpenTelemetry metrics in the ASP.NET Core API exposed via /metrics, Prometheus + Grafana + Loki containers on the VPS, Serilog shipping to Loki, dashboards for sync jobs, HTTP latency/errors, Hangfire job health"
 
 ## User Scenarios & Testing *(mandatory)*
@@ -50,6 +50,22 @@ As the operator, I can see failure trends of scheduled jobs over time (which job
 
 1. **Given** a job has failed 3 times this week, **When** the operator opens the job-health dashboard, **Then** the failure count and duration trend per job over the selected period is shown.
 
+---
+
+### User Story 4 - Get told when a job keeps failing (Priority: P2)
+
+As the operator, when a scheduled background job fails repeatedly (N consecutive failures), I receive a push notification through my existing Telegram channel — so I learn about an outage the moment it becomes a pattern, instead of discovering it days later by reading logs.
+
+**Why this priority**: The live-log investigation (2026-08-05) found a news-source ingestion job that had failed **636 consecutive times over ~13 days** with no one aware, and an expired-consent bank sync retrying ~48×/day indefinitely. Dashboards only help when the operator thinks to look; a pushed alert closes the "silent outage" gap that visibility alone does not. A minimal alerting slice reuses the already-deployed Companion notification dispatch (Telegram), so cost is low.
+
+**Independent Test**: Force a job to fail N consecutive times; a single Telegram alert fires (not one per failure), naming the job and the consecutive-failure count. A subsequent success clears the state so the next failure re-alerts.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scheduled job has failed N consecutive times, **When** the Nth failure is recorded, **Then** exactly one alert is dispatched to the operator's Telegram channel identifying the job, failure count, and last error summary.
+2. **Given** an alert has already fired for a job, **When** the job continues to fail, **Then** no duplicate alert is sent until the job first succeeds again (de-duplicated / cooldown).
+3. **Given** the alerting path (Telegram/dispatch) is itself unavailable, **When** an alert cannot be sent, **Then** request handling and other jobs are unaffected (fire-and-forget).
+
 ### Edge Cases
 
 - Metrics/log infrastructure itself goes down: application must keep serving user traffic unaffected (fire-and-forget shipping, no hard dependency).
@@ -69,6 +85,9 @@ As the operator, I can see failure trends of scheduled jobs over time (which job
 - **FR-006**: The metrics endpoint MUST NOT be reachable from the public internet without authorization (internal network / scrape-only access).
 - **FR-007**: Metric labels MUST NOT contain personal or financial data; label cardinality MUST be bounded by design (route templates, not raw URLs).
 - **FR-008**: The observability stack MUST run on the existing single production host alongside the app and MUST be part of the same deployment process.
+- **FR-009**: The system MUST alert the operator (via the existing Companion Telegram dispatch path) when a scheduled job reaches N consecutive failures; alerts MUST be de-duplicated (at most one per failure streak) and MUST clear on the next success. Alert dispatch failures MUST NOT affect request handling or job execution.
+- **FR-010**: Background job state (history, outcomes, failed-job records) MUST survive process restarts, so job-health metrics and failure trends (FR-002, US3) reflect real history rather than only the current process lifetime. *(Today Hangfire uses in-memory storage; this is a prerequisite for durable job observability.)*
+- **FR-011**: Application log output MUST be filtered so that framework/ORM diagnostic noise (e.g. per-query SQL at Information level) does not drown application-level events in the log store; log levels MUST be configurable without a code change.
 
 ### Key Entities
 
@@ -96,6 +115,6 @@ As the operator, I can see failure trends of scheduled jobs over time (which job
 ## Notes
 
 - [DECISION] Placement: observability components deploy on the same host as the app via the existing compose/deploy pipeline — no separate infrastructure host.
-- [OUT OF SCOPE] Alert notifications (push/Telegram/email on threshold breach) — deferred to a future feature once baselines are known.
+- [DECISION 2026-08-05] A **minimal** alerting slice is now IN SCOPE (US4 / FR-009): consecutive-failure alerts for scheduled jobs, routed through the existing Companion Telegram dispatch. Rich metric-threshold alert rules in Grafana remain deferred until baselines exist.
 - [OUT OF SCOPE] Frontend (browser) telemetry and distributed tracing — metrics + logs first; tracing becomes relevant when services split.
 - [DEFERRED] Uptime probing from outside the host (external synthetic checks).

--- a/specs/037-structured-data-sources/spec.md
+++ b/specs/037-structured-data-sources/spec.md
@@ -1,0 +1,54 @@
+# Feature Specification: Structured Data Sources (retire brittle scraping)
+
+**Feature Branch**: `037-structured-data-sources`
+**Created**: 2026-08-05
+**Status**: Backlog — spec only, not yet planned
+**Origin**: Reliability session 2026-08-05. Reading VPS logs surfaced that the two most-broken data feeds are both *reverse-engineered scraping*, not real integrations: Yahoo's unofficial `quoteSummary` endpoints (crumb/cookie dance, intermittent 404s) for analyst actions, and HTML scraping of TrendForce. Scraping breaks silently and repeatedly; a stable contract does not.
+
+## Problem
+
+The research/companion data layer pulls several signals by scraping, because when it was built the fastest path was "parse what the website returns." Two classes of fragility resulted:
+
+1. **Reverse-engineered private APIs** — Yahoo `quoteSummary/upgradeDowngradeHistory` (analyst actions) and `quoteSummary` valuation modules. These are undocumented, unversioned, rate-limited, and actively anti-scraped (crumb+cookie, UA sniffing, inconsistent 404/401/429). They work until Yahoo tweaks anything.
+2. **HTML page scraping** — MarketBeat ratings table, TrendForce press center. Coupled to page markup that vendors restyle without notice (TrendForce drifted twice; the parser was hardened to key on URL permalinks, but it is still scraping).
+
+The 2026-08-05 fixes hardened these and added auto-disable + alerting so failures are *loud and bounded*. This spec is the durable follow-up: **move the highest-value signals onto structured contracts** so they stop breaking in the first place.
+
+## Proposed direction
+
+Prefer, in order: (1) an official/documented data API with a versioned JSON contract; (2) an RSS/Atom feed; (3) embedded structured data (JSON-LD / news sitemap); (4) DOM scraping only where none of the above exist.
+
+Candidate providers with **free tiers** offering structured, documented endpoints:
+
+| Signal | Current (scraped) | Structured candidate(s) |
+|---|---|---|
+| Analyst upgrades/downgrades & price targets | Yahoo `quoteSummary` + MarketBeat HTML | Finnhub (`/stock/upgrade-downgrade`), Financial Modeling Prep (`/upgrades-downgrades`, `/price-target`) |
+| Valuation multiples / fundamentals | Yahoo `quoteSummary` modules | FMP (`/ratios`, `/key-metrics`), Alpha Vantage (`OVERVIEW`) |
+| Company/market news | RSS (already) + scraping for some | Keep RSS; Finnhub `/company-news` / `/news` where an RSS feed is absent |
+
+TrendForce specifically has **no API, no RSS, no usable structured data** — it stays scraped (hardened) or gets dropped; it is out of scope for migration.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Analyst-actions ingestion MUST be able to source from a documented structured API behind the existing `IAnalystActionsSource` abstraction, with the current Yahoo/MarketBeat scrapers demoted to fallback (or removed) once parity is confirmed.
+- **FR-002**: Provider API keys MUST be configuration (env/secret), never hard-coded; the layer MUST degrade gracefully (and log at Debug, not Error) when no key is configured, preserving today's key-less behavior.
+- **FR-003**: A structured source MUST NOT introduce per-ticker Warning/Error log spam for expected empty results (no coverage / delisted) — parity with the 2026-08-05 log-hygiene fix.
+- **FR-004**: Migration MUST be incremental and reversible per signal — swap analyst-actions first, validate against a week of real data (coverage + freshness vs the scraped baseline), then decide on valuation/news.
+- **FR-005**: Free-tier rate limits MUST be respected (documented budget per provider); the universe sweep MUST fit within them or degrade deterministically.
+
+## Success Criteria
+
+- **SC-001**: Analyst-actions failures attributable to source drift/anti-scraping drop to ~zero over a 30-day window (baseline: the 2026-08-05 Yahoo 404 warnings).
+- **SC-002**: Coverage (tickers with ≥1 action/quarter) is ≥ the scraped baseline for the same universe.
+- **SC-003**: Adding a new provider is a new `IAnalystActionsSource` implementation + config, no changes to ingestion/scoring.
+
+## Assumptions & tension to resolve
+
+- **"Build in Finance Sentry over paid APIs"** (Denys's standing preference) still holds: the point is not to *pay* for data but to consume a **stable contract** instead of scraping. Free tiers of Finnhub/FMP/Alpha Vantage give exactly that. Where a free tier is insufficient, the fallback is the hardened scraper, not a paid plan — a paid plan is an explicit, separate decision.
+- The number-crunching/aggregation stays in FS; only the *upstream fetch* changes from "scrape a page" to "call a documented endpoint."
+
+## Out of scope
+
+- TrendForce (no structured option — stays hardened-scraped or dropped).
+- Paid data tiers (separate decision if free tiers prove insufficient).
+- Any change to how signals are stored, scored, or surfaced downstream.

--- a/specs/ROADMAP.md
+++ b/specs/ROADMAP.md
@@ -14,7 +14,8 @@
 | `033-analytics-query-tool` | Feature | — | **Planned — ready to implement.** Guarded read-only query tool (escape-hatch for the long tail; relieves tool sprawl) |
 | `034-research-rag` | Feature | — | Spec + **research done**; ready to plan/implement. Semantic search over the text corpus (news/filings/notes); complements 033 (prose vs numbers) |
 | `032-agent-as-code` | Architecture | 031 (proves the pattern) | Draft — agent definition in the repo, CI-deployed to the runtime |
-| `023-observability-stack` | Platform | — | Don't orchestrate what you can't observe — do this rung first |
+| `023-observability-stack` | Platform | — | Don't orchestrate what you can't observe — do this rung first. **Alerting slice pulled into v1 (2026-08-05)** after a 13-day silent cron outage |
+| `037-structured-data-sources` | Platform | — | Retire brittle scraping (Yahoo `quoteSummary`, MarketBeat) → free-tier structured APIs (Finnhub/FMP). Analyst-actions first. Origin: 2026-08-05 reliability session |
 | `024-data-retention` | Platform | 023 | Retention policies + verified off-host backups |
 | `025-edge-gateway` | Platform | — | Single reverse-proxy entrypoint, TLS, rate limits |
 | `026-event-bus-outbox` | Platform | 023 | In-monolith broker + transactional outbox (031 is a focused precursor) |


### PR DESCRIPTION
## Why
Investigating FS reliability, I read 72h of VPS container logs (no persistent error store exists yet) and found **three background jobs failing on a loop with no alert** — one silently for ~13 days:
- **TrueLayer** sync for one account ~48×/day: `invalid_grant / consent expired or revoked`, logged as `errorCode=UNKNOWN`.
- **TrendForce** news source: **636 consecutive** parse failures (markup drifted).
- **Yahoo analyst-actions**: ~20 `Warning`/day (symbol format + Yahoo 404s).

## What
- **TrueLayer**: map expired/revoked consent → `ITEM_LOGIN_REQUIRED` → account flagged `reauth_required`; the recurring scheduler now **skips reauth-required accounts** instead of re-hammering the token endpoint every 30 min. Manual/webhook/reconnect unaffected. Self-heals the stuck account after one more cycle.
- **TrendForce**: page restyled again (`list-item` → `advs-box.niche-box-post`) — **not** a SPA. Rewrote the parser to key on the **stable permalink pattern** `/presscenter/news/<date>-<id>.html` (class selectors kept as a fast path). Validated against the live page; added current-shape + drift-resilience tests.
- **Yahoo**: normalize symbols (`BRK.B`→`BRK-B`); treat per-ticker `404/429` as "no data" at `Debug` not a `Warning` each.
- **News sources**: `RecordFailure` returns an outcome — alert fires **once** at threshold (was every run) and a source failing to the disable threshold is **auto-retired**.
- **spec 023 (observability)**: pulled a minimal consecutive-failure **alerting** slice into v1 (US4/FR-009) + durable-job-state & log-hygiene prerequisites.

## Verification
- Root causes confirmed by probing live endpoints from the VPS; parser selectors validated against the live TrendForce page via headless browser before writing them.
- `dotnet build` (sdk:10.0): **0 warnings, 0 errors**. Affected tests green (Research 10, Tests.Unit 16), incl. new tests for advs-box parse, class-drift recovery, alert-once, auto-disable, reauth-skip.
- Backend-only; the `reauth_required` reconnect UX already exists on the frontend.

## Backlog (not here)
Migrate analyst-actions off reverse-engineered Yahoo endpoints to a free structured API (Finnhub/FMP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)