### PR TITLE
fix(truelayer): persist rotated refresh token before sync + serialize per connection

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.BankSync.Application.Services;
 
+using System.Collections.Concurrent;
 using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Infrastructure.Encryption;
 using FinanceSentry.Infrastructure.Logging;
@@ -309,33 +310,29 @@ public class ScheduledSyncService(
         return new SyncResult(true, candidates.Count, entities.Count, null, null);
     }
 
+    // Serializes the refresh-token exchange per TrueLayer connection. A connection can back several
+    // accounts, each with its own scheduled sync job firing on the same cron; without this gate two
+    // jobs could refresh the shared, rotating refresh_token concurrently — one wins, the other gets
+    // invalid_grant and the rotated token is lost, bricking the connection.
+    private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> TrueLayerRefreshLocks = new();
+
     private async Task<SyncResult> SyncTrueLayerAsync(
         Domain.BankAccount account, SyncJob job, DateTime startedAt, CancellationToken ct)
     {
         if (account.TrueLayerConnectionId is null)
             throw new InvalidOperationException($"TrueLayer account {account.Id} has no connection id.");
 
-        var connection = await _truelayerConnections.GetByIdAsync(account.TrueLayerConnectionId.Value, ct)
-            ?? throw new InvalidOperationException($"TrueLayer connection {account.TrueLayerConnectionId} not found.");
+        var connectionId = account.TrueLayerConnectionId.Value;
+        var accessToken = await AcquireTrueLayerAccessTokenAsync(connectionId, job, account.Id, ct);
 
-        var refreshToken = _encryption.Decrypt(
-            connection.EncryptedRefreshToken, connection.Iv, connection.AuthTag, connection.KeyVersion);
-        _logger.CredentialAccessed(job.CorrelationId ?? job.Id.ToString(), account.Id);
-
-        var tokenSet = await _truelayerClient.RefreshAccessTokenAsync(refreshToken, ct);
-
-        // TrueLayer rotates refresh tokens — persist the new one.
-        if (!string.IsNullOrEmpty(tokenSet.RefreshToken) && tokenSet.RefreshToken != refreshToken)
-        {
-            var encrypted = _encryption.Encrypt(tokenSet.RefreshToken);
-            connection.SetRefreshToken(encrypted.Ciphertext, encrypted.Iv, encrypted.AuthTag);
-        }
+        var connection = await _truelayerConnections.GetByIdAsync(connectionId, ct)
+            ?? throw new InvalidOperationException($"TrueLayer connection {connectionId} not found.");
 
         var provider = _providerFactory.Resolve("truelayer");
         var since = connection.LastSyncAt;
 
         var (candidates, _) = await provider.SyncTransactionsAsync(
-            tokenSet.AccessToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
+            accessToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
 
         var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
 
@@ -348,7 +345,7 @@ public class ScheduledSyncService(
         decimal latestBalance = 0m;
         try
         {
-            var bal = await _truelayerClient.GetBalanceAsync(tokenSet.AccessToken, account.ExternalAccountId, ct);
+            var bal = await _truelayerClient.GetBalanceAsync(accessToken, account.ExternalAccountId, ct);
             if (bal is not null)
                 latestBalance = bal.Current;
         }
@@ -372,6 +369,45 @@ public class ScheduledSyncService(
             candidates.Count, entities.Count, durationMs);
 
         return new SyncResult(true, candidates.Count, entities.Count, null, null);
+    }
+
+    /// <summary>
+    /// Exchanges a connection's rotating refresh_token for a fresh access_token, serialized per
+    /// connection. The rotated refresh_token is persisted <em>immediately</em> — before any transaction
+    /// fetch — so a later sync failure cannot strand a consumed token and permanently brick the
+    /// connection (the invalid_grant root cause). The connection is re-read inside the lock so parallel
+    /// per-account jobs always refresh from the latest persisted token.
+    /// </summary>
+    private async Task<string> AcquireTrueLayerAccessTokenAsync(
+        Guid connectionId, SyncJob job, Guid accountId, CancellationToken ct)
+    {
+        var gate = TrueLayerRefreshLocks.GetOrAdd(connectionId, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            var connection = await _truelayerConnections.GetByIdAsync(connectionId, ct)
+                ?? throw new InvalidOperationException($"TrueLayer connection {connectionId} not found.");
+
+            var refreshToken = _encryption.Decrypt(
+                connection.EncryptedRefreshToken, connection.Iv, connection.AuthTag, connection.KeyVersion);
+            _logger.CredentialAccessed(job.CorrelationId ?? job.Id.ToString(), accountId);
+
+            var tokenSet = await _truelayerClient.RefreshAccessTokenAsync(refreshToken, ct);
+
+            // Persist the rotated refresh_token now — not after the sync — so nothing downstream can lose it.
+            if (!string.IsNullOrEmpty(tokenSet.RefreshToken) && tokenSet.RefreshToken != refreshToken)
+            {
+                var encrypted = _encryption.Encrypt(tokenSet.RefreshToken);
+                connection.SetRefreshToken(encrypted.Ciphertext, encrypted.Iv, encrypted.AuthTag);
+                await _truelayerConnections.UpdateAsync(connection, ct);
+            }
+
+            return tokenSet.AccessToken;
+        }
+        finally
+        {
+            gate.Release();
+        }
     }
 
     private static string? ExtractErrorCode(string message, string provider)

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
@@ -370,4 +370,73 @@ public class ScheduledSyncServiceTests
             s => s.PerformFullSyncAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // Regression: TrueLayer rotates the refresh_token on every refresh. The new token MUST be persisted
+    // before the transaction fetch, so a mid-sync failure can't strand a consumed token and brick the
+    // connection (the invalid_grant root cause). Here the provider sync throws — the rotated token must
+    // still have been saved.
+    [Fact]
+    public async Task SyncTrueLayer_PersistsRotatedRefreshToken_EvenWhenSyncFails()
+    {
+        var accountRepo = new Mock<IBankAccountRepository>();
+        var txRepo = new Mock<ITransactionRepository>();
+        var jobRepo = new Mock<ISyncJobRepository>();
+        var credRepo = new Mock<IEncryptedCredentialRepository>();
+        var encryption = new Mock<ICredentialEncryptionService>();
+        var plaid = new Mock<IPlaidAdapterInterface>();
+        var dedup = new Mock<ITransactionDeduplicationService>();
+        var logger = new Mock<IBankSyncLogger>();
+        var providerFactory = new Mock<IBankProviderFactory>();
+        var monobankCreds = new Mock<IMonobankCredentialRepository>();
+        var truelayerConnections = new Mock<ITrueLayerConnectionRepository>();
+        var truelayerClient = new Mock<FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer.ITrueLayerClient>();
+        var balanceCache = new FinanceSentry.Modules.BankSync.Infrastructure.Monobank.MonobankBalanceCache();
+        var alertGen = new Mock<FinanceSentry.Core.Interfaces.IAlertGeneratorService>();
+        var userPrefs = new Mock<FinanceSentry.Core.Interfaces.IUserAlertPreferencesReader>();
+
+        var connection = new TrueLayerConnection(UserId, "ob-natwest", "NatWest", "ref-1");
+        connection.SetRefreshToken([1], [2], [3]);
+        var account = new BankAccount
+        {
+            UserId = UserId,
+            Provider = "truelayer",
+            ExternalAccountId = "tl-acc-1",
+            TrueLayerConnectionId = connection.Id,
+            SyncStatus = "active",
+        };
+
+        accountRepo.Setup(r => r.GetByIdAsync(account.Id, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        truelayerConnections.Setup(r => r.GetByIdAsync(connection.Id, It.IsAny<CancellationToken>())).ReturnsAsync(connection);
+        encryption.Setup(e => e.Decrypt(It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<int>()))
+                  .Returns("old-refresh");
+        encryption.Setup(e => e.Encrypt("new-refresh")).Returns(new EncryptionResult([9], [8], [7], 1));
+        truelayerClient
+            .Setup(c => c.RefreshAccessTokenAsync("old-refresh", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer.TrueLayerTokenSet("AT", "new-refresh", 3600));
+
+        var provider = new Mock<IBankProvider>();
+        provider
+            .Setup(p => p.SyncTransactionsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("mid-sync failure"));
+        providerFactory.Setup(f => f.Resolve("truelayer")).Returns(provider.Object);
+
+        var sut = new ScheduledSyncService(
+            accountRepo.Object, txRepo.Object, jobRepo.Object, credRepo.Object,
+            encryption.Object, plaid.Object, dedup.Object, logger.Object,
+            providerFactory.Object, monobankCreds.Object,
+            truelayerConnections.Object, truelayerClient.Object,
+            balanceCache, alertGen.Object, userPrefs.Object);
+
+        var result = await sut.PerformFullSyncAsync(account.Id);
+
+        result.Success.Should().BeFalse("the transaction fetch threw");
+        truelayerConnections.Verify(
+            r => r.UpdateAsync(
+                It.Is<TrueLayerConnection>(c => c.EncryptedRefreshToken.Length == 1 && c.EncryptedRefreshToken[0] == 9),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "the rotated refresh token must be persisted before the failing transaction fetch");
+    }
 }


### PR DESCRIPTION
## Why
Follow-up to #342. The bricked TrueLayer account wasn't the 90-day expiry — our records show consent valid to **Sep 28**, yet TrueLayer rejected it with `invalid_grant`. Root cause: **two bugs that break a connection *before* consent expires.**

## Bugs fixed
1. **Persist-too-late (the bricker).** TrueLayer rotates the `refresh_token` on every refresh. We saved the new token only *after* the transaction fetch + reconcile. Any failure in between = old token consumed on TrueLayer's side, new token never saved → **every later cycle fails `invalid_grant`**. Fits the live account exactly (worked until Jun 30, then died). **Fix:** persist the rotated token immediately after the refresh, before any sync work.
2. **Per-connection race.** One connection can back multiple accounts (one of ours has 5), each with its own 30-min job on the same cron; with Hangfire `WorkerCount=2` two can refresh the shared rotating token at once → one wins, the other gets `invalid_grant`. **Fix:** a per-connection lock around decrypt→refresh→persist, re-reading the connection inside the lock so it always uses the freshest token.

## Test
New regression test: the rotated token is persisted **even when the subsequent transaction fetch throws**. `dotnet build` 0 warnings; ScheduledSyncService suite green (8 tests).

## Not in scope
The ~90-day PSD2 consent expiry is regulatory and still needs user re-consent — this stops the *premature* breaks. Proactive pre-expiry reminder + one-tap reconnect (email + Telegram) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)