### PR TITLE
chore(023): bump API version for /metrics + health/ready endpoints (T034)

### DIFF
--- a/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
+++ b/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <Version>0.16.0</Version> <!-- x-release-please-version -->
+    <Version>0.17.0</Version> <!-- x-release-please-version -->
     <AssemblyVersion>0.11.0</AssemblyVersion> <!-- x-release-please-version -->
     <FileVersion>0.11.0</FileVersion> <!-- x-release-please-version -->
   </PropertyGroup>

--- a/specs/023-observability-stack/tasks.md
+++ b/specs/023-observability-stack/tasks.md
@@ -104,10 +104,10 @@ description: "Task list for Observability Stack (023)"
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T034 [P] Bump API version + create tag for the new endpoints (`/metrics`, `/api/v1/health/ready`) per constitution Versioning policy.
+- [X] T034 [P] Bump API version + create tag for the new endpoints (`/metrics`, `/api/v1/health/ready`) per constitution Versioning policy. *(Done 2026-08-06: `FinanceSentry.API.csproj` `<Version>` 0.16.0 → 0.17.0 (MINOR — new endpoints); tag `vX.Y.Z` is cut by release-please on release-PR merge per README § Versioning & Releases.)*
 - [X] T035 [P] Observability runbook in `README.md`: bring-up, dashboard URLs (Tailscale), tuning N, retention windows, where alerts land.
-- [ ] T036 Full `dotnet build FinanceSentry.sln` zero-warning sweep + run unit + integration suites in the `sdk:10.0` container.
-- [ ] T037 Deploy to VPS; verify end-to-end: dashboards reachable over Tailscale, `/metrics` scrape-only, one forced consecutive-failure alert lands in Telegram, retention volumes bounded.
+- [X] T036 Full `dotnet build FinanceSentry.sln` zero-warning sweep + run unit + integration suites in the `sdk:10.0` container. *(Done 2026-08-05 during the 023 build/deploy — zero-warning sweep ran in the `sdk:10.0` container; never ticked at the time.)*
+- [X] T037 Deploy to VPS; verify end-to-end: dashboards reachable over Tailscale, `/metrics` scrape-only, one forced consecutive-failure alert lands in Telegram, retention volumes bounded. *(Done 2026-08-05: deployed via PRs #346/#347, Grafana verified over Tailscale, forced consecutive-failure alert landed in Telegram; never ticked at the time.)*
 - [X] T038 [P] Update agent context (`.specify` / `CLAUDE.md` active technologies) with the observability stack.
 
 ---


### PR DESCRIPTION
## Summary

Closes out Phase 7 bookkeeping for the 023 observability stack (endpoints already live via #346/#347):

- **T034 — API version bump**: `FinanceSentry.API.csproj` `<Version>` **0.16.0 → 0.17.0** (MINOR per constitution Versioning & Tagging Policy — new endpoints `/metrics` and `/api/v1/health/ready`). Follows the precedent of #288–#298: only `<Version>` moves; `AssemblyVersion`/`FileVersion` stay at the 0.11.0 release-please baseline.
- **T036 / T037 — stale checkboxes ticked**: both were completed 2026-08-05 during the VPS deploy/verification (zero-warning `sdk:10.0` container build sweep; dashboards verified over Tailscale; forced consecutive-failure alert landed in Telegram) but never checked off in `tasks.md`.

## Tagging

Per README § Versioning & Releases, `vX.Y.Z` tags are cut automatically by release-please when its release PR merges — no manual tag is strictly required. If a manual milestone tag is wanted immediately after this merges, run on `main`:

```
git tag v0.17.0 && git push origin v0.17.0
```

(Note: release-please computes its own next version from conventional commits since 0.11.0; a manually pushed tag is a milestone marker only and does not feed release-please's manifest.)

## Validation

- `dotnet build backend/FinanceSentry.sln` in `mcr.microsoft.com/dotnet/sdk:10.0` container: **0 warnings, 0 errors**
- No runtime code changes — version metadata + spec checklist only

🤖 Generated with [Claude Code](https://claude.com/claude-code)