### PR TITLE
feat(truelayer): inline history-fetch at reconnect + pre-expiry reminder

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs
@@ -103,4 +103,16 @@ public interface IAlertGeneratorService
         string ticker,
         string reason,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Raises a heads-up Alert that a bank connection's consent is about to expire, so the user can
+    /// reconnect proactively instead of after data goes stale. <paramref name="referenceId"/> is the
+    /// connection id so a daily detector doesn't spam duplicates within the silence window.
+    /// </summary>
+    Task GenerateConsentExpiringAlertAsync(
+        Guid userId,
+        Guid referenceId,
+        string providerName,
+        DateTime expiresAt,
+        CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
@@ -16,6 +16,9 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
     private static readonly TimeSpan MarketStructureFreshnessSilenceWindow = TimeSpan.FromHours(12);
     private static readonly TimeSpan PolicyViolationSilenceWindow = TimeSpan.FromHours(24);
     private static readonly TimeSpan OpportunitySilenceWindow = TimeSpan.FromHours(24);
+    // Reminders repeat only every 3 days while inside the pre-expiry window, so the detector can run
+    // daily without spamming the same connection.
+    private static readonly TimeSpan ConsentExpiringSilenceWindow = TimeSpan.FromDays(3);
 
     private readonly IAlertRepository _alerts = alerts;
 
@@ -245,6 +248,31 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
             Message = $"{ticker} scored top-tier on conviction scoring: {reason}",
             ReferenceId = referenceId,
             ReferenceLabel = ticker,
+        }, ct);
+    }
+
+    public async Task GenerateConsentExpiringAlertAsync(
+        Guid userId, Guid referenceId, string providerName, DateTime expiresAt, CancellationToken ct = default)
+    {
+        var existing = await _alerts.FindActiveAsync(userId, AlertType.ConsentExpiring, referenceId, ct);
+        if (existing is not null) return;
+
+        var quietSince = DateTimeOffset.UtcNow - ConsentExpiringSilenceWindow;
+        if (await _alerts.HasRecentAsync(userId, AlertType.ConsentExpiring, referenceId, providerName, quietSince, ct))
+            return;
+
+        var days = Math.Max(0, (int)Math.Ceiling((expiresAt - DateTime.UtcNow).TotalDays));
+        var window = days == 0 ? "today" : days == 1 ? "in 1 day" : $"in {days} days";
+
+        await _alerts.AddAsync(new Alert
+        {
+            UserId = userId,
+            Type = AlertType.ConsentExpiring,
+            Severity = AlertSeverity.Warning,
+            Title = $"{providerName} bank connection expires {window}",
+            Message = $"Your {providerName} open-banking consent expires {window} ({expiresAt:yyyy-MM-dd}). Reconnect it to keep balances and transactions syncing.",
+            ReferenceId = referenceId,
+            ReferenceLabel = providerName,
         }, ct);
     }
 

--- a/backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs
@@ -9,4 +9,5 @@ public static class AlertType
     public const string MarketStructure = "MarketStructure";
     public const string PolicyViolation = "PolicyViolation";
     public const string Opportunity = "Opportunity";
+    public const string ConsentExpiring = "ConsentExpiring";
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/FinalizeTrueLayerConnectCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/FinalizeTrueLayerConnectCommand.cs
@@ -2,11 +2,12 @@ namespace FinanceSentry.Modules.BankSync.Application.Commands;
 
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Infrastructure.Encryption;
+using FinanceSentry.Modules.BankSync.Application.Services;
 using FinanceSentry.Modules.BankSync.Domain;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 using FinanceSentry.Modules.BankSync.Infrastructure.TrueLayer;
-using Hangfire;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 public record FinalizeTrueLayerConnectCommand(string Reference, string Code) : ICommand<FinalizeTrueLayerConnectResult>;
 
@@ -20,8 +21,9 @@ public class FinalizeTrueLayerConnectCommandHandler(
     ITrueLayerConnectionRepository connections,
     ICredentialEncryptionService encryption,
     IBankAccountRepository accounts,
-    IBackgroundJobClient backgroundJobs,
-    IConfiguration configuration)
+    IScheduledSyncService syncService,
+    IConfiguration configuration,
+    ILogger<FinalizeTrueLayerConnectCommandHandler> logger)
     : ICommandHandler<FinalizeTrueLayerConnectCommand, FinalizeTrueLayerConnectResult>
 {
     public async Task<FinalizeTrueLayerConnectResult> Handle(
@@ -101,9 +103,26 @@ public class FinalizeTrueLayerConnectCommandHandler(
             createdIds.Add(account.Id);
         }
 
+        // Sync inline with the freshly-exchanged access token while its SCA session is still
+        // active — this is the only window in which strict banks (e.g. AIB) will return
+        // transaction history; a deferred background job would refresh the token and lose SCA.
+        // Failures here don't fail the reconnect: the connection is already linked and the
+        // recurring scheduler will retry (balance-only for SCA-locked providers).
         foreach (var accountId in createdIds)
-            backgroundJobs.Enqueue<FinanceSentry.Modules.BankSync.Infrastructure.Jobs.ScheduledSyncJob>(
-                job => job.ExecuteSyncAsync(accountId));
+        {
+            try
+            {
+                await syncService.PerformFullSyncAsync(
+                    accountId, webhookTriggered: false, ct: cancellationToken,
+                    preAcquiredTrueLayerAccessToken: tokens.AccessToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Inline reconnect sync failed for account {AccountId}; scheduler will retry.",
+                    accountId);
+            }
+        }
 
         return new FinalizeTrueLayerConnectResult(
             UserId: connection.UserId,

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -31,7 +31,8 @@ public interface IScheduledSyncService
     Task<SyncResult> PerformFullSyncAsync(
         Guid accountId,
         bool webhookTriggered = false,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        string? preAcquiredTrueLayerAccessToken = null);
 }
 
 /// <inheritdoc />
@@ -83,7 +84,8 @@ public class ScheduledSyncService(
     public async Task<SyncResult> PerformFullSyncAsync(
           Guid accountId,
           bool webhookTriggered = false,
-          CancellationToken ct = default)
+          CancellationToken ct = default,
+          string? preAcquiredTrueLayerAccessToken = null)
     {
         var startedAt = DateTime.UtcNow;
 
@@ -111,7 +113,7 @@ public class ScheduledSyncService(
             if (account.Provider == "monobank")
                 result = await SyncMonobankAsync(account, job, startedAt, ct);
             else if (account.Provider == "truelayer")
-                result = await SyncTrueLayerAsync(account, job, startedAt, ct);
+                result = await SyncTrueLayerAsync(account, job, startedAt, ct, preAcquiredTrueLayerAccessToken);
             else
                 result = await SyncPlaidAsync(account, job, webhookTriggered, startedAt, ct);
 
@@ -317,13 +319,18 @@ public class ScheduledSyncService(
     private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> TrueLayerRefreshLocks = new();
 
     private async Task<SyncResult> SyncTrueLayerAsync(
-        Domain.BankAccount account, SyncJob job, DateTime startedAt, CancellationToken ct)
+        Domain.BankAccount account, SyncJob job, DateTime startedAt, CancellationToken ct,
+        string? preAcquiredAccessToken = null)
     {
         if (account.TrueLayerConnectionId is null)
             throw new InvalidOperationException($"TrueLayer account {account.Id} has no connection id.");
 
         var connectionId = account.TrueLayerConnectionId.Value;
-        var accessToken = await AcquireTrueLayerAccessTokenAsync(connectionId, job, account.Id, ct);
+        // At reconnect the caller passes the freshly-exchanged access token, which still carries an
+        // active SCA session — the only token that can pull transaction history from strict banks
+        // (e.g. AIB). A refreshed background token cannot, so fall back to it only when none given.
+        var accessToken = preAcquiredAccessToken
+            ?? await AcquireTrueLayerAccessTokenAsync(connectionId, job, account.Id, ct);
 
         var connection = await _truelayerConnections.GetByIdAsync(connectionId, ct)
             ?? throw new InvalidOperationException($"TrueLayer connection {connectionId} not found.");

--- a/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/BankSyncModule.cs
@@ -68,6 +68,11 @@ public static class BankSyncModule
                 job => job.ReapAsync(),
                 "*/15 * * * *");
 
+            mgr.AddOrUpdate<ConsentExpiryReminderJob>(
+                "consent-expiry-reminder",
+                job => job.ExecuteAsync(CancellationToken.None),
+                Cron.Daily());
+
             // Startup sweep: any job still "running"/account still "syncing" after a restart was
             // orphaned mid-sync and would otherwise deadlock the scheduler — reap them all first,
             // then (re)schedule the active accounts.
@@ -154,6 +159,7 @@ public static class BankSyncModule
         services.AddScoped<UnusualSpendDetectionJob>();
         services.AddScoped<SubscriptionDetectionJob>();
         services.AddScoped<StaleSyncReaperJob>();
+        services.AddScoped<ConsentExpiryReminderJob>();
 
         services.AddSingleton<IFeatureFlagService, FeatureFlagService>();
         services.AddSingleton<IAuditLogService, AuditLogService>();

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/Repositories/IRepositories.cs
@@ -255,6 +255,12 @@ public interface ITrueLayerConnectionRepository
     Task<TrueLayerConnection?> GetByReferenceAsync(string reference, CancellationToken cancellationToken = default);
     Task<TrueLayerConnection?> GetByUserAndProviderAsync(Guid userId, string providerId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<TrueLayerConnection>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// LINKED connections whose consent expires on/before <paramref name="threshold"/> (and hasn't
+    /// already lapsed) — the pre-expiry reminder detector uses this to nudge the user to reconnect.
+    /// </summary>
+    Task<IReadOnlyList<TrueLayerConnection>> GetLinkedExpiringBeforeAsync(DateTime threshold, CancellationToken cancellationToken = default);
     Task<TrueLayerConnection> UpdateAsync(TrueLayerConnection connection, CancellationToken cancellationToken = default);
     Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/ConsentExpiryReminderJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/ConsentExpiryReminderJob.cs
@@ -1,0 +1,49 @@
+namespace FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using Hangfire;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Daily detector that nudges the user to reconnect a TrueLayer bank connection <b>before</b> its
+/// open-banking consent (~90 days) expires, instead of after data silently goes stale. Raises a
+/// <c>ConsentExpiring</c> alert per connection inside the reminder window; the Alerts → Companion
+/// pipeline delivers it (Telegram). Dedup/silence lives in the alert generator so running daily is
+/// safe.
+/// </summary>
+public class ConsentExpiryReminderJob(
+    ITrueLayerConnectionRepository connections,
+    IAlertGeneratorService alerts,
+    ILogger<ConsentExpiryReminderJob> logger)
+{
+    /// <summary>Days before expiry to start reminding.</summary>
+    public const int ReminderWindowDays = 7;
+
+    private readonly ITrueLayerConnectionRepository _connections = connections;
+    private readonly IAlertGeneratorService _alerts = alerts;
+    private readonly ILogger<ConsentExpiryReminderJob> _logger = logger;
+
+    [AutomaticRetry(Attempts = 0)]
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        var threshold = DateTime.UtcNow.AddDays(ReminderWindowDays);
+        var expiring = await _connections.GetLinkedExpiringBeforeAsync(threshold, ct);
+
+        var reminded = 0;
+        foreach (var c in expiring)
+        {
+            if (c.ConnectionExpiresAt is null)
+                continue;
+
+            await _alerts.GenerateConsentExpiringAlertAsync(
+                c.UserId, c.Id, c.ProviderDisplayName, c.ConnectionExpiresAt.Value, ct);
+            reminded++;
+        }
+
+        if (reminded > 0)
+            _logger.LogInformation(
+                "Consent-expiry reminder raised alerts for {Count} connection(s) expiring within {Days} days.",
+                reminded, ReminderWindowDays);
+    }
+}

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Persistence/Repositories/Repositories.cs
@@ -429,6 +429,14 @@ public class TrueLayerConnectionRepository(BankSyncDbContext context) : ITrueLay
         => await _context.TrueLayerConnections.FirstOrDefaultAsync(
             tc => tc.UserId == userId && tc.ProviderId == providerId, cancellationToken);
 
+    public async Task<IReadOnlyList<TrueLayerConnection>> GetLinkedExpiringBeforeAsync(DateTime threshold, CancellationToken cancellationToken = default)
+        => await _context.TrueLayerConnections
+            .Where(tc => tc.Status == "LINKED"
+                && tc.ConnectionExpiresAt != null
+                && tc.ConnectionExpiresAt <= threshold
+                && tc.ConnectionExpiresAt > DateTime.UtcNow)
+            .ToListAsync(cancellationToken);
+
     public async Task<IReadOnlyList<TrueLayerConnection>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
         => await _context.TrueLayerConnections
             .Where(tc => tc.UserId == userId)

--- a/backend/src/FinanceSentry.Modules.Companion/Application/Services/MaterialityPolicy.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Application/Services/MaterialityPolicy.cs
@@ -19,6 +19,7 @@ public sealed class MaterialityPolicy : IMaterialityPolicy
         "ThesisBroken" => CompanionEventKind.ThesisBreak,
         "MarketStructure" => CompanionEventKind.MarketStructure,
         "LowBalance" => CompanionEventKind.LowBalance,
+        "ConsentExpiring" => CompanionEventKind.ConsentExpiring,
         _ => null,
     };
 

--- a/backend/src/FinanceSentry.Modules.Companion/Domain/CompanionEventKind.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Domain/CompanionEventKind.cs
@@ -15,4 +15,5 @@ public enum CompanionEventKind
     MarketStructure,
     LowBalance,
     AnalystAction,
+    ConsentExpiring,
 }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
@@ -167,6 +167,7 @@ internal sealed class FakeOpportunityAlertGenerator : IAlertGeneratorService
         return Task.CompletedTask;
     }
 
+    public Task GenerateConsentExpiringAlertAsync(Guid userId, Guid referenceId, string providerName, DateTime expiresAt, CancellationToken ct = default) => Task.CompletedTask;
     public Task GenerateLowBalanceAlertAsync(Guid userId, Guid accountId, string accountName, decimal balance, decimal threshold, CancellationToken ct = default) => Task.CompletedTask;
     public Task ResolveLowBalanceAlertAsync(Guid userId, Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     public Task GenerateSyncFailureAlertAsync(Guid userId, string provider, Guid? accountId, string? accountName, string? errorCode, CancellationToken ct = default) => Task.CompletedTask;

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs
@@ -275,6 +275,10 @@ public class RunThesisMonitorHandlerTests
         public Task DeleteAlertsForAccountAsync(Guid accountId, CancellationToken ct = default)
             => Task.CompletedTask;
 
+        public Task GenerateConsentExpiringAlertAsync(
+            Guid userId, Guid referenceId, string providerName, DateTime expiresAt, CancellationToken ct = default)
+            => Task.CompletedTask;
+
         public Task GenerateThesisBreakAlertAsync(
             Guid userId, Guid thesisId, string ticker, string reason, CancellationToken ct = default)
         {

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/ConsentExpiryReminderJobTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/ConsentExpiryReminderJobTests.cs
@@ -1,0 +1,67 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for <see cref="ConsentExpiryReminderJob"/> (TrueLayer #3, part 2) — nudges the user to
+/// reconnect before an open-banking consent lapses. Dedup/silence is the alert generator's job, so
+/// this only verifies one alert is raised per expiring connection with the right identifiers.
+/// </summary>
+public class ConsentExpiryReminderJobTests
+{
+    private readonly Mock<ITrueLayerConnectionRepository> _connections = new();
+    private readonly Mock<IAlertGeneratorService> _alerts = new();
+
+    [Fact]
+    public async Task ExecuteAsync_RaisesOneAlertPerExpiringConnection()
+    {
+        var expiresAt = DateTime.UtcNow.AddDays(3);
+        var conn = new TrueLayerConnection(Guid.NewGuid(), "ob-aib", "AIB", "ref-1");
+        conn.MarkLinked(expiresAt);
+        _connections.Setup(r => r.GetLinkedExpiringBeforeAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([conn]);
+
+        await MakeJob().ExecuteAsync();
+
+        _alerts.Verify(a => a.GenerateConsentExpiringAlertAsync(
+            conn.UserId, conn.Id, "AIB", expiresAt, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoExpiringConnections_RaisesNothing()
+    {
+        _connections.Setup(r => r.GetLinkedExpiringBeforeAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await MakeJob().ExecuteAsync();
+
+        _alerts.Verify(a => a.GenerateConsentExpiringAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_QueriesWithinReminderWindow()
+    {
+        DateTime? askedThreshold = null;
+        _connections.Setup(r => r.GetLinkedExpiringBeforeAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback((DateTime t, CancellationToken _) => askedThreshold = t)
+            .ReturnsAsync([]);
+
+        await MakeJob().ExecuteAsync();
+
+        Assert.NotNull(askedThreshold);
+        // Threshold is ~ReminderWindowDays in the future (allow scheduling slack).
+        var expected = DateTime.UtcNow.AddDays(ConsentExpiryReminderJob.ReminderWindowDays);
+        Assert.True(Math.Abs((askedThreshold!.Value - expected).TotalMinutes) < 5);
+    }
+
+    private ConsentExpiryReminderJob MakeJob()
+        => new(_connections.Object, _alerts.Object, Mock.Of<ILogger<ConsentExpiryReminderJob>>());
+}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -41,11 +41,13 @@ services:
       TrueLayer__FrontendRedirectBase: ${TRUELAYER_FRONTEND_REDIRECT_BASE:-https://lifekit-vps.tail1cb676.ts.net:4200}
       TrueLayer__CallbackPath: /api/v1/accounts/truelayer/callback
       # Public base of the API itself — used to build the OAuth redirect_uri TrueLayer sends the
-      # browser back to after consent. Must be the externally reachable API URL (Tailscale serve
-      # maps :5001 → the api container) and MUST exactly match a redirect URI registered in the
-      # TrueLayer console. Left unset it defaults to http://localhost:5001, which dead-ends the
-      # callback for any non-local user.
-      PublicApiBaseUrl: ${PUBLIC_API_BASE_URL:-https://lifekit-vps.tail1cb676.ts.net:5001}
+      # browser back to after consent. This MUST exactly match a redirect URI registered in the
+      # TrueLayer console, or consent is rejected. Default is the console-registered
+      # http://localhost:5001; the browser redirect then dead-ends locally but the callback is
+      # recoverable server-side. To enable true one-tap reconnect, register
+      # https://lifekit-vps.tail1cb676.ts.net:5001/api/v1/accounts/truelayer/callback in the
+      # console, then set PUBLIC_API_BASE_URL=https://lifekit-vps.tail1cb676.ts.net:5001 here.
+      PublicApiBaseUrl: ${PUBLIC_API_BASE_URL:-http://localhost:5001}
       TrueLayer__Scopes: "info accounts balance transactions cards offline_access"
     ports:
       - "127.0.0.1:${API_PORT:-5001}:5000"


### PR DESCRIPTION
Follow-up to #344 (TrueLayer #3), closing the two open items.

## Changes
- **Inline transaction-fetch at reconnect** — `FinalizeTrueLayerConnect` now syncs inline with the freshly-exchanged access token (SCA session still active) instead of enqueuing a deferred job that refreshes the token and loses SCA. This is the only window in which strict banks (AIB) return transaction history. Threaded via optional `preAcquiredTrueLayerAccessToken`; inline failure doesn't fail the reconnect (scheduler retries balance-only).
- **Pre-expiry reminder** — new daily `ConsentExpiryReminderJob` scans LINKED connections whose consent expires within 7 days and raises a `ConsentExpiring` alert (new `AlertType` + generator, 3-day silence keyed on connection id). Flows through the existing Alerts → Companion pipeline (new `CompanionEventKind` + `ClassifyAlert` mapping) to **Telegram**.
- **Config** — revert `PublicApiBaseUrl` default to the console-registered `http://localhost:5001` (the tailscale URL isn't registered yet and would reject consent). Override via `PUBLIC_API_BASE_URL` once registered.

## Not built (needs a decision)
- **Email** reminder — no SMTP/email infra exists; building it needs an SMTP/SendGrid sender + secrets. Telegram covers the reminder for now.

## Follow-up for the user
- Register `https://lifekit-vps.tail1cb676.ts.net:5001/api/v1/accounts/truelayer/callback` in the TrueLayer console to enable one-tap reconnect (then flip `PUBLIC_API_BASE_URL`).
- AIB transaction history backfills on the **next** reconnect (inline fetch); today's reconnect predated this code.

## Tests
Reminder job + fakes updated. **391 unit + 153 research tests green, 0 warnings.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)