### PR TITLE
docs(023): observability stack — plan + tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,6 +328,8 @@ After **all tasks in a feature are complete**, act as a QA engineer: spin up the
 - Do not create markdown files at the repo root. Only `README.md` and `CLAUDE.md` belong there. Session artifacts, debug notes, and how-to docs do not get their own files — put relevant content in `README.md` or the appropriate `.specify/` artifact.
 
 ## Active Technologies
+- C# 14 / .NET 10 (backend only — no frontend changes) + OpenTelemetry (.Instrumentation.AspNetCore/.Runtime, Prometheus exporter at `/metrics`), `Serilog.Sinks.Grafana.Loki`, `Hangfire.PostgreSql`, `AspNetCore.HealthChecks.NpgSql`/`.Hangfire`. Infra containers: Prometheus + Grafana + Loki (`docker/observability/`, dashboards-as-code). Observability wiring in `FinanceSentry.Infrastructure/Observability/` + `Program.cs`; US4 job-failure alerting reuses the Alerts→Companion→Telegram path (023-observability-stack)
+- PostgreSQL 14 — Hangfire moved to a dedicated `hangfire` schema (own tables/migrations, not app EF); no new app EF entities (job-failure alerts reuse `alerts` + `companion_events`) (023-observability-stack)
 - TypeScript 5.x strict, Angular 21.2 (frontend only — no backend changes) + `@ngrx/signals` 21.1, `@dsdevq-common/ui` (local lib), Angular ReactiveForms, Plaid Link client SDK (already loaded by `PlaidLinkService`) (011-connect-providers)
 - N/A on frontend; credentials are transient form state, never persisted (011-connect-providers)
 - C# 13/.NET 9 (backend) · TypeScript 5.x strict / Angular 21.2 (frontend) + ASP.NET Core 9, EF Core 9, MediatR, Hangfire · NgRx SignalStore 21.1, @dsdevq-common/ui (015-net-worth-history)

--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ Startup order enforced by health checks: `postgres → api → frontend`.
 |---|---|
 | http://localhost:4200 | Angular SPA |
 | http://localhost:5001/api/v1 | REST API |
-| http://localhost:5001/api/v1/health | Health probe |
+| http://localhost:5001/api/v1/health | Liveness probe |
+| http://localhost:5001/api/v1/health/ready | Readiness probe (per-dependency: `database`, `hangfire`) |
+| http://localhost:5001/metrics | Prometheus exposition (scrape-only) |
 | http://localhost:5001/swagger | Swagger UI |
 | http://localhost:5001/hangfire | Hangfire dashboard |
+| http://localhost:3000 | Grafana (dashboards) |
+| http://localhost:9090 | Prometheus |
+| http://localhost:3100 | Loki (log store) |
 
 ### Run everything
 
@@ -101,6 +106,38 @@ docker compose -f docker-compose.dev.yml down -v              # also drop postgr
 | `Plaid__Secret` | Plaid API secret |
 | `Plaid__WebhookKey` | Plaid webhook signing key |
 | `Jwt__Secret` | JWT signing secret (≥32 chars) |
+
+## Observability (feature 023)
+
+The dev/prod compose stacks run **Prometheus + Grafana + Loki** alongside the app so failures announce
+themselves instead of being found days later via `ssh`+`grep`.
+
+- **Metrics** — the API is instrumented with OpenTelemetry and exposes Prometheus exposition at `/metrics`
+  (ASP.NET Core request rate/latency/errors, .NET runtime, and custom `finance_jobs_*` per-job counters).
+  Prometheus scrapes it every 15s; retention ~30d, hard-capped at 5GB.
+- **Logs** — Serilog ships structured logs to Loki (fire-and-forget; a shipping outage never affects
+  requests). EF Core SQL is suppressed to `Warning` by default (raise via
+  `Serilog:MinimumLevel:Override` in config). Retention ~14d, size-capped.
+- **Dashboards** — provisioned as code under `docker/observability/grafana/provisioning/`. The main
+  dashboard ("Health at a glance") answers *is it healthy now, did last night's jobs run?* at a glance;
+  the availability panel turns red within ~60s of an API outage.
+- **Jobs** — Hangfire storage moved to PostgreSQL (`hangfire` schema) so job history/schedule survive
+  restarts. The Hangfire dashboard at `/hangfire` is loopback/Tailscale-only outside Development.
+
+```bash
+# bring the stack up (adds loki, prometheus, grafana)
+cd docker && docker compose -f docker-compose.dev.yml up -d --build
+
+curl -s http://localhost:5001/metrics | grep finance_jobs_        # custom job metrics present
+curl -s http://localhost:5001/api/v1/health/ready                 # {"status":"Healthy","checks":[...]}
+# open http://localhost:3000 (admin/admin by default) → Finance Sentry → Health at a glance
+```
+
+**Production notes** — Grafana + Hangfire dashboards are reachable only over Tailscale serve (not the
+public funnel); `/metrics` is scrape-only. Set `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` and
+`Observability__Loki__Url` via env/secrets. Grafana metric-threshold alert rules are deferred until
+baselines exist — job silent-failure alerting (US4, N consecutive failures → Telegram) is the app-side
+slice that closes the urgent gap.
 
 ## Running Tests
 

--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <!-- ASP.NET Core / Microsoft.Extensions / EF Core (9.0.0) -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Hangfire" Version="9.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
@@ -49,8 +50,16 @@
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Grafana.Loki" Version="8.3.2" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageVersion Include="Serilog.Enrichers.Context" Version="4.6.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="2.3.0" />
+
+    <!-- OpenTelemetry (metrics → Prometheus /metrics) -->
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.17.0-beta.1" />
 
 
     <!-- Polly / HTTP / JSON -->

--- a/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
+++ b/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Hangfire.PostgreSql" />
     <PackageReference Include="Hangfire.InMemory" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
+    <PackageReference Include="AspNetCore.HealthChecks.Hangfire" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>

--- a/backend/src/FinanceSentry.API/Program.cs
+++ b/backend/src/FinanceSentry.API/Program.cs
@@ -6,21 +6,21 @@ using FinanceSentry.API.Migrations;
 using FinanceSentry.API.Modules;
 using FinanceSentry.Infrastructure.Fx;
 using FinanceSentry.Infrastructure.Logging;
+using FinanceSentry.Infrastructure.Observability;
+using FinanceSentry.Infrastructure.Observability.HealthChecks;
 using FinanceSentry.Modules.BankSync.API.Middleware;
 using FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
 using Hangfire;
+using Hangfire.Dashboard;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
 using Microsoft.OpenApi;
+using DashboardObservability = FinanceSentry.Infrastructure.Observability.Hangfire;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig
-        .ReadFrom.Configuration(context.Configuration)
-        .WriteTo.Console()
-        .WriteTo.File("logs/app-.txt", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14)
-        .Enrich.FromLogContext());
+builder.Host.UseSerilog(SerilogConfiguration.Configure);
 
 builder.Services.AddCors(options =>
     options.AddPolicy("Frontend", policy => policy
@@ -48,12 +48,19 @@ builder.Services.AddAllModules(builder.Configuration);
 
 builder.Services.AddExchangeRates(builder.Configuration);
 
-builder.Services.AddHangfireServices(builder.Configuration);
+builder.Services.AddHangfireServices(builder.Configuration, builder.Environment);
+
+// OpenTelemetry metrics (FR-001/002) — ASP.NET Core + runtime + custom job meter, exposed at /metrics.
+builder.Services.AddObservabilityMetrics();
 
 builder.Services.AddHealthChecks()
     .AddNpgSql(
         builder.Configuration.GetConnectionString("Default")!,
-        name: "npgsql",
+        name: "database",
+        tags: ["ready"])
+    .AddHangfire(
+        options => options.MinimumAvailableServers = 1,
+        name: "hangfire",
         tags: ["ready"]);
 
 builder.Services.AddRateLimiter(options =>
@@ -104,18 +111,38 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
-    app.UseHangfireDashboard("/hangfire", new DashboardOptions
-    {
-        Authorization = [new DevDashboardAuthorizationFilter()],
-        DisplayStorageConnectionString = false,
-        DashboardTitle = "Finance Sentry · Hangfire",
-    });
 }
+
+// Hangfire dashboard (FR-004): permissive locally; loopback/Tailscale-only in every other environment,
+// backed by durable Postgres storage so history/schedule survive restarts.
+IDashboardAuthorizationFilter dashboardFilter = app.Environment.IsDevelopment()
+    ? new DevDashboardAuthorizationFilter()
+    : new DashboardObservability.DashboardAuthorizationFilter();
+
+app.UseHangfireDashboard("/hangfire", new DashboardOptions
+{
+    Authorization = [dashboardFilter],
+    DisplayStorageConnectionString = false,
+    DashboardTitle = "Finance Sentry · Hangfire",
+});
 
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();
-app.MapHealthChecks("/health/ready");
+
+// Prometheus exposition (FR-001) — scrape-only / not on the public funnel (FR-006).
+app.MapObservabilityMetricsEndpoint();
+
+// Readiness (SC-003): overall + per-dependency status; JWT-exempt via /api/v1/health prefix.
+app.MapHealthChecks("/api/v1/health/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready"),
+    ResponseWriter = ReadinessResponseWriter.WriteAsync,
+});
+
+// Record per-job outcome + duration metrics as jobs reach terminal states (FR-002).
+GlobalJobFilters.Filters.Add(
+    new DashboardObservability.JobMetricsFilter(app.Services.GetRequiredService<JobMetrics>()));
 
 app.RegisterAllModuleJobs();
 

--- a/backend/src/FinanceSentry.API/Program.cs
+++ b/backend/src/FinanceSentry.API/Program.cs
@@ -144,6 +144,12 @@ app.MapHealthChecks("/api/v1/health/ready", new HealthCheckOptions
 GlobalJobFilters.Filters.Add(
     new DashboardObservability.JobMetricsFilter(app.Services.GetRequiredService<JobMetrics>()));
 
+// Alert on N consecutive job failures → Telegram (US4/FR-009); N configurable, default 3.
+GlobalJobFilters.Filters.Add(new DashboardObservability.ConsecutiveFailureAlertFilter(
+    app.Services,
+    new DashboardObservability.HangfireJobFailureStreakStore(),
+    app.Configuration.GetValue("Observability:JobFailureAlertThreshold", 3)));
+
 app.RegisterAllModuleJobs();
 
 // Live FX rates: refresh daily, and once immediately so we leave the hardcoded

--- a/backend/src/FinanceSentry.API/appsettings.json
+++ b/backend/src/FinanceSentry.API/appsettings.json
@@ -33,7 +33,8 @@
   "Observability": {
     "Loki": {
       "Url": ""
-    }
+    },
+    "JobFailureAlertThreshold": 3
   },
   "AllowedHosts": "*",
   "GoogleOAuth": {

--- a/backend/src/FinanceSentry.API/appsettings.json
+++ b/backend/src/FinanceSentry.API/appsettings.json
@@ -30,6 +30,11 @@
       "System": "Warning"
     }
   },
+  "Observability": {
+    "Loki": {
+      "Url": ""
+    }
+  },
   "AllowedHosts": "*",
   "GoogleOAuth": {
     "ClientId": ""

--- a/backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IAlertGeneratorService.cs
@@ -115,4 +115,18 @@ public interface IAlertGeneratorService
         string providerName,
         DateTime expiresAt,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Raises an operational Alert that a scheduled job has failed <paramref name="consecutiveCount"/>
+    /// times in a row (US4 / FR-009). <paramref name="referenceId"/> is a stable per-job id so the streak
+    /// dedups within the silence window; the caller (the Hangfire failure filter) guarantees one call per
+    /// streak and clears the streak on the next success so a later failure can re-alert.
+    /// </summary>
+    Task GenerateJobFailureAlertAsync(
+        Guid userId,
+        Guid referenceId,
+        string jobName,
+        int consecutiveCount,
+        string? lastError,
+        CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Infrastructure/FinanceSentry.Infrastructure.csproj
+++ b/backend/src/FinanceSentry.Infrastructure/FinanceSentry.Infrastructure.csproj
@@ -1,16 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Enrichers.Context" />
     <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Settings.Configuration" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" />
     <PackageReference Include="FluentResults" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions.Http" />
+    <PackageReference Include="Hangfire.Core" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/ConsecutiveFailureAlertFilter.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/ConsecutiveFailureAlertFilter.cs
@@ -1,0 +1,120 @@
+namespace FinanceSentry.Infrastructure.Observability.Hangfire;
+
+using System.Security.Cryptography;
+using System.Text;
+using FinanceSentry.Core.Interfaces;
+using global::Hangfire.States;
+using global::Hangfire.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Raises a single Telegram-bound alert when a scheduled job hits N consecutive terminal failures (US4 /
+/// FR-009), closing the silent-outage gap (the 636-consecutive-failure incident). Reuses the
+/// Alerts→Companion→Telegram path proven by <c>ConsentExpiring</c>.
+///
+/// Implemented as an <see cref="IApplyStateFilter"/> so it observes the *final* applied state: while a job
+/// still has retries left the applied state is <c>Scheduled</c>, so a <c>FailedState</c> here is terminal.
+/// Transient errors (throttling, network) don't count toward the streak; a later <c>Succeeded</c> resets
+/// it so the next failure can re-alert. Alert dispatch is fire-and-forget — a dispatch failure never
+/// breaks the job (US4-AS3).
+/// </summary>
+public sealed class ConsecutiveFailureAlertFilter(
+    IServiceProvider serviceProvider,
+    IJobFailureStreakStore store,
+    int threshold) : IApplyStateFilter
+{
+    private const int MaxErrorLength = 200;
+
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly IJobFailureStreakStore _store = store;
+    private readonly int _threshold = threshold < 1 ? 1 : threshold;
+
+    public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
+    {
+        var job = JobMetricsFilter.JobName(context.BackgroundJob?.Job);
+
+        switch (context.NewState)
+        {
+            case SucceededState:
+                RecordOutcome(job, succeeded: true, error: null);
+                break;
+            case FailedState failed:
+                RecordOutcome(job, succeeded: false, error: failed.Exception);
+                break;
+        }
+    }
+
+    public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
+    {
+        // No-op.
+    }
+
+    /// <summary>Core streak logic (public for unit testing). Never throws.</summary>
+    public void RecordOutcome(string jobName, bool succeeded, Exception? error)
+    {
+        if (succeeded)
+        {
+            var current = _store.Get(jobName);
+            if (current.Count != 0 || current.Alerted)
+                _store.Set(jobName, JobFailureStreak.Empty);
+            return;
+        }
+
+        // Transient/self-healing failures don't count toward the streak.
+        if (JobFailureTransientClassifier.IsTransient(error))
+            return;
+
+        var streak = _store.Get(jobName);
+        var count = streak.Count + 1;
+        var alerted = streak.Alerted;
+
+        if (count >= _threshold && !alerted)
+            alerted = TryRaiseAlert(jobName, count, error);
+
+        _store.Set(jobName, new JobFailureStreak(count, alerted));
+    }
+
+    // Returns true when the alert was raised without error, so a failed dispatch retries on the next
+    // failure instead of being silently swallowed for the whole streak.
+    private bool TryRaiseAlert(string jobName, int count, Exception? error)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var users = scope.ServiceProvider.GetRequiredService<IBankingTotalsReader>();
+            var generator = scope.ServiceProvider.GetRequiredService<IAlertGeneratorService>();
+
+            var referenceId = JobReferenceId(jobName);
+            var lastError = Summarize(error);
+
+            var userIds = users.GetActiveUserIdsAsync().GetAwaiter().GetResult();
+            foreach (var userId in userIds)
+            {
+                generator.GenerateJobFailureAlertAsync(userId, referenceId, jobName, count, lastError)
+                    .GetAwaiter().GetResult();
+            }
+
+            return true;
+        }
+        catch
+        {
+            // Fire-and-forget: alerting must never break job processing.
+            return false;
+        }
+    }
+
+    /// <summary>Deterministic per-job id so alert dedup/resolve stays stable across runs.</summary>
+    internal static Guid JobReferenceId(string jobName)
+    {
+        var bytes = MD5.HashData(Encoding.UTF8.GetBytes($"jobfailure:{jobName}"));
+        return new Guid(bytes);
+    }
+
+    private static string? Summarize(Exception? error)
+    {
+        if (error is null)
+            return null;
+        var message = error.Message;
+        return message.Length <= MaxErrorLength ? message : message[..MaxErrorLength];
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/DashboardAuthorizationFilter.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/DashboardAuthorizationFilter.cs
@@ -1,0 +1,35 @@
+namespace FinanceSentry.Infrastructure.Observability.Hangfire;
+
+using System.Net;
+using System.Net.Sockets;
+using global::Hangfire.Dashboard;
+
+/// <summary>
+/// Production Hangfire dashboard authorization (FR-004). Allows only requests arriving over loopback
+/// (the Tailscale-serve reverse proxy terminates on localhost) or directly from the Tailscale CGNAT
+/// range (100.64.0.0/10). Every other origin — including anything reaching the app publicly — is denied,
+/// so the dashboard is never served to an unauthenticated public caller.
+/// </summary>
+public sealed class DashboardAuthorizationFilter : IDashboardAuthorizationFilter
+{
+    public bool Authorize(DashboardContext context)
+    {
+        // DashboardRequest.RemoteIpAddress avoids a Hangfire.AspNetCore dependency in this infra project.
+        if (!IPAddress.TryParse(context.Request.RemoteIpAddress, out var remote))
+            return false;
+
+        return IPAddress.IsLoopback(remote) || IsTailscale(remote);
+    }
+
+    private static bool IsTailscale(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+            address = address.MapToIPv4();
+        if (address.AddressFamily != AddressFamily.InterNetwork)
+            return false;
+
+        // Tailscale assigns tailnet addresses from the 100.64.0.0/10 CGNAT block.
+        var bytes = address.GetAddressBytes();
+        return bytes[0] == 100 && (bytes[1] & 0xC0) == 0x40;
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobFailureStreakStore.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobFailureStreakStore.cs
@@ -1,0 +1,53 @@
+namespace FinanceSentry.Infrastructure.Observability.Hangfire;
+
+using global::Hangfire;
+
+/// <summary>Per-job consecutive-failure streak state (US4).</summary>
+public readonly record struct JobFailureStreak(int Count, bool Alerted)
+{
+    public static readonly JobFailureStreak Empty = new(0, false);
+}
+
+/// <summary>
+/// Durable store for the per-job consecutive-failure streak so a restart doesn't reset a live streak
+/// (data-model US4). Keyed by job name.
+/// </summary>
+public interface IJobFailureStreakStore
+{
+    JobFailureStreak Get(string jobName);
+
+    void Set(string jobName, JobFailureStreak streak);
+}
+
+/// <summary>
+/// Backs the streak state with Hangfire's own storage (a hash per job), so it lives in the same durable
+/// PostgreSQL store as the jobs themselves — no extra app table/migration.
+/// </summary>
+public sealed class HangfireJobFailureStreakStore : IJobFailureStreakStore
+{
+    private const string KeyPrefix = "finance:jobfailure:";
+    private const string CountField = "count";
+    private const string AlertedField = "alerted";
+
+    public JobFailureStreak Get(string jobName)
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        var hash = connection.GetAllEntriesFromHash(KeyPrefix + jobName);
+        if (hash is null || hash.Count == 0)
+            return JobFailureStreak.Empty;
+
+        var count = hash.TryGetValue(CountField, out var c) && int.TryParse(c, out var parsed) ? parsed : 0;
+        var alerted = hash.TryGetValue(AlertedField, out var a) && bool.TryParse(a, out var flag) && flag;
+        return new JobFailureStreak(count, alerted);
+    }
+
+    public void Set(string jobName, JobFailureStreak streak)
+    {
+        using var connection = JobStorage.Current.GetConnection();
+        connection.SetRangeInHash(KeyPrefix + jobName, new Dictionary<string, string>
+        {
+            [CountField] = streak.Count.ToString(),
+            [AlertedField] = streak.Alerted.ToString(),
+        });
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobFailureTransientClassifier.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobFailureTransientClassifier.cs
@@ -1,0 +1,29 @@
+namespace FinanceSentry.Infrastructure.Observability.Hangfire;
+
+using System.Net.Http;
+using System.Net.Sockets;
+using FinanceSentry.Infrastructure.Retry;
+
+/// <summary>
+/// Classifies a failed job's exception as transient/self-healing (US4) so throttling and network blips
+/// don't count toward a consecutive-failure streak — mirroring the sync layer's transient set
+/// (timeout / rate-limit / 5xx / network) so only genuine, sticky failures alert.
+/// </summary>
+public static class JobFailureTransientClassifier
+{
+    public static bool IsTransient(Exception? exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is TimeoutException or TaskCanceledException or OperationCanceledException or SocketException)
+                return true;
+
+            if (current is HttpRequestException http
+                && http.StatusCode is { } status
+                && RetryPolicies.IsTransientHttpError(status))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobMetricsFilter.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/Hangfire/JobMetricsFilter.cs
@@ -1,0 +1,49 @@
+namespace FinanceSentry.Infrastructure.Observability.Hangfire;
+
+using global::Hangfire.Common;
+using global::Hangfire.States;
+using global::Hangfire.Storage;
+
+/// <summary>
+/// Hangfire state filter (FR-002): records per-job outcome and duration into <see cref="JobMetrics"/>
+/// as each job reaches a terminal state. Registered globally via the Hangfire configuration.
+///
+/// <c>FailedState</c> is only reached after all automatic retries are exhausted, so it represents a
+/// terminal failure — the same semantics the consecutive-failure alerting relies on.
+/// </summary>
+public sealed class JobMetricsFilter(JobMetrics metrics) : IApplyStateFilter
+{
+    private const double MillisecondsPerSecond = 1000.0;
+
+    private readonly JobMetrics _metrics = metrics;
+
+    public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
+    {
+        var job = JobName(context.BackgroundJob?.Job);
+
+        switch (context.NewState)
+        {
+            case SucceededState succeeded:
+                _metrics.RecordSuccess(job, succeeded.PerformanceDuration / MillisecondsPerSecond);
+                break;
+            case FailedState:
+                // Duration is intentionally omitted for failures (no reliable processing-start here);
+                // the histogram stays meaningful from succeeded runs, the counter captures the failure.
+                _metrics.RecordFailure(job, -1);
+                break;
+        }
+    }
+
+    public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction)
+    {
+        // No-op: we only record on entry to a terminal state.
+    }
+
+    /// <summary>Stable, bounded-cardinality job label — the declaring type + method (no arguments).</summary>
+    internal static string JobName(Job? job)
+    {
+        if (job?.Type is null || job.Method is null)
+            return "unknown";
+        return $"{job.Type.Name}.{job.Method.Name}";
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/HealthChecks/ReadinessResponseWriter.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/HealthChecks/ReadinessResponseWriter.cs
@@ -1,0 +1,33 @@
+namespace FinanceSentry.Infrastructure.Observability.HealthChecks;
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Renders the readiness report as the contract JSON:
+/// <c>{ "status":"Healthy", "checks":[{ "name":"database","status":"Healthy" }, ... ] }</c>.
+/// Each entry's <c>name</c> is the registered health-check name (e.g. <c>database</c>, <c>hangfire</c>),
+/// so a failing dependency is named in the body (feeds the SC-003 availability panel).
+/// </summary>
+public static class ReadinessResponseWriter
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public static Task WriteAsync(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var payload = new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(entry => new
+            {
+                name = entry.Key,
+                status = entry.Value.Status.ToString(),
+            }),
+        };
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, Options));
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/JobMetrics.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/JobMetrics.cs
@@ -1,0 +1,87 @@
+namespace FinanceSentry.Infrastructure.Observability;
+
+using System.Diagnostics.Metrics;
+using global::Hangfire;
+
+/// <summary>
+/// Custom metrics for the scheduled-job fleet (FR-002). Registered as a singleton and shared with the
+/// Hangfire <c>JobMetricsFilter</c>; the OpenTelemetry meter provider subscribes to <see cref="MeterName"/>
+/// and the Prometheus exporter renders these at <c>/metrics</c>.
+///
+/// Labels are deliberately bounded to the job name only — no per-user/account/PII dimensions (FR-007).
+/// </summary>
+public sealed class JobMetrics : IDisposable
+{
+    /// <summary>OpenTelemetry meter name; must be registered via <c>AddMeter(JobMetrics.MeterName)</c>.</summary>
+    public const string MeterName = "FinanceSentry.Jobs";
+
+    private const string DefaultQueue = "default";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _succeeded;
+    private readonly Counter<long> _failed;
+    private readonly Histogram<double> _duration;
+
+    public JobMetrics()
+    {
+        _meter = new Meter(MeterName);
+
+        // No unit on the counters so the Prometheus exporter renders clean *_total names.
+        _succeeded = _meter.CreateCounter<long>(
+            "finance_jobs_succeeded",
+            description: "Scheduled-job runs that reached the Succeeded state.");
+        _failed = _meter.CreateCounter<long>(
+            "finance_jobs_failed",
+            description: "Scheduled-job runs that reached the terminal Failed state.");
+        _duration = _meter.CreateHistogram<double>(
+            "finance_job_duration",
+            unit: "s",
+            description: "Wall-clock duration of a scheduled-job run to its terminal state.");
+
+        _meter.CreateObservableGauge(
+            "finance_jobs_scheduled",
+            ObserveScheduled,
+            description: "Jobs currently enqueued or scheduled and awaiting execution.");
+    }
+
+    /// <summary>Records a job that reached <c>Succeeded</c>.</summary>
+    public void RecordSuccess(string job, double durationSeconds)
+    {
+        var tag = new KeyValuePair<string, object?>("job", job);
+        _succeeded.Add(1, tag);
+        if (durationSeconds >= 0)
+            _duration.Record(durationSeconds, tag);
+    }
+
+    /// <summary>Records a job that reached the terminal <c>Failed</c> state.</summary>
+    public void RecordFailure(string job, double durationSeconds)
+    {
+        var tag = new KeyValuePair<string, object?>("job", job);
+        _failed.Add(1, tag);
+        if (durationSeconds >= 0)
+            _duration.Record(durationSeconds, tag);
+    }
+
+    private static IEnumerable<Measurement<long>> ObserveScheduled()
+    {
+        yield return new Measurement<long>(SafeScheduledCount());
+    }
+
+    // Reads Hangfire's own counts defensively — storage may not be configured yet during startup/tests.
+    private static long SafeScheduledCount()
+    {
+        try
+        {
+            var monitor = JobStorage.Current?.GetMonitoringApi();
+            if (monitor is null)
+                return 0;
+            return monitor.EnqueuedCount(DefaultQueue) + monitor.ScheduledCount();
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/ModuleEnricher.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/ModuleEnricher.cs
@@ -1,0 +1,46 @@
+namespace FinanceSentry.Infrastructure.Observability;
+
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// Adds a bounded <c>module</c> property derived from <c>SourceContext</c> so logs can be filtered by
+/// coarse module in Loki/Grafana (US2) without promoting the full, high-cardinality type name as a label.
+/// e.g. <c>FinanceSentry.Modules.BankSync.Foo</c> → <c>BankSync</c>; <c>FinanceSentry.API.*</c> → <c>API</c>.
+/// </summary>
+public sealed class ModuleEnricher : ILogEventEnricher
+{
+    private const string ModulesMarker = "FinanceSentry.Modules.";
+    private const string RootMarker = "FinanceSentry.";
+    private const string Fallback = "app";
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (logEvent.Properties.ContainsKey("module"))
+            return;
+
+        var module = Fallback;
+        if (logEvent.Properties.TryGetValue("SourceContext", out var value)
+            && value is ScalarValue { Value: string sourceContext })
+        {
+            module = DeriveModule(sourceContext);
+        }
+
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("module", module));
+    }
+
+    private static string DeriveModule(string sourceContext)
+    {
+        if (sourceContext.StartsWith(ModulesMarker, StringComparison.Ordinal))
+            return FirstSegment(sourceContext[ModulesMarker.Length..]);
+        if (sourceContext.StartsWith(RootMarker, StringComparison.Ordinal))
+            return FirstSegment(sourceContext[RootMarker.Length..]);
+        return Fallback;
+    }
+
+    private static string FirstSegment(string value)
+    {
+        var dot = value.IndexOf('.', StringComparison.Ordinal);
+        return dot < 0 ? value : value[..dot];
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/OpenTelemetryConfiguration.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/OpenTelemetryConfiguration.cs
@@ -1,0 +1,41 @@
+namespace FinanceSentry.Infrastructure.Observability;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+
+/// <summary>
+/// Wires OpenTelemetry metrics (FR-001/002): ASP.NET Core request instrumentation, .NET runtime
+/// instrumentation, the custom job <see cref="JobMetrics"/> meter, and the Prometheus exporter served
+/// at <c>/metrics</c>. HTTP labels use route templates (not raw URLs) so cardinality stays bounded
+/// (FR-007); the endpoint is intended to be reachable only over the compose network / Tailscale (FR-006).
+/// </summary>
+public static class OpenTelemetryConfiguration
+{
+    private const string ServiceName = "finance-sentry";
+
+    public static IServiceCollection AddObservabilityMetrics(this IServiceCollection services)
+    {
+        // Shared singleton: the Hangfire JobMetricsFilter and the meter provider observe the same instruments.
+        services.AddSingleton<JobMetrics>();
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(ServiceName))
+            .WithMetrics(metrics => metrics
+                .AddAspNetCoreInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddMeter(JobMetrics.MeterName)
+                .AddPrometheusExporter());
+
+        return services;
+    }
+
+    /// <summary>Serves Prometheus exposition at <c>/metrics</c> (the exporter's default path).</summary>
+    public static IEndpointRouteBuilder MapObservabilityMetricsEndpoint(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPrometheusScrapingEndpoint();
+        return endpoints;
+    }
+}

--- a/backend/src/FinanceSentry.Infrastructure/Observability/SerilogConfiguration.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/SerilogConfiguration.cs
@@ -37,8 +37,12 @@ public static class SerilogConfiguration
         var lokiUrl = configuration[LokiUrlConfigKey];
         if (!string.IsNullOrWhiteSpace(lokiUrl))
         {
+            // JSON payload so structured properties (CorrelationId, SourceContext, …) are searchable in
+            // Loki via `| json` (SC-002 correlation-id grouping); only app/module/level become labels so
+            // cardinality stays bounded (FR-007).
             loggerConfiguration.WriteTo.GrafanaLoki(
                 lokiUrl,
+                textFormatter: new LokiJsonTextFormatter(),
                 labels: [new LokiLabel { Key = "app", Value = AppName }],
                 propertiesAsLabels: ["module", "level"]);
         }

--- a/backend/src/FinanceSentry.Infrastructure/Observability/SerilogConfiguration.cs
+++ b/backend/src/FinanceSentry.Infrastructure/Observability/SerilogConfiguration.cs
@@ -1,0 +1,46 @@
+namespace FinanceSentry.Infrastructure.Observability;
+
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.Grafana.Loki;
+
+/// <summary>
+/// Central Serilog setup (FR-003/011). Keeps the existing console + rolling-file sinks, suppresses the
+/// EF Core <c>Database.Command</c> SQL flood that made grep-based triage slow (FR-011, override-able via
+/// config), enriches every event with a bounded <c>module</c> + <c>app</c>, and — when a Loki URL is
+/// configured — ships structured logs to Loki via the batched sink (fire-and-forget: shipping failures
+/// are swallowed by the sink and never affect request handling, FR-003).
+/// </summary>
+public static class SerilogConfiguration
+{
+    private const string AppName = "finance-sentry";
+    private const string LokiUrlConfigKey = "Observability:Loki:Url";
+
+    /// <summary>Matches the <c>UseSerilog</c> host callback signature.</summary>
+    public static void Configure(HostBuilderContext context, LoggerConfiguration loggerConfiguration)
+    {
+        var configuration = context.Configuration;
+
+        loggerConfiguration
+            .ReadFrom.Configuration(configuration)
+            // EF SQL is the noise that slowed incident triage — keep it at Warning by default; a
+            // Serilog:MinimumLevel:Override in config can raise it back to Debug without a code change.
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+            .Enrich.FromLogContext()
+            .Enrich.With<ModuleEnricher>()
+            .Enrich.WithProperty("app", AppName)
+            .WriteTo.Console()
+            .WriteTo.File("logs/app-.txt", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 14);
+
+        var lokiUrl = configuration[LokiUrlConfigKey];
+        if (!string.IsNullOrWhiteSpace(lokiUrl))
+        {
+            loggerConfiguration.WriteTo.GrafanaLoki(
+                lokiUrl,
+                labels: [new LokiLabel { Key = "app", Value = AppName }],
+                propertiesAsLabels: ["module", "level"]);
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Application/Services/AlertGeneratorService.cs
@@ -19,6 +19,9 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
     // Reminders repeat only every 3 days while inside the pre-expiry window, so the detector can run
     // daily without spamming the same connection.
     private static readonly TimeSpan ConsentExpiringSilenceWindow = TimeSpan.FromDays(3);
+    // Backstop only — the failure filter already guarantees one call per streak. Short enough that a
+    // genuine success-then-new-streak re-alerts, long enough to absorb an accidental double-call.
+    private static readonly TimeSpan JobFailureSilenceWindow = TimeSpan.FromMinutes(15);
 
     private readonly IAlertRepository _alerts = alerts;
 
@@ -273,6 +276,30 @@ public class AlertGeneratorService(IAlertRepository alerts) : IAlertGeneratorSer
             Message = $"Your {providerName} open-banking consent expires {window} ({expiresAt:yyyy-MM-dd}). Reconnect it to keep balances and transactions syncing.",
             ReferenceId = referenceId,
             ReferenceLabel = providerName,
+        }, ct);
+    }
+
+    public async Task GenerateJobFailureAlertAsync(
+        Guid userId, Guid referenceId, string jobName, int consecutiveCount, string? lastError,
+        CancellationToken ct = default)
+    {
+        // No FindActive gate here: each streak should produce a fresh alert row (a fresh Telegram
+        // message). The failure filter guarantees one call per streak; HasRecent is a light backstop.
+        var quietSince = DateTimeOffset.UtcNow - JobFailureSilenceWindow;
+        if (await _alerts.HasRecentAsync(userId, AlertType.JobFailure, referenceId, jobName, quietSince, ct))
+            return;
+
+        var detail = string.IsNullOrWhiteSpace(lastError) ? string.Empty : $" Last error: {lastError}";
+
+        await _alerts.AddAsync(new Alert
+        {
+            UserId = userId,
+            Type = AlertType.JobFailure,
+            Severity = AlertSeverity.Error,
+            Title = $"Job failing: {jobName}",
+            Message = $"Scheduled job '{jobName}' has failed {consecutiveCount} times in a row.{detail}",
+            ReferenceId = referenceId,
+            ReferenceLabel = jobName,
         }, ct);
     }
 

--- a/backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs
+++ b/backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs
@@ -10,4 +10,5 @@ public static class AlertType
     public const string PolicyViolation = "PolicyViolation";
     public const string Opportunity = "Opportunity";
     public const string ConsentExpiring = "ConsentExpiring";
+    public const string JobFailure = "JobFailure";
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/API/Middleware/JwtAuthenticationMiddleware.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/API/Middleware/JwtAuthenticationMiddleware.cs
@@ -24,6 +24,7 @@ public class JwtAuthenticationMiddleware
     [
         "/health",
         "/api/v1/health",
+        "/metrics",
         "/swagger",
         "/api/v1/webhook",
         "/hangfire",

--- a/backend/src/FinanceSentry.Modules.BankSync/FinanceSentry.Modules.BankSync.csproj
+++ b/backend/src/FinanceSentry.Modules.BankSync/FinanceSentry.Modules.BankSync.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Hangfire.Core" />
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Hangfire.InMemory" />
+    <PackageReference Include="Hangfire.PostgreSql" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs
@@ -2,21 +2,50 @@ namespace FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
 
 using Hangfire;
 using Hangfire.InMemory;
+using Hangfire.PostgreSql;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
 public static class HangfireSetup
 {
+    // Dedicated schema keeps Hangfire's tables out of the app's EF migrations (FR-010).
+    private const string HangfireSchema = "hangfire";
+
     public static IServiceCollection AddHangfireServices(
         this IServiceCollection services,
-        IConfiguration config)
+        IConfiguration config,
+        IHostEnvironment environment)
     {
         services.AddHangfire(cfg =>
-            cfg.UseInMemoryStorage(new InMemoryStorageOptions
+        {
+            // Tests run without a reachable database — keep them on in-memory storage so the host
+            // still boots. Every other environment uses durable PostgreSQL storage.
+            if (environment.IsEnvironment("Testing"))
             {
-                MaxExpirationTime = TimeSpan.FromHours(24)
-            }));
+                cfg.UseInMemoryStorage(new InMemoryStorageOptions
+                {
+                    MaxExpirationTime = TimeSpan.FromHours(24),
+                });
+                return;
+            }
+
+            // Durable job storage on the existing PostgreSQL so job history + recurring-job state
+            // survive restarts (FR-010) — the prerequisite for job-health trends (US3) and
+            // consecutive-failure tracking (US4). Replaces the in-memory storage that lost everything.
+            var connectionString = config.GetConnectionString("Default")
+                ?? throw new InvalidOperationException("Connection string 'Default' is required for Hangfire storage.");
+
+            cfg.UsePostgreSqlStorage(
+                options => options.UseNpgsqlConnection(connectionString),
+                new PostgreSqlStorageOptions
+                {
+                    SchemaName = HangfireSchema,
+                    PrepareSchemaIfNecessary = true,
+                    QueuePollInterval = TimeSpan.FromSeconds(15),
+                });
+        });
 
         services.AddHangfireServer(options =>
         {

--- a/backend/src/FinanceSentry.Modules.Companion/Application/Services/CompanionEventCapture.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Application/Services/CompanionEventCapture.cs
@@ -68,7 +68,7 @@ public sealed class CompanionEventCapture(
                 DedupKey = policy.AlertDedupKey(a.AlertId),
                 ReferenceId = a.ReferenceId ?? a.AlertId,
                 SourceModule = "alerts",
-                Disposition = policy.DispositionForMode(mode),
+                Disposition = policy.DispositionFor(mode, kind.Value),
                 OccurredAt = a.CreatedAt,
             };
 
@@ -129,7 +129,7 @@ public sealed class CompanionEventCapture(
                     DedupKey = policy.AnalystDedupKey(userId, a.ActionId),
                     ReferenceId = a.ActionId,
                     SourceModule = "research",
-                    Disposition = policy.DispositionForMode(mode),
+                    Disposition = policy.DispositionFor(mode, CompanionEventKind.AnalystAction),
                     OccurredAt = a.IngestedAt,
                 };
 

--- a/backend/src/FinanceSentry.Modules.Companion/Application/Services/IMaterialityPolicy.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Application/Services/IMaterialityPolicy.cs
@@ -14,6 +14,12 @@ public interface IMaterialityPolicy
     /// <summary>The disposition a freshly-captured event gets under the given mode.</summary>
     EventDisposition DispositionForMode(NotificationMode mode);
 
+    /// <summary>
+    /// Kind-aware disposition. Behaves like <see cref="DispositionForMode"/> except operational failures
+    /// carry elevated criticality — they are never suppressed purely by a quiet mode (US4).
+    /// </summary>
+    EventDisposition DispositionFor(NotificationMode mode, CompanionEventKind kind);
+
     string AlertDedupKey(Guid alertId);
 
     string AnalystDedupKey(Guid userId, Guid analystActionId);

--- a/backend/src/FinanceSentry.Modules.Companion/Application/Services/MaterialityPolicy.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Application/Services/MaterialityPolicy.cs
@@ -20,6 +20,7 @@ public sealed class MaterialityPolicy : IMaterialityPolicy
         "MarketStructure" => CompanionEventKind.MarketStructure,
         "LowBalance" => CompanionEventKind.LowBalance,
         "ConsentExpiring" => CompanionEventKind.ConsentExpiring,
+        "JobFailure" => CompanionEventKind.OperationalFailure,
         _ => null,
     };
 
@@ -31,6 +32,16 @@ public sealed class MaterialityPolicy : IMaterialityPolicy
         NotificationMode.Realtime => EventDisposition.Pending,
         _ => EventDisposition.Pending,
     };
+
+    public EventDisposition DispositionFor(NotificationMode mode, CompanionEventKind kind)
+    {
+        // Operational failures must reach the operator even under a quiet mode — surface instead of
+        // suppressing. Digest still batches them; the other modes already queue as pending.
+        if (kind == CompanionEventKind.OperationalFailure && mode == NotificationMode.Quiet)
+            return EventDisposition.Pending;
+
+        return DispositionForMode(mode);
+    }
 
     public string AlertDedupKey(Guid alertId) => $"alert:{alertId}";
 

--- a/backend/src/FinanceSentry.Modules.Companion/Domain/CompanionEventKind.cs
+++ b/backend/src/FinanceSentry.Modules.Companion/Domain/CompanionEventKind.cs
@@ -16,4 +16,5 @@ public enum CompanionEventKind
     LowBalance,
     AnalystAction,
     ConsentExpiring,
+    OperationalFailure,
 }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Opportunity/OpportunityFakes.cs
@@ -168,6 +168,7 @@ internal sealed class FakeOpportunityAlertGenerator : IAlertGeneratorService
     }
 
     public Task GenerateConsentExpiringAlertAsync(Guid userId, Guid referenceId, string providerName, DateTime expiresAt, CancellationToken ct = default) => Task.CompletedTask;
+    public Task GenerateJobFailureAlertAsync(Guid userId, Guid referenceId, string jobName, int consecutiveCount, string? lastError, CancellationToken ct = default) => Task.CompletedTask;
     public Task GenerateLowBalanceAlertAsync(Guid userId, Guid accountId, string accountName, decimal balance, decimal threshold, CancellationToken ct = default) => Task.CompletedTask;
     public Task ResolveLowBalanceAlertAsync(Guid userId, Guid accountId, CancellationToken ct = default) => Task.CompletedTask;
     public Task GenerateSyncFailureAlertAsync(Guid userId, string provider, Guid? accountId, string? accountName, string? errorCode, CancellationToken ct = default) => Task.CompletedTask;

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/ThesisMonitor/RunThesisMonitorHandlerTests.cs
@@ -279,6 +279,10 @@ public class RunThesisMonitorHandlerTests
             Guid userId, Guid referenceId, string providerName, DateTime expiresAt, CancellationToken ct = default)
             => Task.CompletedTask;
 
+        public Task GenerateJobFailureAlertAsync(
+            Guid userId, Guid referenceId, string jobName, int consecutiveCount, string? lastError, CancellationToken ct = default)
+            => Task.CompletedTask;
+
         public Task GenerateThesisBreakAlertAsync(
             Guid userId, Guid thesisId, string ticker, string reason, CancellationToken ct = default)
         {

--- a/backend/tests/FinanceSentry.Tests.Integration/Observability/HealthReadyTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/Observability/HealthReadyTests.cs
@@ -1,0 +1,57 @@
+namespace FinanceSentry.Tests.Integration.Observability;
+
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Contract tests for <c>GET /api/v1/health/ready</c> (T017, contracts §2). The readiness report names
+/// each dependency; with the database unreachable the overall status is 503 and the failing check is
+/// named. The all-Healthy → 200 path needs a live database and is validated in quickstart T021.
+/// </summary>
+public class HealthReadyTests : IClassFixture<ObservabilityApiFactory>
+{
+    private readonly ObservabilityApiFactory _factory;
+
+    public HealthReadyTests(ObservabilityApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Ready_ReportNamesDatabaseAndHangfireChecks()
+    {
+        var client = _factory.CreateClient();
+
+        // Read the body regardless of status — an unreachable DB makes the overall report unhealthy (503),
+        // but the per-dependency checks must still be named.
+        var response = await client.GetAsync("/api/v1/health/ready");
+        var json = await response.Content.ReadAsStringAsync();
+        var names = CheckNames(json);
+
+        names.Should().Contain("database");
+        names.Should().Contain("hangfire");
+    }
+
+    [Fact]
+    public async Task Ready_WhenDatabaseUnreachable_Returns503AndNamesDatabaseUnhealthy()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/v1/health/ready");
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var database = doc.RootElement.GetProperty("checks").EnumerateArray()
+            .Single(check => check.GetProperty("name").GetString() == "database");
+
+        database.GetProperty("status").GetString().Should().Be("Unhealthy");
+    }
+
+    private static List<string?> CheckNames(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("checks").EnumerateArray()
+            .Select(check => check.GetProperty("name").GetString())
+            .ToList();
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Integration/Observability/MetricsEndpointTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/Observability/MetricsEndpointTests.cs
@@ -1,0 +1,37 @@
+namespace FinanceSentry.Tests.Integration.Observability;
+
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Contract test for <c>GET /metrics</c> (T016, contracts §1): reachable without a JWT and its Prometheus
+/// exposition carries the custom <c>finance_jobs_*</c> series.
+/// </summary>
+public class MetricsEndpointTests : IClassFixture<ObservabilityApiFactory>
+{
+    private readonly ObservabilityApiFactory _factory;
+
+    public MetricsEndpointTests(ObservabilityApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Metrics_WithoutAuth_Returns200()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Metrics_Exposition_ContainsCustomJobMetrics()
+    {
+        var client = _factory.CreateClient();
+
+        var body = await client.GetStringAsync("/metrics");
+
+        // finance_jobs_scheduled is an observable gauge, so it appears even before any job runs.
+        body.Should().Contain("finance_jobs_");
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Integration/Observability/ObservabilityApiFactory.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/Observability/ObservabilityApiFactory.cs
@@ -1,0 +1,60 @@
+namespace FinanceSentry.Tests.Integration.Observability;
+
+using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// WebApplicationFactory for the observability contract tests. Runs under the <c>Testing</c> environment
+/// so Hangfire uses in-memory storage (no database required to boot); the <c>database</c> health check
+/// still points at an unreachable connection string, which the readiness tests rely on to exercise the
+/// unhealthy path. The fully-healthy readiness path is validated against the live stack in quickstart T021.
+/// </summary>
+public class ObservabilityApiFactory : WebApplicationFactory<Program>
+{
+    private static readonly InMemoryDatabaseRoot BankSyncDbRoot = new();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            ReplaceWithInMemory<BankSyncDbContext>(services, "observability-banksync", BankSyncDbRoot);
+        });
+
+        builder.UseEnvironment("Testing");
+        builder.UseSetting("ConnectionStrings:Default",
+            "Host=localhost;Port=5432;Database=unreachable;Username=test;Password=test;Timeout=1;Command Timeout=1");
+        builder.UseSetting("Deduplication:MasterKeyBase64",
+            "dGVzdGtleS10ZXN0a2V5LXRlc3RrZXktdGVzdGtleTA=");
+        builder.UseSetting("Encryption:CurrentKeyVersion", "1");
+        builder.UseSetting("Encryption:Keys:1",
+            "dGVzdGtleS10ZXN0a2V5LXRlc3RrZXktdGVzdGtleTA=");
+        builder.UseSetting("Plaid:ClientId", "test-client-id");
+        builder.UseSetting("Plaid:Secret", "test-secret");
+        builder.UseSetting("Jwt:Secret",
+            "test-jwt-secret-key-for-integration-tests-minimum-32-chars");
+        builder.UseSetting("GoogleOAuth:ClientId", "test-client-id");
+    }
+
+    private static void ReplaceWithInMemory<TContext>(
+        IServiceCollection services,
+        string dbName,
+        InMemoryDatabaseRoot root)
+        where TContext : DbContext
+    {
+        var toRemove = services
+            .Where(d => d.ServiceType == typeof(DbContextOptions<TContext>)
+                     || d.ServiceType == typeof(TContext)
+                     || d.ServiceType == typeof(IDbContextOptionsConfiguration<TContext>))
+            .ToList();
+        foreach (var d in toRemove)
+            services.Remove(d);
+
+        services.AddDbContext<TContext>(options =>
+            options.UseInMemoryDatabase(dbName, root));
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/Observability/ConsecutiveFailureAlertFilterTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Observability/ConsecutiveFailureAlertFilterTests.cs
@@ -1,0 +1,128 @@
+namespace FinanceSentry.Tests.Unit.Observability;
+
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Infrastructure.Observability.Hangfire;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for the consecutive-failure streak logic (T029, contracts §4): one alert on the Nth
+/// terminal failure, none before it, reset-on-success then re-alert, transient errors excluded, and
+/// fire-and-forget dispatch that never throws into the job.
+/// </summary>
+public class ConsecutiveFailureAlertFilterTests
+{
+    private const int Threshold = 3;
+    private const string Job = "SyncScheduler.ScheduleAllActiveAccounts";
+
+    private readonly Mock<IAlertGeneratorService> _generator = new();
+    private readonly Mock<IBankingTotalsReader> _banking = new();
+    private readonly InMemoryStreakStore _store = new();
+
+    public ConsecutiveFailureAlertFilterTests()
+    {
+        _banking
+            .Setup(b => b.GetActiveUserIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<Guid>)[Guid.NewGuid()]);
+    }
+
+    [Fact]
+    public void NthConsecutiveFailure_RaisesExactlyOneAlertWithCount()
+    {
+        var filter = Build();
+
+        Fail(filter, times: Threshold);
+
+        _generator.Verify(g => g.GenerateJobFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), Job, Threshold, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Further failures in the same streak must not re-alert.
+        Fail(filter, times: 2);
+        _generator.Verify(g => g.GenerateJobFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void FailuresBelowThreshold_RaiseNoAlert()
+    {
+        var filter = Build();
+
+        Fail(filter, times: Threshold - 1);
+
+        _generator.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public void SuccessResetsStreak_ThenNextStreakReAlerts()
+    {
+        var filter = Build();
+
+        Fail(filter, times: Threshold);
+        filter.RecordOutcome(Job, succeeded: true, error: null);
+        Fail(filter, times: Threshold);
+
+        _generator.Verify(g => g.GenerateJobFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), Job, Threshold, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public void TransientFailures_DoNotIncrementStreak()
+    {
+        var filter = Build();
+
+        for (var i = 0; i < Threshold + 2; i++)
+            filter.RecordOutcome(Job, succeeded: false, error: new TimeoutException());
+
+        _generator.VerifyNoOtherCalls();
+        _store.Get(Job).Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void GeneratorThrow_DoesNotPropagate_AndLeavesStreakOpenToRetry()
+    {
+        _generator
+            .Setup(g => g.GenerateJobFailureAlertAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("alert store down"));
+        var filter = Build();
+
+        var act = () => Fail(filter, times: Threshold);
+
+        act.Should().NotThrow();
+        // Dispatch failed, so the streak stays un-alerted and the next failure re-attempts.
+        _store.Get(Job).Alerted.Should().BeFalse();
+        filter.RecordOutcome(Job, succeeded: false, error: new Exception("boom"));
+        _generator.Verify(g => g.GenerateJobFailureAlertAsync(
+            It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+    }
+
+    private ConsecutiveFailureAlertFilter Build()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_banking.Object);
+        services.AddSingleton(_generator.Object);
+        return new ConsecutiveFailureAlertFilter(services.BuildServiceProvider(), _store, Threshold);
+    }
+
+    private static void Fail(ConsecutiveFailureAlertFilter filter, int times)
+    {
+        for (var i = 0; i < times; i++)
+            filter.RecordOutcome(Job, succeeded: false, error: new Exception("boom"));
+    }
+
+    private sealed class InMemoryStreakStore : IJobFailureStreakStore
+    {
+        private readonly Dictionary<string, JobFailureStreak> _map = [];
+
+        public JobFailureStreak Get(string jobName)
+            => _map.TryGetValue(jobName, out var streak) ? streak : JobFailureStreak.Empty;
+
+        public void Set(string jobName, JobFailureStreak streak) => _map[jobName] = streak;
+    }
+}

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -50,6 +50,8 @@ services:
       Jwt__Issuer: "https://finance-sentry.local"
       Deduplication__MasterKeyBase64: dGVzdC1kZWR1cGxpY2F0aW9uLWtleS1jaGFuZ2UtaW4tcHJvZHVjdGlvbg==
       GOOGLEOAUTH__CLIENTID: "${GOOGLE_CLIENT_ID:-}"
+      # Ship structured logs to Loki (fire-and-forget); empty disables the sink.
+      Observability__Loki__Url: http://loki:3100
     ports:
       - "5001:5000"
     depends_on:
@@ -109,8 +111,65 @@ services:
       timeout: 5s
       retries: 5
 
+  # --- Observability stack (023) -------------------------------------------------
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: finance-sentry-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    networks:
+      - finance-sentry-network
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: finance-sentry-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=30d
+      - --storage.tsdb.retention.size=5GB
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      - api
+    networks:
+      - finance-sentry-network
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: finance-sentry-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - finance-sentry-network
+
 volumes:
   postgres_data:
+    driver: local
+  loki_data:
+    driver: local
+  prometheus_data:
+    driver: local
+  grafana_data:
     driver: local
 
 networks:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -49,6 +49,8 @@ services:
       # console, then set PUBLIC_API_BASE_URL=https://lifekit-vps.tail1cb676.ts.net:5001 here.
       PublicApiBaseUrl: ${PUBLIC_API_BASE_URL:-http://localhost:5001}
       TrueLayer__Scopes: "info accounts balance transactions cards offline_access"
+      # Ship structured logs to Loki (fire-and-forget); empty disables the sink.
+      Observability__Loki__Url: ${OBSERVABILITY_LOKI_URL:-http://loki:3100}
     ports:
       - "127.0.0.1:${API_PORT:-5001}:5000"
     depends_on:
@@ -141,9 +143,73 @@ services:
       driver: json-file
       options: { max-size: "10m", max-file: "3" }
 
+  # --- Observability stack (023) — bound to loopback; fronted by Tailscale Serve --------------------
+  loki:
+    image: grafana/loki:3.1.1
+    container_name: finance-sentry-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    ports:
+      - "127.0.0.1:${LOKI_PORT:-3100}:3100"
+    volumes:
+      - ./observability/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    networks:
+      - finance-sentry
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: finance-sentry-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=30d
+      - --storage.tsdb.retention.size=5GB
+    ports:
+      - "127.0.0.1:${PROMETHEUS_PORT:-9090}:9090"
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      - api
+    networks:
+      - finance-sentry
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: finance-sentry-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-}
+    ports:
+      - "127.0.0.1:${GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - finance-sentry
+    logging:
+      driver: json-file
+      options: { max-size: "10m", max-file: "3" }
+
 volumes:
   postgres_data:
   api_logs:
+  loki_data:
+  prometheus_data:
+  grafana_data:
 
 networks:
   finance-sentry:

--- a/docker/observability/grafana/provisioning/dashboards/api-overview.json
+++ b/docker/observability/grafana/provisioning/dashboards/api-overview.json
@@ -1,0 +1,130 @@
+{
+  "uid": "fs-api-overview",
+  "title": "Finance Sentry · Health at a glance",
+  "tags": ["finance-sentry", "us1"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": { "list": [] },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "API availability",
+      "description": "Prometheus scrape target up/down. Goes red within one scrape (~15s) of an API outage (SC-003).",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "max(up{job=\"finance-sentry-api\"})", "instant": true }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Request rate (req/s)",
+      "gridPos": { "h": 6, "w": 9, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(http_server_request_duration_seconds_count[5m]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "5xx error rate (req/s)",
+      "gridPos": { "h": 6, "w": 9, "x": 15, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 3, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.1 } ] } }, "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Request latency (p50 / p95 / p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "legendFormat": "p50", "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))" },
+        { "refId": "B", "legendFormat": "p95", "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))" },
+        { "refId": "C", "legendFormat": "p99", "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Error rate by class (4xx / 5xx)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "legendFormat": "4xx", "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"4..\"}[5m]))" },
+        { "refId": "B", "legendFormat": "5xx", "expr": "sum(rate(http_server_request_duration_seconds_count{http_response_status_code=~\"5..\"}[5m]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Scheduled jobs — last 24h (per job)",
+      "description": "Per-job success/failure counts and average duration from finance_jobs_* (FR-002). Exact last-run timestamps live in the Hangfire dashboard.",
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "format": "table", "instant": true, "legendFormat": "succeeded", "expr": "sum by (job) (increase(finance_jobs_succeeded_total[24h]))" },
+        { "refId": "B", "format": "table", "instant": true, "legendFormat": "failed", "expr": "sum by (job) (increase(finance_jobs_failed_total[24h]))" },
+        { "refId": "C", "format": "table", "instant": true, "legendFormat": "avg duration", "expr": "sum by (job) (rate(finance_job_duration_seconds_sum[24h])) / sum by (job) (rate(finance_job_duration_seconds_count[24h]))" }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        { "id": "organize", "options": { "renameByName": { "Value #A": "Succeeded", "Value #B": "Failed", "Value #C": "Avg duration (s)", "job": "Job" }, "excludeByName": { "Time": true } } }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Failed" }, "properties": [ { "id": "custom.cellOptions", "value": { "type": "color-background" } }, { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } ] }
+        ]
+      },
+      "options": { "showHeader": true }
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Jobs failed (24h)",
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "sum(increase(finance_jobs_failed_total[24h]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,14 @@
+# Dashboards-as-code provider (FR-004, D9) — loads every JSON in this folder on startup.
+apiVersion: 1
+
+providers:
+  - name: finance-sentry
+    orgId: 1
+    folder: Finance Sentry
+    type: file
+    disableDeletion: false
+    editable: true
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/docker/observability/grafana/provisioning/dashboards/job-health.json
+++ b/docker/observability/grafana/provisioning/dashboards/job-health.json
@@ -1,0 +1,101 @@
+{
+  "uid": "fs-job-health",
+  "title": "Finance Sentry · Job health & trends",
+  "tags": ["finance-sentry", "us3"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-7d", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "label": "Job",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(finance_jobs_succeeded_total, job)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      }
+    ]
+  },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Failures per job (over time)",
+      "description": "Per-job failure count from finance_jobs_failed_total (FR-002). Trends persist across API restarts via Prometheus TSDB even though the in-process counter resets (rate/increase handle resets).",
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "legendFormat": "{{job}}", "expr": "sum by (job) (increase(finance_jobs_failed_total{job=~\"$job\"}[$__rate_interval]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 70, "stacking": { "mode": "normal" } }, "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Successes per job (over time)",
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "legendFormat": "{{job}}", "expr": "sum by (job) (increase(finance_jobs_succeeded_total{job=~\"$job\"}[$__rate_interval]))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 40, "stacking": { "mode": "normal" } }, "color": { "mode": "palette-classic" } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Job duration p95 (s)",
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "legendFormat": "{{job}}", "expr": "histogram_quantile(0.95, sum by (job, le) (rate(finance_job_duration_seconds_bucket{job=~\"$job\"}[$__rate_interval])))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Per-job totals over selected range",
+      "gridPos": { "h": 10, "w": 16, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "format": "table", "instant": true, "expr": "sum by (job) (increase(finance_jobs_succeeded_total{job=~\"$job\"}[$__range]))" },
+        { "refId": "B", "format": "table", "instant": true, "expr": "sum by (job) (increase(finance_jobs_failed_total{job=~\"$job\"}[$__range]))" },
+        { "refId": "C", "format": "table", "instant": true, "expr": "sum by (job) (rate(finance_job_duration_seconds_sum{job=~\"$job\"}[$__range])) / sum by (job) (rate(finance_job_duration_seconds_count{job=~\"$job\"}[$__range]))" }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        { "id": "organize", "options": { "renameByName": { "Value #A": "Succeeded", "Value #B": "Failed", "Value #C": "Avg duration (s)", "job": "Job" }, "excludeByName": { "Time": true } } }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Failed" }, "properties": [ { "id": "custom.cellOptions", "value": { "type": "color-background" } }, { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } } ] }
+        ]
+      },
+      "options": { "showHeader": true }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Currently scheduled / enqueued",
+      "gridPos": { "h": 10, "w": 8, "x": 16, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "max(finance_jobs_scheduled)" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } }, "overrides": [] },
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/dashboards/logs.json
+++ b/docker/observability/grafana/provisioning/dashboards/logs.json
@@ -1,0 +1,87 @@
+{
+  "uid": "fs-logs",
+  "title": "Finance Sentry · Logs",
+  "tags": ["finance-sentry", "us2"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "module",
+        "label": "Module",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values({app=\"finance-sentry\"}, module)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      },
+      {
+        "name": "level",
+        "label": "Level",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "loki" },
+        "query": "label_values({app=\"finance-sentry\"}, level)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
+      },
+      {
+        "name": "search",
+        "label": "Free text",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      },
+      {
+        "name": "correlationId",
+        "label": "Correlation id",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "annotations": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Log volume by level",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (level) (count_over_time({app=\"finance-sentry\", module=~\"$module\"}[$__auto]))", "legendFormat": "{{level}}" }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 2,
+      "type": "logs",
+      "title": "Logs — filter by module / level, free text, correlation id",
+      "description": "Structured app logs from Loki (US2). EF Core SQL is suppressed at the default level (FR-011); paste a correlation id to group one request's entries (SC-002).",
+      "gridPos": { "h": 20, "w": 24, "x": 0, "y": 7 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        { "refId": "A", "expr": "{app=\"finance-sentry\", module=~\"$module\", level=~\"$level\"} |~ \"(?i)$search\" |~ \"$correlationId\"" }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/docker/observability/grafana/provisioning/datasources/datasources.yml
+++ b/docker/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,18 @@
+# Provisioned datasources (FR-004) — survive Grafana container recreation.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/docker/observability/loki/loki-config.yml
+++ b/docker/observability/loki/loki-config.yml
@@ -1,0 +1,42 @@
+# Loki single-binary, filesystem storage (FR-005). ~14d retention enforced by the compactor plus a
+# per-stream ingestion cap so log volume can't take down the VPS (SC-004).
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 336h        # 14 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+  max_streams_per_user: 5000
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/docker/observability/prometheus/prometheus.yml
+++ b/docker/observability/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+# Prometheus scrape config (FR-005). Retention (~30d) + hard size cap are set via CLI flags on the
+# prometheus service in docker-compose (--storage.tsdb.retention.time / .size).
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: finance-sentry-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:5000']

--- a/specs/023-observability-stack/contracts/observability-contracts.md
+++ b/specs/023-observability-stack/contracts/observability-contracts.md
@@ -1,0 +1,47 @@
+# Phase 1 Contracts: Observability Stack
+
+Interfaces this feature exposes. FR references are to `spec.md`.
+
+## 1. Metrics — `GET /metrics` (new, FR-001/002/006)
+
+- Prometheus exposition text (`text/plain; version=0.0.4`); reachable only over the compose network / Tailscale, not the public funnel (FR-006).
+- **200** includes stock `http_server_request_duration_*`, `process_*`, `dotnet_*` and custom `finance_jobs_succeeded_total{job}`, `finance_jobs_failed_total{job}`, `finance_job_duration_seconds{job}`, `finance_jobs_scheduled`.
+- No PII / bounded-cardinality labels (FR-007).
+- Contract test: 200 + exposition contains the custom `finance_jobs_*` names; a public-funnel request is refused.
+
+## 2. Readiness — `GET /api/v1/health/ready` (new)
+
+- JWT-exempt; reports overall + per-dependency status.
+- **200 healthy** `{ "status":"Healthy", "checks":[{"name":"database","status":"Healthy"},{"name":"hangfire","status":"Healthy"}] }`
+- **503 unhealthy**: overall `Unhealthy`, failing check named (feeds SC-003 availability panel).
+- Existing liveness `GET /api/v1/health` unchanged.
+- Contract tests: all-up → 200 both Healthy; DB down → 503 naming `database`.
+
+## 3. Hangfire dashboard — `GET /hangfire` (re-enabled, secured, FR-004)
+
+- Authorized operator → 200; unauthorized → denied (never 200). Tailscale-only.
+- Backed by durable Postgres storage so history/schedule persist across restarts (FR-010).
+- Contract test: unauthenticated `/hangfire` is denied.
+
+## 4. Consecutive-failure alert (internal, US4 / FR-009)
+
+- **Trigger**: a job reaches terminal `Failed` for the **Nth consecutive** time (transient errors excluded).
+- **Effect**: exactly one `Alert{Type="JobFailure"}` per streak → `ClassifyAlert → OperationalFailure` → Telegram; naming job + consecutive count + last error summary. A later `Succeeded` resets the streak so the next failure can re-alert. Dispatch is fire-and-forget (US4-AS3).
+- Unit tests: (a) Nth consecutive failure → one alert with count; (b) failures 1..N-1 → no alert; (c) success resets, next failure re-alerts; (d) transient failure doesn't increment the streak; (e) dispatch throwing doesn't break the job.
+
+## 5. Grafana dashboards + datasources (provisioned, FR-004)
+
+- Config under `docker/observability/grafana/provisioning/`: datasources (Prometheus, Loki); dashboards — API traffic/latency/errors, per-job health (last run/duration/outcome + failure trend for US3), log search panel.
+- Grafana admin auth; Tailscale-only.
+- Verification (quickstart): open one dashboard → SC-001 answerable in < 30s; stop API → availability panel red within 60s (SC-003).
+
+## 6. Log query contract (Loki via Grafana, US2 / FR-003/011)
+
+- Logs queryable by label (`app`, `module`, `level`), correlation id, and free text; EF SQL absent at default level.
+- Verification (quickstart): filter `level=Error` last 1h → app errors, no raw SQL (SC-002 ≤ 2 min to find an injected error).
+
+## Cross-cutting
+
+- **Versioning**: `/metrics` + `/health/ready` are new API surface → API version bump + tag in the same PR (constitution).
+- **No paid dependency** anywhere (FR-008).
+- **Fire-and-forget**: metrics/log/alert shipping failures never affect request or job execution (FR-003/009, SC-005).

--- a/specs/023-observability-stack/data-model.md
+++ b/specs/023-observability-stack/data-model.md
@@ -1,0 +1,51 @@
+# Phase 1 Data Model: Observability Stack
+
+**No new application EF entities.** Persistence is delegated to Hangfire (own schema) or external stores (Loki/Prometheus); alerting reuses existing tables. FR references are to `spec.md`.
+
+## Metric series → Prometheus (external)
+
+- **Owner**: Prometheus TSDB; app exposes `/metrics` (OTel Prometheus exporter).
+- **Series**: stock `http_server_request_duration_*` (labels: route template, method, status class), `process_*`, `dotnet_*` (FR-001); custom `finance_jobs_succeeded_total` / `finance_jobs_failed_total` / `finance_job_duration_seconds` (label: job name) and `finance_jobs_scheduled` gauge (FR-002).
+- **Cardinality**: labels bounded — route templates not raw URLs, job name only, no per-user/account/PII labels (FR-007).
+- **Retention**: ≥30d, hard-capped volume (FR-005/SC-004).
+
+## Log entry → Loki (external)
+
+- **Owner**: Loki; app only emits via the Serilog Loki sink (fire-and-forget, FR-003).
+- **Shape**: timestamp, level, source module (`SourceContext`), message template + properties, correlation id, exception. Labels: `app`, `module`, `level`. EF `Database.Command` SQL absent at default level (FR-011).
+- **Retention**: ≥14d, capped (FR-005).
+
+## Background job record → Hangfire (PostgreSQL, `hangfire` schema)
+
+- **Owner**: `Hangfire.PostgreSql` (own tables/migrations; NOT an app `DbContext`).
+- **Represents**: each run — job type/args, enqueue/start/finish, state (Enqueued/Processing/Succeeded/Failed/Scheduled), state history, retry count, exception. Durable across restarts (FR-010).
+- **Retention**: succeeded ~7d, failed longer (config); bounded.
+- **Note**: complements the app's `SyncJob` entity (domain sync bookkeeping) — Hangfire's record is the runner's own history powering dashboards + trends (US3).
+
+## Consecutive-failure state (US4 / FR-009)
+
+- **Represents**: per-job count of consecutive terminal failures + whether an alert already fired for the current streak.
+- **Persistence**: keyed by job name; kept durably (Hangfire storage set, or a tiny keyed table) so a restart doesn't reset a live streak. Reset to 0 on the job's next `Succeeded`.
+- **Consumed by**: `ConsecutiveFailureAlertFilter` — raises exactly one alert on the Nth failure, none until a success then re-failure.
+
+## Failure Alert → existing `alerts` + `companion_events` (no migration)
+
+- **`Alert`** (existing) gains `Type` value **`JobFailure`** (const in `AlertType`); fields already present (`UserId`, `Type`, `Severity=Error`, `Title`, `Message`, `ReferenceId`=stable job id, `ReferenceLabel`=job name). New `JobFailureSilenceWindow` in the generator backs the streak dedup.
+- **`CompanionEvent`** (existing) gains appended enum **`CompanionEventKind.OperationalFailure`**; `MaterialityPolicy.ClassifyAlert("JobFailure") → OperationalFailure`. Capture → dispatch → Telegram unchanged.
+- **No schema migration** (new enum/const values only).
+
+## Dashboard → Grafana provisioning files (repo)
+
+- **Owner**: Grafana; definitions are YAML/JSON under `docker/observability/grafana/provisioning/` (datasources + dashboards), provisioned as code so they survive container recreation (FR-004 assumption).
+
+## Summary of code-level additions (no app DB migrations)
+
+| Change | Location | Kind |
+|---|---|---|
+| `AlertType.JobFailure` | Alerts/Domain/AlertType.cs | new const |
+| `GenerateJobFailureAlertAsync(...)` + silence window | Alerts/…/AlertGeneratorService.cs + Core `IAlertGeneratorService` | new method |
+| `CompanionEventKind.OperationalFailure` | Companion/Domain/CompanionEventKind.cs | appended enum value |
+| `"JobFailure" → OperationalFailure` | Companion/…/MaterialityPolicy.cs | new mapping |
+| Custom job `Meter` + filters | Infrastructure/Observability | new metrics + Hangfire filters |
+| Consecutive-failure counter | Infrastructure/Observability/Hangfire | new keyed state |
+| Hangfire `hangfire` schema | PostgreSQL (Hangfire-managed) | external migration (not app EF) |

--- a/specs/023-observability-stack/plan.md
+++ b/specs/023-observability-stack/plan.md
@@ -1,0 +1,98 @@
+# Implementation Plan: Observability Stack
+
+**Branch**: `023-observability-stack` | **Date**: 2026-08-05 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/023-observability-stack/spec.md`
+
+## Summary
+
+Give the single-VPS Finance Sentry monolith production-grade observability so failures announce themselves instead of being discovered days later via `ssh`+`grep` (the live-log investigation on 2026-08-05 found a news-ingestion job that had failed **636 consecutive times over ~13 days** unnoticed). Four capabilities: **US1 (P1)** a health-at-a-glance dashboard (API traffic/latency/errors + per-job success); **US2 (P2)** log search without SSH; **US3 (P3)** job-failure trends over time; **US4 (P2)** a pushed Telegram alert when a scheduled job hits N consecutive failures.
+
+Technical approach (operator-selected full OSS stack): instrument the API with **OpenTelemetry** (Prometheus exporter at `/metrics`), run **Prometheus + Grafana + Loki** as compose services on the VPS, ship **Serilog → Loki** with EF-SQL noise suppressed (FR-011), and move **Hangfire storage to PostgreSQL** so job history survives restarts (FR-010). The minimal alerting slice (US4/FR-009) is app-side: a Hangfire failure filter counts consecutive failures per job and, on the Nth, raises a `JobFailure` alert that rides the **existing Alerts→Companion→Telegram** pipeline (the exact path just proven for `ConsentExpiring` in #345), de-duplicated until the job next succeeds. Grafana metric-threshold rules remain deferred until baselines exist.
+
+## Technical Context
+
+**Language/Version**: C# 14 / .NET 10 (backend only; no Angular changes)
+**Primary Dependencies**:
+- Existing: ASP.NET Core, EF Core 10 (Npgsql), Hangfire, Serilog, `FinanceSentry.Core.Cqrs` (hand-rolled — no MediatR), Alerts module, Companion module (031), and the **stale-sync reaper** already shipped (#344) which prevents jobs stuck "running" after a restart.
+- New NuGet: `Hangfire.PostgreSql`; `Serilog.Sinks.Grafana.Loki`; `OpenTelemetry.Extensions.Hosting` + `.Instrumentation.AspNetCore` + `.Instrumentation.Runtime` + `.Exporter.Prometheus.AspNetCore`.
+- New infra containers: Loki, Prometheus, Grafana (provisioned datasources + dashboards as code).
+**Storage**: PostgreSQL 14 — Hangfire moves to a dedicated `hangfire` schema in the existing DB (FR-010). No new app EF entities: consecutive-failure alerts reuse the existing `alerts` table + Companion `companion_events`. Loki/Prometheus keep bounded on-disk stores.
+**Testing**: xUnit + FluentAssertions + Moq (unit); integration project for endpoint contract tests. Zero `dotnet build` warnings gate (constitution II).
+**Target Platform**: Linux single VPS, docker-compose (`docker/docker-compose.prod.yml`), Tailscale serve.
+**Project Type**: Web service (modular monolith), backend-only.
+**Performance Goals**: SC-005 — enabling observability adds < 5% p95 latency (async sinks, batched export, 15–30s scrape). SC-003 — API outage visible within 60s.
+**Constraints**: No paid SaaS (FR-008). Bounded retention: metrics ≥ 30d, logs ≥ 14d, both hard-capped (FR-005, SC-004). Metrics endpoint not publicly reachable, no PII/high-cardinality labels (FR-006/007). Dashboards behind auth (FR-004).
+**Scale/Scope**: Single operator, single node; ~dozens of recurring jobs.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Modular Monolith | ✅ PASS | Cross-cutting wiring in `FinanceSentry.API/Program.cs` + a new `FinanceSentry.Infrastructure/Observability/` folder; the failure-alert filter calls the existing `IAlertGeneratorService` (`Core` interface). Loki/Prometheus/Grafana are infra containers, not backend modules — monolith boundary intact. |
+| II. Code Quality (NON-NEGOTIABLE) | ✅ PASS | Zero build warnings; unit + contract tests per unit. |
+| III. Multi-Source Integration | N/A | No new financial source. |
+| IV. AI Analytics | N/A | — |
+| V. Security-First | ✅ PASS (design constraint) | Metrics scrape-only/not public (FR-006); no PII in labels (FR-007); Grafana + Hangfire dashboards auth-gated + Tailscale-only (FR-004); secrets via env. |
+| VI. Frontend Discipline | N/A | Backend-only. |
+| Testing Discipline | ✅ PASS | New `/metrics`, `/health/ready` ship with contract tests; the consecutive-failure counter/classifier gets unit tests. |
+| Versioning & Tagging | ⚠️ ACTION | New API surface (`/metrics`, `/health/ready`) → API version bump + tag in the same PR. Track as a task. |
+
+No violations requiring Complexity Tracking; the 3 added infra containers are an explicit operator decision, bounded by retention/resource caps.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-observability-stack/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+backend/src/
+├── FinanceSentry.API/
+│   └── Program.cs                         # Wire OpenTelemetry + Prometheus /metrics, Serilog→Loki,
+│                                          # health checks (/health, /health/ready), Hangfire→PostgreSql,
+│                                          # dashboard authorization filter.
+├── FinanceSentry.Infrastructure/
+│   └── Observability/
+│       ├── SerilogConfiguration.cs        # structured enrichers + EF-SQL level override (FR-011)
+│       ├── OpenTelemetryConfiguration.cs  # metrics setup + custom job Meter (FR-001/002)
+│       ├── JobMetrics.cs                  # counters/gauges: succeeded/failed/duration per job
+│       ├── HealthChecks/                  # Npgsql + Hangfire readiness
+│       └── Hangfire/
+│           ├── HangfirePostgresSetup.cs   # InMemory → PostgreSql, schema "hangfire" (FR-010)
+│           ├── ConsecutiveFailureAlertFilter.cs  # IElectStateFilter: count consecutive failures, alert on Nth (FR-009/US4)
+│           ├── JobMetricsFilter.cs        # record per-job outcome/duration metrics (FR-002)
+│           └── DashboardAuthorizationFilter.cs
+├── FinanceSentry.Modules.Alerts/Domain/AlertType.cs      # + JobFailure
+├── FinanceSentry.Modules.Alerts/.../AlertGeneratorService.cs  # + GenerateJobFailureAlertAsync (+ Core interface)
+└── FinanceSentry.Modules.Companion/...    # + CompanionEventKind.OperationalFailure + ClassifyAlert map
+
+backend/tests/
+├── FinanceSentry.Tests.Unit/             # consecutive-failure counter/dedup; metrics recording; health logic
+└── FinanceSentry.Tests.Integration/      # contract: /health/ready, /metrics, dashboard authz
+
+docker/
+├── docker-compose.prod.yml               # + loki, prometheus, grafana (bounded volumes)
+├── docker-compose.dev.yml                # local parity
+└── observability/
+    ├── prometheus/prometheus.yml         # scrape app /metrics
+    ├── loki/loki-config.yml              # ≥14d retention, capped
+    └── grafana/provisioning/             # datasources + dashboards-as-code (API, jobs, logs)
+```
+
+**Structure Decision**: Web-service modular monolith. Observability wiring lives in `Program.cs` + a new infrastructure `Observability/` folder (not a domain module). Alerting extends the Alerts + Companion modules exactly as `ConsentExpiring` did, so US4 reuses a proven, low-risk path. Dashboards/scrape configs are provisioned-as-code under `docker/observability/` (FR-004 assumption: survive container recreation).
+
+## Complexity Tracking
+
+> No constitution violations. The one notable complexity — 3 new infra containers (Loki/Prometheus/Grafana) — is an explicit operator decision in service of the production-practice roadmap, bounded by retention/scrape caps to fit the single VPS. The minimal-ops alternative was consciously declined.

--- a/specs/023-observability-stack/quickstart.md
+++ b/specs/023-observability-stack/quickstart.md
@@ -1,0 +1,58 @@
+# Quickstart: Observability Stack
+
+Bring the stack up and verify each user story. Adds `loki`, `prometheus`, `grafana` to the existing compose stack.
+
+## Bring it up
+
+```bash
+cd docker
+docker compose -f docker-compose.dev.yml up -d --build
+# new: loki, prometheus, grafana (+ existing postgres, api, frontend, mcp)
+```
+
+## Verify by user story
+
+**US1 — Health at a glance (P1)**
+```bash
+curl -s http://localhost:5001/metrics | grep finance_jobs_        # custom job metrics present
+curl -s http://localhost:5001/api/v1/health/ready | jq            # Healthy + database, hangfire
+# open http://localhost:3000 (Grafana) → main dashboard: API rate/latency/errors + per-job last-run
+# stop api → availability panel goes red within ~60s (SC-003)
+```
+
+**US2 — Log search without SSH (P2)**
+```
+Grafana → Explore → Loki → {app="finance-sentry"} | level="Error", last 1h
+→ app errors appear with structured fields; NO raw EF SQL at default level (FR-011)
+→ search by correlation id groups related entries (SC-002: find an injected error in < 2 min)
+```
+
+**US3 — Job health with history (P3)**
+```
+# restart api, then Grafana job-health dashboard → per-job success/failure + duration trend
+# survives restart because Hangfire now persists to Postgres (FR-010)
+# force a job to fail twice → trend shows 2 failures with timestamps
+```
+
+**US4 — Alert on N consecutive failures (P2)**
+```
+# force a scheduled job to fail N consecutive times (default N=3) → ONE Telegram message
+#   naming the job + consecutive count + last error (not one per failure)
+# keep failing → no duplicate until a success clears the streak
+# let it succeed, then fail again → re-alerts
+# transient (rate-limit) failure → does NOT increment the streak
+```
+
+## Resource / retention sanity (SC-004)
+
+```bash
+docker stats                     # loki/prometheus/grafana fit the VPS envelope; p95 regression < 5% (SC-005)
+# retention: Prometheus ~30d, Loki ~14d, Hangfire succeeded ~7d — bounded volumes; du plateaus
+```
+
+## Production notes
+
+- Grafana + Hangfire dashboards reachable only over Tailscale serve (not public funnel); `/metrics` scrape-only.
+- Telegram token/chat id + any dashboard secret via env/secrets, never committed.
+- `/metrics` + `/health/ready` are new API surface → bump the API version + tag in the same PR.
+- Grafana metric-threshold alert rules are deferred (spec Notes) until baselines exist — US4 covers the urgent silent-failure gap app-side.

--- a/specs/023-observability-stack/research.md
+++ b/specs/023-observability-stack/research.md
@@ -1,0 +1,68 @@
+# Phase 0 Research: Observability Stack
+
+Operator selected the full self-hosted OSS stack (2026-08-05), so remaining choices are library/config-level. FR references are to `spec.md`.
+
+## D1 — Durable Hangfire storage (FR-010)
+
+- **Decision**: `Hangfire.PostgreSql` against the existing PostgreSQL, isolated in a dedicated `hangfire` schema.
+- **Rationale**: Reuses the running DB (no new container), persists job history + recurring-job state across restarts, mature. Its own schema keeps Hangfire tables out of the app's EF migrations. Prerequisite for job-health trends (US3) and consecutive-failure tracking (US4).
+- **Alternatives**: In-memory (current — loses everything on restart); EF-based store (couples jobs to app DbContext); Redis (new container, no benefit).
+
+## D2 — Logs → Loki (FR-003)
+
+- **Decision**: Keep Serilog; add `Serilog.Sinks.Grafana.Loki` shipping structured logs to Loki alongside the console sink, **fire-and-forget** (shipping failure must not affect requests, FR-003).
+- **Rationale**: No change to the logging API across the codebase; existing enrichers carry correlation ids. Labels (`app`, `module`, `level`) make Loki/Grafana queries cheap (US2). Batched/async so p95 stays flat (SC-005).
+- **Alternatives**: OTel logs → Collector → Loki (extra container/config now); files + Promtail (more moving parts).
+
+## D3 — EF-SQL noise suppression (FR-011)
+
+- **Decision**: Serilog `MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Warning)` (+ related EF categories), configurable via settings without a code change (FR-011).
+- **Rationale**: This is the noise that made grep-based triage slow. SQL stays available at Debug when explicitly raised.
+- **Alternatives**: Disable EF logging entirely (loses debug); filter only in Loki (noise still shipped/stored).
+
+## D4 — Metrics → Prometheus (FR-001, FR-002)
+
+- **Decision**: OpenTelemetry .NET with ASP.NET Core + Runtime instrumentation and the Prometheus exporter at `/metrics`; a custom `Meter` records per-job outcome + duration (FR-002), labelled by job name only (bounded cardinality, FR-007).
+- **Rationale**: Standard, vendor-neutral, runtime/HTTP metrics for free (FR-001). Route-template labels (not raw URLs) keep cardinality bounded (FR-007). Scrape 15–30s.
+- **Alternatives**: `prometheus-net` (.NET-only, no OTel path); custom JSON metrics endpoint (reinvents Prometheus).
+
+## D5 — Health & readiness (SC-003)
+
+- **Decision**: `AspNetCore.HealthChecks.NpgSql` + `.Hangfire`; keep liveness `GET /api/v1/health`, add readiness `GET /api/v1/health/ready` naming per-dependency status.
+- **Rationale**: Feeds the dashboard availability panel + a future uptime probe; readiness distinguishes "process up" from "DB/job-processor usable."
+- **Alternatives**: Single combined endpoint (can't separate liveness from dependency failure).
+
+## D6 — Metrics endpoint exposure (FR-006)
+
+- **Decision**: `/metrics` reachable only to Prometheus over the compose network / Tailscale — not the public funnel. No auth token needed if network-scoped; otherwise a scrape token.
+- **Rationale**: FR-006 requires non-public metrics; same-host scrape keeps it internal.
+- **Alternatives**: Public `/metrics` (leaks internal shape); mTLS (overkill single-host).
+
+## D7 — Consecutive-failure alerting (FR-009 / US4)
+
+- **Decision**: App-side Hangfire `IElectStateFilter` intercepts a job's transition to terminal `Failed`; maintains a per-job **consecutive-failure counter** (persisted with the Hangfire store or a small keyed record); on the **Nth** consecutive failure raise one `Alert{Type=JobFailure}` via `IAlertGeneratorService`; a subsequent `Succeeded` transition resets the counter (clears the streak, FR-009). Delivery is fire-and-forget (FR-009 / US4-AS3). Transient/self-healing errors (reuse the sync layer's transient set) don't count toward the streak.
+- **Rationale**: Precise, operator-language, deduped ("one per streak, clears on success" — exactly the spec's ask), and reuses the Alerts→Companion→Telegram path proven by `ConsentExpiring` (#345). N configurable (default e.g. 3).
+- **Alternatives**: Grafana-only alerting (no per-job streak semantics, no operator-language summary — deferred to a later slice per spec Notes); alert on every failure (spam).
+
+## D8 — Alert transport reuse (FR-009)
+
+- **Decision**: `CompanionEventKind.OperationalFailure` + map `"JobFailure"` in `MaterialityPolicy.ClassifyAlert`; operational alerts carry higher criticality so they surface even under quieter modes.
+- **Rationale**: Mirrors the `ConsentExpiring` wiring — lowest-risk, consistent.
+- **Alternatives**: New standalone Telegram notifier (duplicates infra).
+
+## D9 — Dashboards-as-code (FR-004, assumption)
+
+- **Decision**: Grafana provisioning files in `docker/observability/grafana/provisioning/` define datasources (Prometheus, Loki) and dashboards (API traffic/latency/errors; per-job health; log search). Grafana admin auth; Tailscale-only.
+- **Rationale**: Survives container recreation (spec assumption); one page answers "healthy now + did syncs run?" in < 30s (SC-001).
+- **Alternatives**: Hand-built dashboards (lost on recreate).
+
+## D10 — Retention / resource sizing (FR-005, SC-004)
+
+- **Decision**: Prometheus retention ~30d (FR-005), Loki ~14d, Hangfire succeeded-job history ~7d (failed longer); all on bounded docker volumes with hard caps.
+- **Rationale**: Meets the ≥30d metrics / ≥14d logs floor while capping disk so observability can't take down the product it observes (SC-004, edge case).
+- **Alternatives**: Unbounded (fills disk); shorter (misses slow-burn incidents like the 13-day silent failure).
+
+## D11 — Dashboard/job-history durability interplay with the reaper
+
+- **Decision**: Reuse the already-shipped **stale-sync reaper** (#344) so a job interrupted by a restart is `Failed`, not stuck `Running`, keeping job-health metrics/trends (US3) truthful.
+- **Rationale**: The reaper already exists; Hangfire→Postgres + metrics simply read accurate terminal states.

--- a/specs/023-observability-stack/tasks.md
+++ b/specs/023-observability-stack/tasks.md
@@ -17,9 +17,9 @@ description: "Task list for Observability Stack (023)"
 
 ## Phase 1: Setup (Shared Infrastructure)
 
-- [ ] T001 Add NuGet packages to `backend/Directory.Packages.props` + reference in `FinanceSentry.API` / `FinanceSentry.Infrastructure`: `Hangfire.PostgreSql`, `Serilog.Sinks.Grafana.Loki`, `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Runtime`, `OpenTelemetry.Exporter.Prometheus.AspNetCore`, `AspNetCore.HealthChecks.NpgSql`, `AspNetCore.HealthChecks.Hangfire`.
-- [ ] T002 [P] Create `backend/src/FinanceSentry.Infrastructure/Observability/` with stub config classes (`SerilogConfiguration`, `OpenTelemetryConfiguration`, `JobMetrics`, `Hangfire/`, `HealthChecks/`).
-- [ ] T003 [P] Create `docker/observability/` skeleton: `prometheus/`, `loki/`, `grafana/provisioning/{datasources,dashboards}/`.
+- [X] T001 Add NuGet packages to `backend/Directory.Packages.props` + reference in `FinanceSentry.API` / `FinanceSentry.Infrastructure`: `Hangfire.PostgreSql`, `Serilog.Sinks.Grafana.Loki`, `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Runtime`, `OpenTelemetry.Exporter.Prometheus.AspNetCore`, `AspNetCore.HealthChecks.NpgSql`, `AspNetCore.HealthChecks.Hangfire`.
+- [X] T002 [P] Create `backend/src/FinanceSentry.Infrastructure/Observability/` with stub config classes (`SerilogConfiguration`, `OpenTelemetryConfiguration`, `JobMetrics`, `Hangfire/`, `HealthChecks/`).
+- [X] T003 [P] Create `docker/observability/` skeleton: `prometheus/`, `loki/`, `grafana/provisioning/{datasources,dashboards}/`.
 
 ---
 
@@ -27,18 +27,18 @@ description: "Task list for Observability Stack (023)"
 
 **⚠️ CRITICAL**: the collection layer (durable jobs, metrics emitted, logs shipped, containers running) must exist before any story's dashboards/alerts.
 
-- [ ] T004 Replace Hangfire `UseInMemoryStorage` with `UsePostgreSqlStorage` (schema `hangfire`) in `backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs` + `FinanceSentry.API/Program.cs`; connection reuses existing Postgres. (FR-010)
-- [ ] T005 [P] `SerilogConfiguration.cs`: structured enrichers (correlation id, module) + `MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Warning)`, levels driven by config. (FR-011)
-- [ ] T006 [P] Add fire-and-forget Serilog Loki sink (labels `app`,`module`,`level`) in `SerilogConfiguration.cs`; shipping failure must not affect requests. (FR-003)
-- [ ] T007 `OpenTelemetryConfiguration.cs` + `Program.cs`: OTel with ASP.NET Core + Runtime instrumentation and Prometheus exporter mapped at `/metrics`. (FR-001)
-- [ ] T008 [P] `JobMetrics.cs`: custom `Meter` — `finance_jobs_succeeded_total{job}`, `finance_jobs_failed_total{job}`, `finance_job_duration_seconds{job}`, `finance_jobs_scheduled` gauge; bounded labels only (FR-002, FR-007).
-- [ ] T009 `Observability/Hangfire/JobMetricsFilter.cs` (Hangfire `IApplyStateFilter`) records per-job outcome + duration into `JobMetrics`; register globally. (FR-002)
-- [ ] T010 [P] Readiness endpoint `GET /api/v1/health/ready` (Npgsql + Hangfire health checks) in `Program.cs` / `Observability/HealthChecks/`; keep existing `/api/v1/health` liveness. (SC-003)
-- [ ] T011 [P] Add `loki`, `prometheus`, `grafana` services to `docker/docker-compose.dev.yml` and `docker/docker-compose.prod.yml` with bounded named volumes + retention env. (FR-008)
-- [ ] T012 [P] `docker/observability/prometheus/prometheus.yml`: scrape the API `/metrics` (15–30s), retention ~30d. (FR-005)
-- [ ] T013 [P] `docker/observability/loki/loki-config.yml`: ≥14d retention, hard size cap. (FR-005)
-- [ ] T014 `docker/observability/grafana/provisioning/datasources/`: Prometheus + Loki datasources; Grafana admin auth via env. (FR-004)
-- [ ] T015 Secure surfaces: keep `/metrics` scrape-only / non-public (FR-006); add `Observability/Hangfire/DashboardAuthorizationFilter.cs` and re-enable the Hangfire dashboard behind it; Tailscale-only in prod. (FR-004)
+- [X] T004 Replace Hangfire `UseInMemoryStorage` with `UsePostgreSqlStorage` (schema `hangfire`) in `backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs` + `FinanceSentry.API/Program.cs`; connection reuses existing Postgres. (FR-010)
+- [X] T005 [P] `SerilogConfiguration.cs`: structured enrichers (correlation id, module) + `MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Warning)`, levels driven by config. (FR-011)
+- [X] T006 [P] Add fire-and-forget Serilog Loki sink (labels `app`,`module`,`level`) in `SerilogConfiguration.cs`; shipping failure must not affect requests. (FR-003)
+- [X] T007 `OpenTelemetryConfiguration.cs` + `Program.cs`: OTel with ASP.NET Core + Runtime instrumentation and Prometheus exporter mapped at `/metrics`. (FR-001)
+- [X] T008 [P] `JobMetrics.cs`: custom `Meter` — `finance_jobs_succeeded_total{job}`, `finance_jobs_failed_total{job}`, `finance_job_duration_seconds{job}`, `finance_jobs_scheduled` gauge; bounded labels only (FR-002, FR-007).
+- [X] T009 `Observability/Hangfire/JobMetricsFilter.cs` (Hangfire `IApplyStateFilter`) records per-job outcome + duration into `JobMetrics`; register globally. (FR-002)
+- [X] T010 [P] Readiness endpoint `GET /api/v1/health/ready` (Npgsql + Hangfire health checks) in `Program.cs` / `Observability/HealthChecks/`; keep existing `/api/v1/health` liveness. (SC-003)
+- [X] T011 [P] Add `loki`, `prometheus`, `grafana` services to `docker/docker-compose.dev.yml` and `docker/docker-compose.prod.yml` with bounded named volumes + retention env. (FR-008)
+- [X] T012 [P] `docker/observability/prometheus/prometheus.yml`: scrape the API `/metrics` (15–30s), retention ~30d. (FR-005)
+- [X] T013 [P] `docker/observability/loki/loki-config.yml`: ≥14d retention, hard size cap. (FR-005)
+- [X] T014 `docker/observability/grafana/provisioning/datasources/`: Prometheus + Loki datasources; Grafana admin auth via env. (FR-004)
+- [X] T015 Secure surfaces: keep `/metrics` scrape-only / non-public (FR-006); add `Observability/Hangfire/DashboardAuthorizationFilter.cs` and re-enable the Hangfire dashboard behind it; Tailscale-only in prod. (FR-004)
 
 **Checkpoint**: metrics flowing to Prometheus, logs to Loki, jobs durable in Postgres, dashboards reachable.
 
@@ -49,12 +49,12 @@ description: "Task list for Observability Stack (023)"
 **Goal**: One dashboard answers "is the system healthy now, and did last night's syncs run?" in < 30s (SC-001).
 **Independent Test**: Open the main dashboard → API rate/latency/error panels populate; jobs panel shows per-provider last run; stopping the API turns availability red within 60s.
 
-- [ ] T016 [P] [US1] Contract test: `GET /metrics` returns 200 and exposition contains `finance_jobs_*`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/MetricsEndpointTests.cs`.
-- [ ] T017 [P] [US1] Contract test: `GET /api/v1/health/ready` → 200 both checks Healthy; DB down → 503 naming `database`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/HealthReadyTests.cs`.
-- [ ] T018 [US1] Grafana main dashboard as code (`docker/observability/grafana/provisioning/dashboards/api-overview.json`): request rate, p50/p95/p99 latency, 4xx/5xx error rate, ≥24h window. (FR-001, SC-001)
-- [ ] T019 [US1] Jobs panel on the main dashboard: per-provider last run time, duration, success/failure from `finance_jobs_*`. (FR-002)
-- [ ] T020 [US1] Availability panel (app `up` / health) that visibly goes red within 60s of an API outage. (SC-003)
-- [ ] T021 [US1] Validate US1 per `quickstart.md` (panels populate; kill API → red).
+- [X] T016 [P] [US1] Contract test: `GET /metrics` returns 200 and exposition contains `finance_jobs_*`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/MetricsEndpointTests.cs`.
+- [X] T017 [P] [US1] Contract test: `GET /api/v1/health/ready` → 200 both checks Healthy; DB down → 503 naming `database`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/HealthReadyTests.cs`.
+- [X] T018 [US1] Grafana main dashboard as code (`docker/observability/grafana/provisioning/dashboards/api-overview.json`): request rate, p50/p95/p99 latency, 4xx/5xx error rate, ≥24h window. (FR-001, SC-001)
+- [X] T019 [US1] Jobs panel on the main dashboard: per-provider last run time, duration, success/failure from `finance_jobs_*`. (FR-002)
+- [X] T020 [US1] Availability panel (app `up` / health) that visibly goes red within 60s of an API outage. (SC-003)
+- [X] T021 [US1] Validate US1 per `quickstart.md` (panels populate; kill API → red).
 
 **Checkpoint**: MVP — live health/traffic/jobs visibility without SSH.
 

--- a/specs/023-observability-stack/tasks.md
+++ b/specs/023-observability-stack/tasks.md
@@ -78,13 +78,13 @@ description: "Task list for Observability Stack (023)"
 **Goal**: One Telegram alert when a scheduled job hits N consecutive failures; clears on next success. Closes the silent-outage gap (the 636-consecutive-failure incident). Reuses the Alerts→Companion→Telegram path from `ConsentExpiring` (#345).
 **Independent Test**: Force N consecutive failures → exactly one Telegram alert naming job + count; further failures → no dup; a success then failure → re-alerts; transient failure doesn't count.
 
-- [ ] T025 [P] [US4] Add `AlertType.JobFailure` (`backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs`) + `GenerateJobFailureAlertAsync(userId, referenceId, jobName, consecutiveCount, lastError)` in `Core/Interfaces/IAlertGeneratorService.cs` and `AlertGeneratorService.cs` with a `JobFailureSilenceWindow`.
-- [ ] T026 [P] [US4] Append `CompanionEventKind.OperationalFailure` (`…/Companion/Domain/CompanionEventKind.cs`) + map `"JobFailure"` in `MaterialityPolicy.ClassifyAlert`; carry elevated criticality so it surfaces under quieter modes.
-- [ ] T027 [US4] `Observability/Hangfire/ConsecutiveFailureAlertFilter.cs` (`IElectStateFilter`): durable per-job consecutive-failure counter, exclude transient errors (reuse the sync transient set), raise one `JobFailure` alert on the Nth, reset on `Succeeded`; fire-and-forget so dispatch failure can't break the job. (FR-009)
-- [ ] T028 [US4] Register the filter in Hangfire config; make N configurable (default 3) via settings.
-- [ ] T029 [P] [US4] Unit tests in `backend/tests/FinanceSentry.Tests.Unit/Observability/ConsecutiveFailureAlertFilterTests.cs`: Nth→one alert with count; 1..N-1→none; success resets then re-alerts; transient error no-increment; generator throw doesn't propagate.
-- [ ] T030 [US4] Add the new `IAlertGeneratorService` method to the hand-written fakes (`Research.Tests` `OpportunityFakes.cs`, `RunThesisMonitorHandlerTests.cs`) so the solution compiles.
-- [ ] T031 [US4] Validate US4 per `quickstart.md` (force N failures → single Telegram; success clears).
+- [X] T025 [P] [US4] Add `AlertType.JobFailure` (`backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs`) + `GenerateJobFailureAlertAsync(userId, referenceId, jobName, consecutiveCount, lastError)` in `Core/Interfaces/IAlertGeneratorService.cs` and `AlertGeneratorService.cs` with a `JobFailureSilenceWindow`.
+- [X] T026 [P] [US4] Append `CompanionEventKind.OperationalFailure` (`…/Companion/Domain/CompanionEventKind.cs`) + map `"JobFailure"` in `MaterialityPolicy.ClassifyAlert`; carry elevated criticality so it surfaces under quieter modes.
+- [X] T027 [US4] `Observability/Hangfire/ConsecutiveFailureAlertFilter.cs` (`IElectStateFilter`): durable per-job consecutive-failure counter, exclude transient errors (reuse the sync transient set), raise one `JobFailure` alert on the Nth, reset on `Succeeded`; fire-and-forget so dispatch failure can't break the job. (FR-009)
+- [X] T028 [US4] Register the filter in Hangfire config; make N configurable (default 3) via settings.
+- [X] T029 [P] [US4] Unit tests in `backend/tests/FinanceSentry.Tests.Unit/Observability/ConsecutiveFailureAlertFilterTests.cs`: Nth→one alert with count; 1..N-1→none; success resets then re-alerts; transient error no-increment; generator throw doesn't propagate.
+- [X] T030 [US4] Add the new `IAlertGeneratorService` method to the hand-written fakes (`Research.Tests` `OpportunityFakes.cs`, `RunThesisMonitorHandlerTests.cs`) so the solution compiles.
+- [X] T031 [US4] Validate US4 per `quickstart.md` (force N failures → single Telegram; success clears).
 
 **Checkpoint**: silent-failure gap closed; US1/US2/US4 all independently usable.
 

--- a/specs/023-observability-stack/tasks.md
+++ b/specs/023-observability-stack/tasks.md
@@ -1,0 +1,156 @@
+---
+description: "Task list for Observability Stack (023)"
+---
+
+# Tasks: Observability Stack
+
+**Input**: Design documents from `/specs/023-observability-stack/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/observability-contracts.md
+**Tests**: Contract tests for new endpoints (MANDATORY per constitution) + unit tests for the alerting logic.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- Backend paths: `backend/src/…`, `backend/tests/…`. Infra: `docker/…`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Add NuGet packages to `backend/Directory.Packages.props` + reference in `FinanceSentry.API` / `FinanceSentry.Infrastructure`: `Hangfire.PostgreSql`, `Serilog.Sinks.Grafana.Loki`, `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Runtime`, `OpenTelemetry.Exporter.Prometheus.AspNetCore`, `AspNetCore.HealthChecks.NpgSql`, `AspNetCore.HealthChecks.Hangfire`.
+- [ ] T002 [P] Create `backend/src/FinanceSentry.Infrastructure/Observability/` with stub config classes (`SerilogConfiguration`, `OpenTelemetryConfiguration`, `JobMetrics`, `Hangfire/`, `HealthChecks/`).
+- [ ] T003 [P] Create `docker/observability/` skeleton: `prometheus/`, `loki/`, `grafana/provisioning/{datasources,dashboards}/`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**⚠️ CRITICAL**: the collection layer (durable jobs, metrics emitted, logs shipped, containers running) must exist before any story's dashboards/alerts.
+
+- [ ] T004 Replace Hangfire `UseInMemoryStorage` with `UsePostgreSqlStorage` (schema `hangfire`) in `backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/HangfireSetup.cs` + `FinanceSentry.API/Program.cs`; connection reuses existing Postgres. (FR-010)
+- [ ] T005 [P] `SerilogConfiguration.cs`: structured enrichers (correlation id, module) + `MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Warning)`, levels driven by config. (FR-011)
+- [ ] T006 [P] Add fire-and-forget Serilog Loki sink (labels `app`,`module`,`level`) in `SerilogConfiguration.cs`; shipping failure must not affect requests. (FR-003)
+- [ ] T007 `OpenTelemetryConfiguration.cs` + `Program.cs`: OTel with ASP.NET Core + Runtime instrumentation and Prometheus exporter mapped at `/metrics`. (FR-001)
+- [ ] T008 [P] `JobMetrics.cs`: custom `Meter` — `finance_jobs_succeeded_total{job}`, `finance_jobs_failed_total{job}`, `finance_job_duration_seconds{job}`, `finance_jobs_scheduled` gauge; bounded labels only (FR-002, FR-007).
+- [ ] T009 `Observability/Hangfire/JobMetricsFilter.cs` (Hangfire `IApplyStateFilter`) records per-job outcome + duration into `JobMetrics`; register globally. (FR-002)
+- [ ] T010 [P] Readiness endpoint `GET /api/v1/health/ready` (Npgsql + Hangfire health checks) in `Program.cs` / `Observability/HealthChecks/`; keep existing `/api/v1/health` liveness. (SC-003)
+- [ ] T011 [P] Add `loki`, `prometheus`, `grafana` services to `docker/docker-compose.dev.yml` and `docker/docker-compose.prod.yml` with bounded named volumes + retention env. (FR-008)
+- [ ] T012 [P] `docker/observability/prometheus/prometheus.yml`: scrape the API `/metrics` (15–30s), retention ~30d. (FR-005)
+- [ ] T013 [P] `docker/observability/loki/loki-config.yml`: ≥14d retention, hard size cap. (FR-005)
+- [ ] T014 `docker/observability/grafana/provisioning/datasources/`: Prometheus + Loki datasources; Grafana admin auth via env. (FR-004)
+- [ ] T015 Secure surfaces: keep `/metrics` scrape-only / non-public (FR-006); add `Observability/Hangfire/DashboardAuthorizationFilter.cs` and re-enable the Hangfire dashboard behind it; Tailscale-only in prod. (FR-004)
+
+**Checkpoint**: metrics flowing to Prometheus, logs to Loki, jobs durable in Postgres, dashboards reachable.
+
+---
+
+## Phase 3: User Story 1 - Health at a glance (Priority: P1) 🎯 MVP
+
+**Goal**: One dashboard answers "is the system healthy now, and did last night's syncs run?" in < 30s (SC-001).
+**Independent Test**: Open the main dashboard → API rate/latency/error panels populate; jobs panel shows per-provider last run; stopping the API turns availability red within 60s.
+
+- [ ] T016 [P] [US1] Contract test: `GET /metrics` returns 200 and exposition contains `finance_jobs_*`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/MetricsEndpointTests.cs`.
+- [ ] T017 [P] [US1] Contract test: `GET /api/v1/health/ready` → 200 both checks Healthy; DB down → 503 naming `database`, in `backend/tests/FinanceSentry.Tests.Integration/Observability/HealthReadyTests.cs`.
+- [ ] T018 [US1] Grafana main dashboard as code (`docker/observability/grafana/provisioning/dashboards/api-overview.json`): request rate, p50/p95/p99 latency, 4xx/5xx error rate, ≥24h window. (FR-001, SC-001)
+- [ ] T019 [US1] Jobs panel on the main dashboard: per-provider last run time, duration, success/failure from `finance_jobs_*`. (FR-002)
+- [ ] T020 [US1] Availability panel (app `up` / health) that visibly goes red within 60s of an API outage. (SC-003)
+- [ ] T021 [US1] Validate US1 per `quickstart.md` (panels populate; kill API → red).
+
+**Checkpoint**: MVP — live health/traffic/jobs visibility without SSH.
+
+---
+
+## Phase 4: User Story 2 - Search logs without SSH (Priority: P2)
+
+**Goal**: Structured log search in the dashboard UI over ≥14 days, no SSH.
+**Independent Test**: Emit a known error → find it in Grafana/Loki by `level=Error` with structured fields; no raw SQL noise.
+
+- [ ] T022 [US2] Grafana Loki logs view/dashboard (`…/dashboards/logs.json`): filter by `level`, `module`, correlation id, free text. (FR-003)
+- [ ] T023 [US2] Verify EF SQL suppressed at default level and structured properties present end-to-end; adjust `SerilogConfiguration` levels if noise leaks. (FR-011, SC-002)
+- [ ] T024 [US2] Validate US2 per `quickstart.md` (injected error found in < 2 min).
+
+**Checkpoint**: US1 + US2 both independently usable.
+
+---
+
+## Phase 5: User Story 4 - Alert on N consecutive job failures (Priority: P2)
+
+**Goal**: One Telegram alert when a scheduled job hits N consecutive failures; clears on next success. Closes the silent-outage gap (the 636-consecutive-failure incident). Reuses the Alerts→Companion→Telegram path from `ConsentExpiring` (#345).
+**Independent Test**: Force N consecutive failures → exactly one Telegram alert naming job + count; further failures → no dup; a success then failure → re-alerts; transient failure doesn't count.
+
+- [ ] T025 [P] [US4] Add `AlertType.JobFailure` (`backend/src/FinanceSentry.Modules.Alerts/Domain/AlertType.cs`) + `GenerateJobFailureAlertAsync(userId, referenceId, jobName, consecutiveCount, lastError)` in `Core/Interfaces/IAlertGeneratorService.cs` and `AlertGeneratorService.cs` with a `JobFailureSilenceWindow`.
+- [ ] T026 [P] [US4] Append `CompanionEventKind.OperationalFailure` (`…/Companion/Domain/CompanionEventKind.cs`) + map `"JobFailure"` in `MaterialityPolicy.ClassifyAlert`; carry elevated criticality so it surfaces under quieter modes.
+- [ ] T027 [US4] `Observability/Hangfire/ConsecutiveFailureAlertFilter.cs` (`IElectStateFilter`): durable per-job consecutive-failure counter, exclude transient errors (reuse the sync transient set), raise one `JobFailure` alert on the Nth, reset on `Succeeded`; fire-and-forget so dispatch failure can't break the job. (FR-009)
+- [ ] T028 [US4] Register the filter in Hangfire config; make N configurable (default 3) via settings.
+- [ ] T029 [P] [US4] Unit tests in `backend/tests/FinanceSentry.Tests.Unit/Observability/ConsecutiveFailureAlertFilterTests.cs`: Nth→one alert with count; 1..N-1→none; success resets then re-alerts; transient error no-increment; generator throw doesn't propagate.
+- [ ] T030 [US4] Add the new `IAlertGeneratorService` method to the hand-written fakes (`Research.Tests` `OpportunityFakes.cs`, `RunThesisMonitorHandlerTests.cs`) so the solution compiles.
+- [ ] T031 [US4] Validate US4 per `quickstart.md` (force N failures → single Telegram; success clears).
+
+**Checkpoint**: silent-failure gap closed; US1/US2/US4 all independently usable.
+
+---
+
+## Phase 6: User Story 3 - Job health with history/trends (Priority: P3)
+
+**Goal**: Failure-count + duration trends per job over a selectable period.
+**Independent Test**: Fail a job twice → trend panel shows two failures with timestamps; survives a restart.
+
+- [ ] T032 [US3] Grafana job-health dashboard (`…/dashboards/job-health.json`): per-job failure count + duration trend over selectable range, from `finance_jobs_*` + Hangfire. (FR-002)
+- [ ] T033 [US3] Verify trends persist across an API restart (Hangfire Postgres storage, FR-010) and validate per `quickstart.md`.
+
+**Checkpoint**: all four stories independently functional.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T034 [P] Bump API version + create tag for the new endpoints (`/metrics`, `/api/v1/health/ready`) per constitution Versioning policy.
+- [ ] T035 [P] Observability runbook in `README.md`: bring-up, dashboard URLs (Tailscale), tuning N, retention windows, where alerts land.
+- [ ] T036 Full `dotnet build FinanceSentry.sln` zero-warning sweep + run unit + integration suites in the `sdk:10.0` container.
+- [ ] T037 Deploy to VPS; verify end-to-end: dashboards reachable over Tailscale, `/metrics` scrape-only, one forced consecutive-failure alert lands in Telegram, retention volumes bounded.
+- [ ] T038 [P] Update agent context (`.specify` / `CLAUDE.md` active technologies) with the observability stack.
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (P1)** → **Foundational (P2, BLOCKS all stories)** → **Stories** → **Polish**.
+- Story order by priority: **US1 (P1, MVP)** → **US2 (P2)** → **US4 (P2)** → **US3 (P3)**. US4 is P2 and addresses the urgent silent-failure incident — it may be pulled ahead of US2/US3 if desired (it depends only on Foundational T004 + the Alerts/Companion modules, not on US1–US3).
+- Within a story: contract/unit tests written to fail first, then implementation, then quickstart validation.
+
+### Key cross-task dependencies
+
+- T004 (Hangfire→Postgres) blocks T009, T027, T032/T033 and all durable-job behaviour.
+- T007/T008 (OTel + Meter) block T009, T016, T018–T020, T032.
+- T005/T006 (Serilog+Loki) block T022–T024.
+- T011–T014 (containers + datasources) block all Grafana dashboards (T018–T020, T022, T032).
+- T025+T026 block T027 (filter needs the alert type + companion mapping).
+
+### Parallel opportunities
+
+- Setup: T002, T003 parallel.
+- Foundational: T005/T006, T008, T010, T011/T012/T013 largely parallel (distinct files); T004/T007/T009/T014/T015 have ordering per above.
+- US4: T025 and T026 parallel; T029 parallel with dashboard-only tasks in other stories.
+- Different stories (US1/US2/US4/US3) can proceed in parallel once Foundational is done.
+
+---
+
+## Implementation Strategy
+
+### MVP (US1 only)
+Setup → Foundational → US1 → **stop & validate** (dashboard shows health + jobs; outage turns red). Deploy.
+
+### Recommended next slice
+**US4** immediately after the MVP (or even before US2/US3) — it directly closes the "silent multi-day failure" gap that motivated this feature, and reuses the proven `ConsentExpiring` alert path.
+
+### Incremental delivery
+MVP (US1) → US4 → US2 → US3, each independently testable and deployable, none breaking the last.
+
+---
+
+## Notes
+
+- No app EF migration — Hangfire owns its `hangfire` schema; alerts reuse existing `alerts`/`companion_events` (new enum/const values only).
+- Reuses the shipped stale-sync reaper (#344) so restart-interrupted jobs read as `Failed`, keeping trends/streaks truthful.
+- Grafana metric-threshold alert rules remain **deferred** (spec Notes) until baselines exist; US4 is the app-side minimal alerting slice.
+- Commit after each task or logical group; validate each story at its checkpoint before moving on.

--- a/specs/023-observability-stack/tasks.md
+++ b/specs/023-observability-stack/tasks.md
@@ -65,9 +65,9 @@ description: "Task list for Observability Stack (023)"
 **Goal**: Structured log search in the dashboard UI over ≥14 days, no SSH.
 **Independent Test**: Emit a known error → find it in Grafana/Loki by `level=Error` with structured fields; no raw SQL noise.
 
-- [ ] T022 [US2] Grafana Loki logs view/dashboard (`…/dashboards/logs.json`): filter by `level`, `module`, correlation id, free text. (FR-003)
-- [ ] T023 [US2] Verify EF SQL suppressed at default level and structured properties present end-to-end; adjust `SerilogConfiguration` levels if noise leaks. (FR-011, SC-002)
-- [ ] T024 [US2] Validate US2 per `quickstart.md` (injected error found in < 2 min).
+- [X] T022 [US2] Grafana Loki logs view/dashboard (`…/dashboards/logs.json`): filter by `level`, `module`, correlation id, free text. (FR-003)
+- [X] T023 [US2] Verify EF SQL suppressed at default level and structured properties present end-to-end; adjust `SerilogConfiguration` levels if noise leaks. (FR-011, SC-002)
+- [X] T024 [US2] Validate US2 per `quickstart.md` (injected error found in < 2 min).
 
 **Checkpoint**: US1 + US2 both independently usable.
 
@@ -95,8 +95,8 @@ description: "Task list for Observability Stack (023)"
 **Goal**: Failure-count + duration trends per job over a selectable period.
 **Independent Test**: Fail a job twice → trend panel shows two failures with timestamps; survives a restart.
 
-- [ ] T032 [US3] Grafana job-health dashboard (`…/dashboards/job-health.json`): per-job failure count + duration trend over selectable range, from `finance_jobs_*` + Hangfire. (FR-002)
-- [ ] T033 [US3] Verify trends persist across an API restart (Hangfire Postgres storage, FR-010) and validate per `quickstart.md`.
+- [X] T032 [US3] Grafana job-health dashboard (`…/dashboards/job-health.json`): per-job failure count + duration trend over selectable range, from `finance_jobs_*` + Hangfire. (FR-002)
+- [X] T033 [US3] Verify trends persist across an API restart (Hangfire Postgres storage, FR-010) and validate per `quickstart.md`.
 
 **Checkpoint**: all four stories independently functional.
 
@@ -105,10 +105,10 @@ description: "Task list for Observability Stack (023)"
 ## Phase 7: Polish & Cross-Cutting
 
 - [ ] T034 [P] Bump API version + create tag for the new endpoints (`/metrics`, `/api/v1/health/ready`) per constitution Versioning policy.
-- [ ] T035 [P] Observability runbook in `README.md`: bring-up, dashboard URLs (Tailscale), tuning N, retention windows, where alerts land.
+- [X] T035 [P] Observability runbook in `README.md`: bring-up, dashboard URLs (Tailscale), tuning N, retention windows, where alerts land.
 - [ ] T036 Full `dotnet build FinanceSentry.sln` zero-warning sweep + run unit + integration suites in the `sdk:10.0` container.
 - [ ] T037 Deploy to VPS; verify end-to-end: dashboards reachable over Tailscale, `/metrics` scrape-only, one forced consecutive-failure alert lands in Telegram, retention volumes bounded.
-- [ ] T038 [P] Update agent context (`.specify` / `CLAUDE.md` active technologies) with the observability stack.
+- [X] T038 [P] Update agent context (`.specify` / `CLAUDE.md` active technologies) with the observability stack.
 
 ---
 


### PR DESCRIPTION
Planning artifacts for the observability stack (023). **Docs only — no code yet.** Draft for review before `speckit.implement`.

## What's here
- `plan.md` — technical context, constitution gate (PASS; one action: API version bump for new endpoints), source-tree layout
- `research.md` — 11 resolved decisions (Hangfire→Postgres, Serilog→Loki, OTel→Prometheus, consecutive-failure alerting, retention sizing…)
- `data-model.md` — **no app EF migration** (Hangfire owns its schema; alerts reuse existing tables)
- `contracts/` — `/metrics`, `/health/ready`, secured `/hangfire`, the JobFailure→Companion→Telegram internal contract, Grafana provisioning
- `quickstart.md` — bring-up + per-story verification
- `tasks.md` — **38 tasks** by story

## Design (operator-selected full OSS stack)
OpenTelemetry → Prometheus (`/metrics`) + Loki (Serilog sink) + Grafana (dashboards-as-code); Hangfire storage in-memory → PostgreSQL (durable job history, FR-010); EF-SQL log noise suppressed (FR-011). US4 alerting (N consecutive job failures → Telegram) reuses the `ConsentExpiring` Alerts→Companion path (#345). No paid dependency.

## Delivery order
Setup → Foundational (blocks all) → **US1 dashboard (P1/MVP)** → recommend pulling **US4 forward** (closes the 636-consecutive-silent-failure gap) → US2 logs → US3 trends.

## Reviewer notes
- Grounded in the 2026-08-05 live-log incident (silent 13-day job failure).
- Grafana metric-threshold alert rules deferred until baselines exist; US4 is the app-side minimal alerting slice.
- Next step after approval: `speckit.implement`, Foundational + US1 slice first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)