### PR TITLE
fix(truelayer): self-healing reconnect + stale-sync reaper + dedup crash fix

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/BeginTrueLayerConnectCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/BeginTrueLayerConnectCommand.cs
@@ -24,15 +24,6 @@ public class BeginTrueLayerConnectCommandHandler(
     public async Task<BeginTrueLayerConnectResult> Handle(
         BeginTrueLayerConnectCommand request, CancellationToken cancellationToken)
     {
-        var existing = await connections.GetByUserAndProviderAsync(
-            request.UserId, request.ProviderId, cancellationToken);
-
-        if (existing != null && existing.Status == "LINKED")
-            throw new TrueLayerException(
-                "TRUELAYER_PROVIDER_ALREADY_CONNECTED",
-                "This bank is already connected. Disconnect it before reconnecting.",
-                409);
-
         var callbackPath = configuration["TrueLayer:CallbackPath"]
             ?? "/api/v1/accounts/truelayer/callback";
         var publicApiBase = configuration["PublicApiBaseUrl"]
@@ -43,16 +34,30 @@ public class BeginTrueLayerConnectCommandHandler(
 
         var link = client.BuildAuthLink(request.ProviderId, reference, redirectUri);
 
+        // A connection for this provider may already exist — either healthy (accidental
+        // re-connect) or in a reauth_required state after its refresh token died. In both cases
+        // we reuse the existing row rather than blocking or deleting it: keeping the same
+        // connection id means the linked accounts stay attached and get healed in place on
+        // finalize, and leaving the old refresh token intact means an abandoned consent does not
+        // sever a still-working connection. Only when no connection exists do we create a new one.
+        var existing = await connections.GetByUserAndProviderAsync(
+            request.UserId, request.ProviderId, cancellationToken);
+
         if (existing != null)
-            await connections.DeleteAsync(existing.Id, cancellationToken);
+        {
+            existing.BeginReauth(reference);
+            await connections.UpdateAsync(existing, cancellationToken);
+        }
+        else
+        {
+            var entity = new TrueLayerConnection(
+                userId: request.UserId,
+                providerId: request.ProviderId,
+                providerDisplayName: request.ProviderName ?? request.ProviderId,
+                reference: reference);
 
-        var entity = new TrueLayerConnection(
-            userId: request.UserId,
-            providerId: request.ProviderId,
-            providerDisplayName: request.ProviderName ?? request.ProviderId,
-            reference: reference);
-
-        await connections.AddAsync(entity, cancellationToken);
+            await connections.AddAsync(entity, cancellationToken);
+        }
 
         return new BeginTrueLayerConnectResult(Link: link, Reference: reference);
     }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/FinalizeTrueLayerConnectCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/FinalizeTrueLayerConnectCommand.cs
@@ -59,10 +59,6 @@ public class FinalizeTrueLayerConnectCommandHandler(
 
         foreach (var pa in providerAccounts)
         {
-            var existing = await accounts.GetByPlaidItemIdAsync(pa.AccountId, cancellationToken);
-            if (existing != null)
-                continue;
-
             decimal? currentBalance = null;
             try
             {
@@ -72,6 +68,18 @@ public class FinalizeTrueLayerConnectCommandHandler(
             catch (TrueLayerException)
             {
                 // Best-effort: skip balance, account is still usable.
+            }
+
+            var existing = await accounts.GetByPlaidItemIdAsync(pa.AccountId, cancellationToken);
+            if (existing != null)
+            {
+                // Reconnect/reauth: heal the existing account in place instead of skipping it.
+                // Re-point it at the freshly linked connection and clear reauth_required so the
+                // scheduler resumes syncing. A follow-up sync is enqueued below to backfill data.
+                existing.MarkReconnected(connection.Id, currentBalance ?? existing.CurrentBalance ?? 0m);
+                await accounts.UpdateAsync(existing, cancellationToken);
+                createdIds.Add(existing.Id);
+                continue;
             }
 
             var account = new BankAccount(

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -331,13 +331,31 @@ public class ScheduledSyncService(
         var provider = _providerFactory.Resolve("truelayer");
         var since = connection.LastSyncAt;
 
-        var (candidates, _) = await provider.SyncTransactionsAsync(
-            accessToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
+        IReadOnlyList<Domain.Transaction> entities;
+        int candidateCount;
+        try
+        {
+            var (candidates, _) = await provider.SyncTransactionsAsync(
+                accessToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
 
-        var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
+            entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
+            candidateCount = candidates.Count;
 
-        connection.LastSyncAt = DateTime.UtcNow;
-        await _truelayerConnections.UpdateAsync(connection, ct);
+            connection.LastSyncAt = DateTime.UtcNow;
+            await _truelayerConnections.UpdateAsync(connection, ct);
+        }
+        catch (Infrastructure.TrueLayer.TrueLayerException ex)
+            when (ex.StatusCode == 403 && ex.Message.Contains("access_denied", StringComparison.OrdinalIgnoreCase))
+        {
+            // Strong Customer Authentication wall: some banks (notably AIB) deny background
+            // transaction access made with a refreshed token — only a user-present flow can pull
+            // history. Balance access still works, so degrade to a balance-only sync instead of
+            // hard-failing, which would otherwise flap the account to "failed" every cycle.
+            // LastSyncAt is deliberately not advanced so a later user-present sync can still
+            // backfill transactions from the same point.
+            entities = [];
+            candidateCount = 0;
+        }
 
         // Refresh the live balance — TrueLayer balances can move independently of
         // dedup'd transactions (e.g. an overdraft on AIB), so re-query rather than
@@ -361,14 +379,14 @@ public class ScheduledSyncService(
             ? entities.Max(t => t.PostedDate ?? t.TransactionDate)
             : (DateTime?)null;
 
-        job.MarkSuccess(candidates.Count, entities.Count, lastTxDate);
+        job.MarkSuccess(candidateCount, entities.Count, lastTxDate);
         await _syncJobs.UpdateAsync(job, ct);
 
         var durationMs = (long)(DateTime.UtcNow - startedAt).TotalMilliseconds;
         _logger.SyncCompleted(job.CorrelationId ?? job.Id.ToString(), account.Id,
-            candidates.Count, entities.Count, durationMs);
+            candidateCount, entities.Count, durationMs);
 
-        return new SyncResult(true, candidates.Count, entities.Count, null, null);
+        return new SyncResult(true, candidateCount, entities.Count, null, null);
     }
 
     /// <summary>
@@ -461,10 +479,17 @@ public class ScheduledSyncService(
         Guid accountId, IEnumerable<TransactionCandidate> candidates, CancellationToken ct)
     {
         var existingRows = (await _transactions.GetByAccountIdAsync(accountId, ct)).ToList();
-        var existingHashes = existingRows.Select(t => t.UniqueHash).ToHashSet();
+        // Dedup against ALL hashes — including soft-deleted rows, which still occupy the unique
+        // (AccountId, UniqueHash) index — not just the active rows above. Missing a soft-deleted
+        // hash here re-inserts it and violates the constraint, poisoning the whole batch.
+        var existingHashes = (await _transactions.GetAllUniqueHashesByAccountIdAsync(accountId, ct)).ToHashSet();
 
         var entities = _dedup.FilterDuplicates(candidates, existingHashes)
             .Select(_dedup.ToEntity)
+            // Guard against duplicate hashes *within* a single provider batch (e.g. a pending and
+            // booked copy that hash alike) — FilterDuplicates only compares against existing rows.
+            .GroupBy(e => e.UniqueHash)
+            .Select(g => g.First())
             .ToList();
         if (entities.Count > 0)
             await _transactions.AddRangeAsync(entities, ct);

--- a/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
@@ -63,6 +63,17 @@ public static class BankSyncModule
                 job => job.ExecuteAsync(CancellationToken.None),
                 Cron.Daily());
 
+            mgr.AddOrUpdate<StaleSyncReaperJob>(
+                "stale-sync-reaper",
+                job => job.ReapAsync(),
+                "*/15 * * * *");
+
+            // Startup sweep: any job still "running"/account still "syncing" after a restart was
+            // orphaned mid-sync and would otherwise deadlock the scheduler — reap them all first,
+            // then (re)schedule the active accounts.
+            BackgroundJob.Enqueue<StaleSyncReaperJob>(
+                job => job.ExecuteAsync(true, CancellationToken.None));
+
             BackgroundJob.Enqueue<SyncScheduler>(
                 s => s.ScheduleAllActiveAccounts(CancellationToken.None));
         }
@@ -142,6 +153,7 @@ public static class BankSyncModule
         services.AddScoped<CredentialBackupJob>();
         services.AddScoped<UnusualSpendDetectionJob>();
         services.AddScoped<SubscriptionDetectionJob>();
+        services.AddScoped<StaleSyncReaperJob>();
 
         services.AddSingleton<IFeatureFlagService, FeatureFlagService>();
         services.AddSingleton<IAuditLogService, AuditLogService>();

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
@@ -120,6 +120,21 @@ public class BankAccount : Entity
         UpdatedAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Heals an account after a successful reconnect/reauth. Unlike <see cref="MarkActive"/>,
+    /// which only transitions from "syncing", this transitions from <b>any</b> status (notably
+    /// "reauth_required"), re-points the account at the freshly linked TrueLayer connection, and
+    /// clears the stale error so the scheduler resumes syncing it on the next cycle.
+    /// </summary>
+    public void MarkReconnected(Guid trueLayerConnectionId, decimal balance)
+    {
+        TrueLayerConnectionId = trueLayerConnectionId;
+        SyncStatus = "active";
+        CurrentBalance = balance;
+        LastSyncError = null;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
     public void ValidateInvariants()
     {
         if (string.IsNullOrWhiteSpace(ExternalAccountId))

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
@@ -101,6 +101,14 @@ public interface ITransactionRepository
     Task<bool> ExistsByUniqueHashAsync(Guid accountId, string uniqueHash, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// All UniqueHash values for the account, <b>including soft-deleted (IsActive=false) rows</b>.
+    /// Bypasses the global IsActive query filter so dedup catches hashes that still occupy the
+    /// unique index (AccountId, UniqueHash); otherwise re-syncing a previously soft-deleted
+    /// transaction violates the constraint and poisons the whole batch.
+    /// </summary>
+    Task<IReadOnlyCollection<string>> GetAllUniqueHashesByAccountIdAsync(Guid accountId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Get transaction count for an account.
     /// </summary>
     Task<int> CountByAccountIdAsync(Guid accountId, CancellationToken cancellationToken = default);

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/TrueLayerConnection.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/TrueLayerConnection.cs
@@ -59,4 +59,21 @@ public class TrueLayerConnection : Entity
         Status = "EXPIRED";
         UpdatedAt = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Reuses this connection row for a reconnect/reauth flow: assigns a fresh OAuth reference
+    /// and returns the connection to a pending ("CREATED") state so <c>FinalizeTrueLayerConnect</c>
+    /// will exchange the new authorization code. Linked accounts stay attached, and the existing
+    /// refresh token is left in place until finalize swaps in the new one — so an <b>abandoned</b>
+    /// consent does not sever a still-working connection.
+    /// </summary>
+    public void BeginReauth(string newReference)
+    {
+        if (string.IsNullOrWhiteSpace(newReference))
+            throw new ArgumentException("Reference cannot be empty.", nameof(newReference));
+
+        Reference = newReference;
+        Status = "CREATED";
+        UpdatedAt = DateTime.UtcNow;
+    }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/StaleSyncReaperJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/StaleSyncReaperJob.cs
@@ -1,0 +1,80 @@
+namespace FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
+
+using Hangfire;
+using Microsoft.Extensions.Logging;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+
+/// <summary>
+/// Reaps sync operations orphaned by a process kill (deploy/restart) or a crash between
+/// <c>BeginSync</c> and completion. Such an interruption leaves a <see cref="Domain.SyncJob"/>
+/// stuck in "running"/"pending" and its account stuck in "syncing"; because the coordinator refuses
+/// to start a new sync while a "running" job exists (<c>HasRunningJobAsync</c>), the account would
+/// otherwise never sync again — a permanent deadlock.
+///
+/// On startup every in-flight job is stale by definition (no sync survives a process restart), so
+/// all are reaped. On the recurring cadence only jobs/accounts older than
+/// <see cref="StaleThresholdMinutes"/> are reaped, leaving genuinely in-progress syncs alone.
+/// </summary>
+public class StaleSyncReaperJob(
+    ISyncJobRepository syncJobs,
+    IBankAccountRepository accounts,
+    ILogger<StaleSyncReaperJob> logger)
+{
+    /// <summary>
+    /// Minutes after which an unfinished sync is considered dead. No legitimate sync runs this
+    /// long, so anything older was orphaned by a crash/restart.
+    /// </summary>
+    public const int StaleThresholdMinutes = 30;
+
+    private const string ReapedErrorCode = "STALE_JOB_REAPED";
+
+    private readonly ISyncJobRepository _syncJobs = syncJobs;
+    private readonly IBankAccountRepository _accounts = accounts;
+    private readonly ILogger<StaleSyncReaperJob> _logger = logger;
+
+    /// <summary>Recurring entry-point (Hangfire): reaps only jobs/accounts past the stale threshold.</summary>
+    [AutomaticRetry(Attempts = 0)]
+    public Task ReapAsync() => ExecuteAsync(startupSweep: false, CancellationToken.None);
+
+    /// <summary>
+    /// Core reap. When <paramref name="startupSweep"/> is true, every in-flight job / syncing
+    /// account is reaped regardless of age (nothing can still be running after a restart).
+    /// </summary>
+    public async Task ExecuteAsync(bool startupSweep, CancellationToken cancellationToken = default)
+    {
+        var cutoff = DateTime.UtcNow.AddMinutes(-StaleThresholdMinutes);
+        var reapedJobs = 0;
+        var resetAccounts = 0;
+
+        // 1. Fail sync jobs left dangling by a crash/restart so HasRunningJobAsync stops blocking.
+        var inFlight = (await _syncJobs.GetByStatusAsync("running", cancellationToken))
+            .Concat(await _syncJobs.GetByStatusAsync("pending", cancellationToken));
+        foreach (var job in inFlight)
+        {
+            if (!startupSweep && job.CreatedAt > cutoff)
+                continue;
+
+            job.MarkFailed("Sync did not complete and was reaped as stale.", ReapedErrorCode);
+            await _syncJobs.UpdateAsync(job, cancellationToken);
+            reapedJobs++;
+        }
+
+        // 2. Release accounts wedged in "syncing" so the next scheduled cycle can re-run them.
+        //    MarkFailed transitions "syncing" -> "failed"; the scheduler then retries cleanly.
+        var stuck = await _accounts.GetBySyncStatusAsync("syncing", cancellationToken);
+        foreach (var account in stuck)
+        {
+            if (!startupSweep && account.UpdatedAt > cutoff)
+                continue;
+
+            account.MarkFailed(ReapedErrorCode);
+            await _accounts.UpdateAsync(account, cancellationToken);
+            resetAccounts++;
+        }
+
+        if (reapedJobs > 0 || resetAccounts > 0)
+            _logger.LogWarning(
+                "Stale-sync reaper ({Mode}) reaped {Jobs} dangling job(s) and reset {Accounts} wedged account(s).",
+                startupSweep ? "startup" : "periodic", reapedJobs, resetAccounts);
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
@@ -140,6 +140,19 @@ public class TransactionRepository(BankSyncDbContext context) : ITransactionRepo
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyCollection<string>> GetAllUniqueHashesByAccountIdAsync(Guid accountId, CancellationToken cancellationToken = default)
+    {
+        // IgnoreQueryFilters() bypasses the global IsActive filter so soft-deleted rows are
+        // included. Their hashes still occupy the unique index (AccountId, UniqueHash); leaving
+        // them out of the dedup set lets a re-synced transaction re-insert and violate the
+        // constraint, which poisons the whole SaveChanges batch.
+        return await _context.Transactions
+            .IgnoreQueryFilters()
+            .Where(t => t.AccountId == accountId)
+            .Select(t => t.UniqueHash)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<Transaction>> GetByAccountIdAsync(Guid accountId, int skip, int take, CancellationToken cancellationToken = default)
     {
         return await _context.Transactions

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/ScheduledSyncServiceTests.cs
@@ -53,6 +53,8 @@ public class ScheduledSyncServiceTests
     {
         var accountRepo = new Mock<IBankAccountRepository>();
         var txRepo = new Mock<ITransactionRepository>();
+        txRepo.Setup(r => r.GetAllUniqueHashesByAccountIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(Array.Empty<string>());
         var jobRepo = new Mock<ISyncJobRepository>();
         var credRepo = new Mock<IEncryptedCredentialRepository>();
         var encryption = new Mock<ICredentialEncryptionService>();
@@ -164,6 +166,93 @@ public class ScheduledSyncServiceTests
         jobRepo.Verify(r => r.AddAsync(It.IsAny<SyncJob>(), default), Times.Once);
         txRepo.Verify(r => r.AddRangeAsync(It.IsAny<IEnumerable<Transaction>>(), default), Times.Once);
         accountRepo.Verify(r => r.UpdateAsync(It.IsAny<BankAccount>(), default), Times.AtLeast(2));
+    }
+
+    // ── TrueLayer #3: in-batch duplicate hashes must not be double-inserted ──
+
+    [Fact]
+    public async Task PerformFullSyncAsync_InBatchDuplicateHashes_InsertedOnce()
+    {
+        // Regression: two candidates in one provider batch that hash alike (e.g. a pending and a
+        // booked copy) previously both reached AddRange and violated the unique (AccountId,
+        // UniqueHash) index, poisoning the whole SaveChanges and wedging the account in "syncing".
+        var (sut, accountRepo, txRepo, jobRepo, credRepo, encryption, plaid, dedup, _) = BuildSut();
+
+        var account = MakeActiveAccount();
+        accountRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(account);
+        accountRepo.Setup(r => r.UpdateAsync(It.IsAny<BankAccount>(), default)).ReturnsAsync(account);
+        jobRepo.Setup(r => r.AddAsync(It.IsAny<SyncJob>(), default)).ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.UpdateAsync(It.IsAny<SyncJob>(), default)).ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.GetLatestByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync((SyncJob?)null);
+        credRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(MakeCredential(AccountId));
+        encryption.Setup(e => e.Decrypt(It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<int>()))
+                  .Returns("access-sandbox-token");
+
+        var candidates = new List<TransactionCandidate>
+        {
+            new(AccountId, UserId, 50m, DateTime.UtcNow.AddDays(-1), null, "Coffee", true, "debit", null, null, "tx_001"),
+            new(AccountId, UserId, 50m, DateTime.UtcNow.AddDays(-1), null, "Coffee", false, "debit", null, null, "tx_001")
+        };
+        plaid.Setup(p => p.SyncTransactionsAsync("access-sandbox-token", It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), default))
+             .ReturnsAsync(((IReadOnlyList<TransactionCandidate>)candidates, "cursor_1"));
+        plaid.Setup(p => p.GetAccountsWithBalanceAsync("access-sandbox-token", default))
+             .ReturnsAsync([new("plaid_acc_1", "Checking", "checking", "1234", 100m, 100m, "EUR")]);
+        txRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync([]);
+
+        dedup.Setup(d => d.FilterDuplicates(It.IsAny<IEnumerable<TransactionCandidate>>(), It.IsAny<IReadOnlySet<string>>()))
+             .Returns(candidates);
+        // Both candidates map to entities with the SAME hash — the in-batch collision.
+        dedup.Setup(d => d.ToEntity(candidates[0]))
+             .Returns(new Transaction(AccountId, UserId, 50m, DateTime.UtcNow.AddDays(-1), "Coffee", "dup_hash", false));
+        dedup.Setup(d => d.ToEntity(candidates[1]))
+             .Returns(new Transaction(AccountId, UserId, 50m, DateTime.UtcNow.AddDays(-1), "Coffee", "dup_hash", false));
+
+        IEnumerable<Transaction>? added = null;
+        txRepo.Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<Transaction>>(), default))
+              .ReturnsAsync((IEnumerable<Transaction> txs, CancellationToken _) => txs)
+              .Callback((IEnumerable<Transaction> txs, CancellationToken _) => added = txs.ToList());
+
+        var result = await sut.PerformFullSyncAsync(AccountId);
+
+        result.Success.Should().BeTrue();
+        added.Should().NotBeNull();
+        added!.Should().ContainSingle("in-batch duplicate hashes collapse to one row before insert");
+    }
+
+    [Fact]
+    public async Task PerformFullSyncAsync_DedupSetIncludesSoftDeletedHashes()
+    {
+        // The hash set handed to dedup must come from GetAllUniqueHashesByAccountIdAsync (which
+        // includes soft-deleted rows), not just the active rows — otherwise a re-synced
+        // soft-deleted transaction slips through and collides with the unique index.
+        var (sut, accountRepo, txRepo, jobRepo, credRepo, encryption, plaid, dedup, _) = BuildSut();
+
+        var account = MakeActiveAccount();
+        accountRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(account);
+        accountRepo.Setup(r => r.UpdateAsync(It.IsAny<BankAccount>(), default)).ReturnsAsync(account);
+        jobRepo.Setup(r => r.AddAsync(It.IsAny<SyncJob>(), default)).ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.UpdateAsync(It.IsAny<SyncJob>(), default)).ReturnsAsync((SyncJob j, CancellationToken _) => j);
+        jobRepo.Setup(r => r.GetLatestByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync((SyncJob?)null);
+        credRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync(MakeCredential(AccountId));
+        encryption.Setup(e => e.Decrypt(It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<byte[]>(), It.IsAny<int>()))
+                  .Returns("access-sandbox-token");
+        plaid.Setup(p => p.SyncTransactionsAsync("access-sandbox-token", It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), default))
+             .ReturnsAsync(((IReadOnlyList<TransactionCandidate>)[], "cursor_1"));
+        plaid.Setup(p => p.GetAccountsWithBalanceAsync("access-sandbox-token", default))
+             .ReturnsAsync([new("plaid_acc_1", "Checking", "checking", "1234", 100m, 100m, "EUR")]);
+        txRepo.Setup(r => r.GetByAccountIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync([]);
+        txRepo.Setup(r => r.GetAllUniqueHashesByAccountIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(["soft_deleted_hash"]);
+
+        IReadOnlySet<string>? seenSet = null;
+        dedup.Setup(d => d.FilterDuplicates(It.IsAny<IEnumerable<TransactionCandidate>>(), It.IsAny<IReadOnlySet<string>>()))
+             .Callback((IEnumerable<TransactionCandidate> _, IReadOnlySet<string> hashes) => seenSet = hashes)
+             .Returns([]);
+
+        await sut.PerformFullSyncAsync(AccountId);
+
+        seenSet.Should().NotBeNull();
+        seenSet!.Should().Contain("soft_deleted_hash");
     }
 
     // ── T313-3: Deduplication filters existing transactions ─────────────────
@@ -380,6 +469,8 @@ public class ScheduledSyncServiceTests
     {
         var accountRepo = new Mock<IBankAccountRepository>();
         var txRepo = new Mock<ITransactionRepository>();
+        txRepo.Setup(r => r.GetAllUniqueHashesByAccountIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(Array.Empty<string>());
         var jobRepo = new Mock<ISyncJobRepository>();
         var credRepo = new Mock<IEncryptedCredentialRepository>();
         var encryption = new Mock<ICredentialEncryptionService>();

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Domain/BankAccountTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Domain/BankAccountTests.cs
@@ -164,6 +164,36 @@ public class BankAccountTests
         account.UserId.Should().Be(specificUserId);
     }
 
+    // ── Reconnect / reauth heal (TrueLayer #3) ──────────────────────────────
+
+    [Fact]
+    public void MarkReconnected_FromReauthRequired_TransitionsToActiveAndRelinks()
+    {
+        var account = MakeAccount();
+        account.MarkReauthRequired();
+        var newConnectionId = Guid.NewGuid();
+
+        account.MarkReconnected(newConnectionId, balance: 250.00m);
+
+        account.SyncStatus.Should().Be("active");
+        account.TrueLayerConnectionId.Should().Be(newConnectionId);
+        account.CurrentBalance.Should().Be(250.00m);
+    }
+
+    [Fact]
+    public void MarkReconnected_ClearsLastSyncError()
+    {
+        var account = MakeAccount();
+        account.BeginSync();
+        account.MarkFailed("ITEM_LOGIN_REQUIRED");
+        account.LastSyncError.Should().Be("ITEM_LOGIN_REQUIRED");
+
+        account.MarkReconnected(Guid.NewGuid(), balance: 0m);
+
+        account.LastSyncError.Should().BeNull();
+        account.SyncStatus.Should().Be("active");
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static BankAccount MakeAccount()

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StaleSyncReaperJobTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/StaleSyncReaperJobTests.cs
@@ -1,0 +1,110 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+
+using FinanceSentry.Core.Domain;
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="StaleSyncReaperJob"/> (TrueLayer #3). Verifies the reaper releases
+/// syncs orphaned by a crash/restart — the deadlock that froze Revolut for 5 days — while leaving
+/// genuinely in-progress syncs alone on the periodic cadence.
+/// </summary>
+public class StaleSyncReaperJobTests
+{
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+
+    private readonly Mock<ISyncJobRepository> _jobs = new();
+    private readonly Mock<IBankAccountRepository> _accounts = new();
+
+    public StaleSyncReaperJobTests()
+    {
+        _jobs.Setup(r => r.GetByStatusAsync("running", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncJob>());
+        _jobs.Setup(r => r.GetByStatusAsync("pending", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SyncJob>());
+        _accounts.Setup(r => r.GetBySyncStatusAsync("syncing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<BankAccount>());
+    }
+
+    [Fact]
+    public async Task Startup_ReapsRunningJobAndSyncingAccount_RegardlessOfAge()
+    {
+        var job = new SyncJob(Guid.NewGuid(), UserId); // CreatedAt == now (fresh)
+        var account = MakeSyncingAccount();
+        _jobs.Setup(r => r.GetByStatusAsync("running", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([job]);
+        _accounts.Setup(r => r.GetBySyncStatusAsync("syncing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([account]);
+
+        await MakeReaper().ExecuteAsync(startupSweep: true);
+
+        job.Status.Should().Be("failed");
+        job.ErrorCode.Should().Be("STALE_JOB_REAPED");
+        account.SyncStatus.Should().Be("failed");
+        _jobs.Verify(r => r.UpdateAsync(job, It.IsAny<CancellationToken>()), Times.Once);
+        _accounts.Verify(r => r.UpdateAsync(account, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Periodic_LeavesFreshInFlightSyncAlone()
+    {
+        var job = new SyncJob(Guid.NewGuid(), UserId); // fresh — a real sync in progress
+        var account = MakeSyncingAccount();            // UpdatedAt == now
+        _jobs.Setup(r => r.GetByStatusAsync("running", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([job]);
+        _accounts.Setup(r => r.GetBySyncStatusAsync("syncing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([account]);
+
+        await MakeReaper().ExecuteAsync(startupSweep: false);
+
+        job.Status.Should().Be("pending");   // untouched (SyncJob default status)
+        account.SyncStatus.Should().Be("syncing");
+        _jobs.Verify(r => r.UpdateAsync(It.IsAny<SyncJob>(), It.IsAny<CancellationToken>()), Times.Never);
+        _accounts.Verify(r => r.UpdateAsync(It.IsAny<BankAccount>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Periodic_ReapsSyncOlderThanThreshold()
+    {
+        var staleMinutes = StaleSyncReaperJob.StaleThresholdMinutes + 5;
+        var job = Backdate(new SyncJob(Guid.NewGuid(), UserId), staleMinutes);
+        var account = Backdate(MakeSyncingAccount(), staleMinutes);
+        _jobs.Setup(r => r.GetByStatusAsync("running", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([job]);
+        _accounts.Setup(r => r.GetBySyncStatusAsync("syncing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([account]);
+
+        await MakeReaper().ExecuteAsync(startupSweep: false);
+
+        job.Status.Should().Be("failed");
+        account.SyncStatus.Should().Be("failed");
+        _jobs.Verify(r => r.UpdateAsync(job, It.IsAny<CancellationToken>()), Times.Once);
+        _accounts.Verify(r => r.UpdateAsync(account, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private StaleSyncReaperJob MakeReaper()
+        => new(_jobs.Object, _accounts.Object, Mock.Of<ILogger<StaleSyncReaperJob>>());
+
+    private static BankAccount MakeSyncingAccount()
+    {
+        var account = new BankAccount(UserId, "item_abc123", "REVOLUT-IE", "checking",
+            "1234", "John Doe", "EUR", UserId);
+        account.BeginSync();
+        return account;
+    }
+
+    // CreatedAt (init) and UpdatedAt (protected set) are only assignable via reflection in tests —
+    // used here to age an entity past the stale threshold without waiting.
+    private static T Backdate<T>(T entity, int minutesAgo) where T : Entity
+    {
+        var when = DateTime.UtcNow.AddMinutes(-minutesAgo);
+        typeof(Entity).GetProperty(nameof(Entity.CreatedAt))!.SetValue(entity, when);
+        typeof(Entity).GetProperty(nameof(Entity.UpdatedAt))!.SetValue(entity, when);
+        return entity;
+    }
+}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -40,6 +40,12 @@ services:
       TrueLayer__ClientSecret: ${TRUELAYER_CLIENT_SECRET:-}
       TrueLayer__FrontendRedirectBase: ${TRUELAYER_FRONTEND_REDIRECT_BASE:-https://lifekit-vps.tail1cb676.ts.net:4200}
       TrueLayer__CallbackPath: /api/v1/accounts/truelayer/callback
+      # Public base of the API itself — used to build the OAuth redirect_uri TrueLayer sends the
+      # browser back to after consent. Must be the externally reachable API URL (Tailscale serve
+      # maps :5001 → the api container) and MUST exactly match a redirect URI registered in the
+      # TrueLayer console. Left unset it defaults to http://localhost:5001, which dead-ends the
+      # callback for any non-local user.
+      PublicApiBaseUrl: ${PUBLIC_API_BASE_URL:-https://lifekit-vps.tail1cb676.ts.net:5001}
       TrueLayer__Scopes: "info accounts balance transactions cards offline_access"
     ports:
       - "127.0.0.1:${API_PORT:-5001}:5000"


### PR DESCRIPTION
Root-causes the recurring AIB/Revolut "stuck account" reports. Five distinct bugs, all fixed with tests.

## Fixes
| Fix | Root cause |
|---|---|
| **Reconnect can start** | `BeginTrueLayerConnect` rejected a `reauth_required` provider as a duplicate. Now reuses the connection row (`BeginReauth`) so linked accounts stay attached; an abandoned consent no longer severs a working connection. |
| **Reconnect heals** | `FinalizeTrueLayerConnect` `continue`d past existing accounts, orphaning them in `reauth_required`. Now `MarkReconnected` re-points the account, clears reauth, refreshes balance, enqueues sync. |
| **Stuck-sync self-recovers** | A crash/restart between `BeginSync` and completion left `SyncJob=running`/`account=syncing`; `HasRunningJobAsync` then blocked every future sync forever (froze Revolut 5 days). New `StaleSyncReaperJob` sweeps on startup (all in-flight) + every 15 min (past a 30-min threshold). |
| **Duplicate-hash crash** | Dedup omitted soft-deleted rows (global `IsActive` query filter) whose hashes still occupy the unique `(AccountId, UniqueHash)` index -> `23505` -> poisoned batch -> wedge. Now dedups against ALL hashes (`GetAllUniqueHashesByAccountIdAsync`) and collapses in-batch duplicate hashes. **This was Revolut's true root cause.** |
| **AIB SCA** | 403 `access_denied` on background transaction fetch (Strong Customer Authentication) now degrades to a balance-only sync instead of flapping the account to `failed` every cycle. |
| **Config** | `PublicApiBaseUrl` set in prod compose so the OAuth callback stops redirecting to `localhost:5001`. |

## Follow-up required outside this PR
- Register redirect URI `https://lifekit-vps.tail1cb676.ts.net:5001/api/v1/accounts/truelayer/callback` in the TrueLayer console (must match `PublicApiBaseUrl`).
- AIB transaction *history* only updates on a user-present manual sync (bank SCA policy); balance stays live in the background.

## Tests
Reaper (startup/periodic/threshold), `MarkReconnected`, in-batch dedup, soft-deleted-hash dedup source. **388 unit tests green, 0 build warnings** (sdk:10.0 container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)