### PR TITLE
test(007): add Monobank contract + unit tests (T011,T012,T023,T034,T035)

### DIFF
--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/BankProviderFactoryTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/BankProviderFactoryTests.cs
@@ -1,0 +1,55 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Domain.Interfaces;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Unit tests for BankProviderFactory (T035): resolves the registered provider
+/// by name and throws for unknown providers.
+/// </summary>
+public class BankProviderFactoryTests
+{
+    private static IBankProvider StubProvider(string name)
+    {
+        var mock = new Mock<IBankProvider>(MockBehavior.Strict);
+        mock.SetupGet(p => p.ProviderName).Returns(name);
+        return mock.Object;
+    }
+
+    private static BankProviderFactory CreateSut(out IBankProvider plaid, out IBankProvider monobank)
+    {
+        plaid = StubProvider("plaid");
+        monobank = StubProvider("monobank");
+        return new BankProviderFactory([plaid, monobank]);
+    }
+
+    [Fact]
+    public void Resolve_Plaid_ReturnsPlaidProvider()
+    {
+        var sut = CreateSut(out var plaid, out _);
+
+        sut.Resolve("plaid").Should().BeSameAs(plaid);
+    }
+
+    [Fact]
+    public void Resolve_Monobank_ReturnsMonobankProvider()
+    {
+        var sut = CreateSut(out _, out var monobank);
+
+        sut.Resolve("monobank").Should().BeSameAs(monobank);
+    }
+
+    [Fact]
+    public void Resolve_UnknownProvider_Throws()
+    {
+        var sut = CreateSut(out _, out _);
+
+        var act = () => sut.Resolve("revolut");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*revolut*");
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/ConnectMonobankContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/ConnectMonobankContractTests.cs
@@ -1,0 +1,207 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using System.Security.Claims;
+using System.Text.Json;
+using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Infrastructure.Encryption;
+using FinanceSentry.Modules.BankSync.API.Controllers;
+using FinanceSentry.Modules.BankSync.API.Middleware;
+using FinanceSentry.Modules.BankSync.Application.Commands;
+using FinanceSentry.Modules.BankSync.Application.Queries;
+using FinanceSentry.Modules.BankSync.Application.Services;
+using FinanceSentry.Modules.BankSync.Domain;
+using FinanceSentry.Modules.BankSync.Domain.Repositories;
+using FinanceSentry.Modules.BankSync.Infrastructure.Monobank;
+using FinanceSentry.Modules.BankSync.Infrastructure.Plaid;
+using FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+using FluentAssertions;
+using Hangfire;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+/// <summary>
+/// Contract tests for POST /api/v1/accounts/monobank/connect (T011):
+/// 201 created, 400 invalid token, 409 duplicate, 429 rate limit.
+/// The 201 path exercises the real controller action; the error paths run the
+/// real command handler through ErrorHandlingMiddleware, which owns the
+/// exception → HTTP status mapping for the endpoint. No database, no live HTTP.
+/// </summary>
+public class ConnectMonobankContractTests
+{
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private const string Token = "uTestToken123";
+
+    private static readonly MonobankAccountInfo BlackAccount = new(
+        Id: "kKGVoZuHWzqVoZuH",
+        Name: "black UAH",
+        Type: "checking",
+        MaskedPan: "537541******1234",
+        CurrencyCode: 980,
+        Balance: 1234567,
+        CreditLimit: 0);
+
+    private readonly Mock<IMonobankAdapter> _adapter = new();
+    private readonly Mock<ICredentialEncryptionService> _encryption = new();
+    private readonly Mock<IBankAccountRepository> _accounts = new();
+    private readonly Mock<IMonobankCredentialRepository> _credentials = new();
+    private readonly Mock<IBackgroundJobClient> _backgroundJobs = new();
+
+    public ConnectMonobankContractTests()
+    {
+        _encryption
+            .Setup(e => e.Encrypt(Token))
+            .Returns(new EncryptionResult([1, 2, 3], [4, 5, 6], [7, 8, 9], 1));
+        _accounts
+            .Setup(a => a.AddAsync(It.IsAny<BankAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BankAccount a, CancellationToken _) => a);
+        _credentials
+            .Setup(c => c.AddAsync(It.IsAny<MonobankCredential>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MonobankCredential c, CancellationToken _) => c);
+        _credentials
+            .Setup(c => c.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MonobankCredential?)null);
+    }
+
+    private ConnectMonobankAccountCommandHandler CreateHandler() => new(
+        _adapter.Object, _encryption.Object, _accounts.Object,
+        _credentials.Object, _backgroundJobs.Object);
+
+    // ── 201 Created ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectMonobank_ValidToken_Returns201WithConnectedAccounts()
+    {
+        _adapter
+            .Setup(a => a.ConnectAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([BlackAccount]);
+
+        var controller = CreateController();
+        var result = await controller.ConnectMonobank(new ConnectMonobankRequest(Token), default);
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(201);
+
+        var body = objectResult.Value.Should().BeOfType<ConnectMonobankResult>().Subject;
+        body.Accounts.Should().ContainSingle();
+        body.Accounts[0].BankName.Should().Be("Monobank");
+        body.Accounts[0].Provider.Should().Be("monobank");
+        body.Accounts[0].Currency.Should().Be("UAH");
+        body.Accounts[0].AccountNumberLast4.Should().Be("1234");
+        body.Accounts[0].CurrentBalance.Should().Be(12345.67m); // 1234567 kopecks ÷ 100
+    }
+
+    // ── 400 invalid token ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectMonobank_InvalidToken_Returns400TokenInvalid()
+    {
+        _adapter
+            .Setup(a => a.ConnectAsync(Token, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MonobankException(
+                "MONOBANK_TOKEN_INVALID", "Invalid or expired Monobank token.", 400));
+
+        var (status, errorCode) = await RunThroughErrorMiddlewareAsync(
+            () => CreateHandler().Handle(new ConnectMonobankAccountCommand(UserId, Token), default));
+
+        status.Should().Be(400);
+        errorCode.Should().Be("MONOBANK_TOKEN_INVALID");
+    }
+
+    // ── 409 duplicate connect ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectMonobank_DuplicateToken_Returns409Duplicate()
+    {
+        _adapter
+            .Setup(a => a.ConnectAsync(Token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([BlackAccount]);
+        _credentials
+            .Setup(c => c.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MonobankCredential(UserId, [1], [2], [3]));
+
+        var (status, errorCode) = await RunThroughErrorMiddlewareAsync(
+            () => CreateHandler().Handle(new ConnectMonobankAccountCommand(UserId, Token), default));
+
+        status.Should().Be(409);
+        errorCode.Should().Be("MONOBANK_TOKEN_DUPLICATE");
+
+        _credentials.Verify(
+            c => c.AddAsync(It.IsAny<MonobankCredential>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── 429 rate limit ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectMonobank_RateLimited_Returns429()
+    {
+        _adapter
+            .Setup(a => a.ConnectAsync(Token, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new MonobankException(
+                "MONOBANK_RATE_LIMITED",
+                "Monobank API rate limit exceeded. Please try again in 60 seconds.", 429));
+
+        var (status, errorCode) = await RunThroughErrorMiddlewareAsync(
+            () => CreateHandler().Handle(new ConnectMonobankAccountCommand(UserId, Token), default));
+
+        status.Should().Be(429);
+        errorCode.Should().Be("MONOBANK_RATE_LIMITED");
+    }
+
+    // ── Plumbing ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs <paramref name="action"/> behind the real ErrorHandlingMiddleware and
+    /// returns the HTTP status code and errorCode the API contract exposes.
+    /// </summary>
+    private static async Task<(int Status, string? ErrorCode)> RunThroughErrorMiddlewareAsync(
+        Func<Task> action)
+    {
+        var middleware = new ErrorHandlingMiddleware(
+            _ => action(), NullLogger<ErrorHandlingMiddleware>.Instance);
+
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        context.Response.Body.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(context.Response.Body);
+        return (context.Response.StatusCode, doc.RootElement.GetProperty("errorCode").GetString());
+    }
+
+    private BankSyncController CreateController()
+    {
+        var controller = new BankSyncController(
+            new Mock<ICommandHandler<ConnectBankAccountCommand, ConnectBankAccountResult>>().Object,
+            CreateHandler(),
+            new Mock<IQueryHandler<GetAccountsQuery, GetAccountsResult>>().Object,
+            new Mock<IQueryHandler<GetAllTransactionsQuery, AllTransactionsResult>>().Object,
+            new Mock<IQueryHandler<ListTrueLayerProvidersQuery, IReadOnlyList<TrueLayerProviderDto>>>().Object,
+            new Mock<ICommandHandler<BeginTrueLayerConnectCommand, BeginTrueLayerConnectResult>>().Object,
+            new Mock<ICommandHandler<FinalizeTrueLayerConnectCommand, FinalizeTrueLayerConnectResult>>().Object,
+            new Mock<ICommandHandler<DisconnectInstitutionCommand, DisconnectInstitutionResult>>().Object,
+            new Mock<IConfiguration>().Object,
+            NullLogger<BankSyncController>.Instance,
+            new PlaidAdapter(new Mock<IPlaidClient>().Object, StubCategoryResolver.Instance),
+            _accounts.Object,
+            new Mock<ITransactionRepository>().Object,
+            _backgroundJobs.Object,
+            new Mock<ISyncJobRepository>().Object,
+            new Mock<ITransactionSyncCoordinator>().Object,
+            new Mock<IAlertGeneratorService>().Object);
+
+        var identity = new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, UserId.ToString())], "test");
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+        return controller;
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankAdapterTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankAdapterTests.cs
@@ -1,0 +1,199 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using System.Net;
+using FinanceSentry.Modules.BankSync.Domain.Interfaces;
+using FinanceSentry.Modules.BankSync.Infrastructure.Monobank;
+using FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Unit tests for MonobankAdapter (T034): connect happy path, invalid token,
+/// and SyncTransactions amount mapping. HTTP is stubbed — no live Monobank calls.
+/// (The duplicate-connect 409 is owned by ConnectMonobankAccountCommandHandler
+/// and is covered in ConnectMonobankContractTests.)
+/// </summary>
+public class MonobankAdapterTests
+{
+    private const string Token = "uTestToken123";
+    private const string ExternalAccountId = "kKGVoZuHWzqVoZuH";
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001");
+    private static readonly Guid AccountId = Guid.Parse("bbbbbbbb-0000-0000-0000-000000000001");
+
+    private const string ClientInfoBody = """
+        {
+          "clientId": "3MSaMMtczs",
+          "name": "Мазепа Іван",
+          "accounts": [
+            {
+              "id": "kKGVoZuHWzqVoZuH",
+              "balance": 1234567,
+              "creditLimit": 0,
+              "type": "black",
+              "currencyCode": 980,
+              "maskedPan": ["537541******1234"]
+            }
+          ]
+        }
+        """;
+
+    private const string StatementBody = """
+        [
+          {
+            "id": "tx-debit-1",
+            "time": 1554466347,
+            "description": "Кава",
+            "mcc": 5814,
+            "hold": false,
+            "amount": -4250,
+            "currencyCode": 980,
+            "operationAmount": -4250,
+            "operationCurrencyCode": 980,
+            "commissionRate": 0,
+            "cashbackAmount": 0,
+            "balance": 1230317
+          },
+          {
+            "id": "tx-credit-1",
+            "time": 1554466400,
+            "description": "Поповнення",
+            "mcc": 4829,
+            "hold": false,
+            "amount": 500000,
+            "currencyCode": 980,
+            "operationAmount": 500000,
+            "operationCurrencyCode": 980,
+            "commissionRate": 0,
+            "cashbackAmount": 0,
+            "balance": 1730317
+          }
+        ]
+        """;
+
+    private static MonobankAdapter CreateSut(MonobankStubHttpHandler handler)
+        => new(handler.BuildClient(), StubCategoryResolver.Instance);
+
+    [Fact]
+    public void ProviderName_IsMonobank()
+    {
+        CreateSut(new MonobankStubHttpHandler()).ProviderName.Should().Be("monobank");
+    }
+
+    // ── Connect ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ConnectAsync_HappyPath_ReturnsAccounts()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, ClientInfoBody);
+
+        var accounts = await CreateSut(handler).ConnectAsync(Token);
+
+        accounts.Should().ContainSingle();
+        accounts[0].Id.Should().Be(ExternalAccountId);
+        accounts[0].Type.Should().Be("checking");
+        accounts[0].CurrencyCode.Should().Be(980);
+        handler.RequestPaths.Should().ContainSingle().Which.Should().Be("/personal/client-info");
+    }
+
+    [Fact]
+    public async Task ConnectAsync_InvalidToken_ThrowsTokenInvalid()
+    {
+        var handler = new MonobankStubHttpHandler()
+            .Enqueue(HttpStatusCode.Unauthorized, """{"errorDescription":"Unknown 'X-Token'"}""");
+
+        var act = () => CreateSut(handler).ConnectAsync("bad-token");
+
+        (await act.Should().ThrowAsync<MonobankException>())
+            .Which.Should().Match<MonobankException>(e =>
+                e.ErrorCode == "MONOBANK_TOKEN_INVALID" && e.StatusCode == 400);
+    }
+
+    // ── IBankProvider.GetAccountsAsync ───────────────────────────────────────
+
+    [Fact]
+    public async Task GetAccountsAsync_AsBankProvider_MapsBalanceCurrencyAndLast4()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, ClientInfoBody);
+        IBankProvider provider = CreateSut(handler);
+
+        var accounts = await provider.GetAccountsAsync(Token, default);
+
+        accounts.Should().ContainSingle();
+        accounts[0].ExternalAccountId.Should().Be(ExternalAccountId);
+        accounts[0].CurrentBalance.Should().Be(12345.67m); // 1234567 kopecks ÷ 100
+        accounts[0].Currency.Should().Be("UAH");
+        accounts[0].AccountNumberLast4.Should().Be("1234");
+        accounts[0].OwnerName.Should().Be("Мазепа Іван");
+    }
+
+    // ── SyncTransactionsAsync ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SyncTransactionsAsync_WithCursor_MapsAmountsSignsAndDates()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, StatementBody);
+        var since = DateTime.UtcNow.AddDays(-7);
+
+        var (candidates, nextSyncFrom) = await CreateSut(handler).SyncTransactionsAsync(
+            Token, ExternalAccountId, AccountId, UserId, since, default);
+
+        nextSyncFrom.Should().NotBeNull();
+        handler.RequestPaths.Should().ContainSingle(); // one incremental window
+        candidates.Should().HaveCount(2);
+
+        var debit = candidates.Single(c => c.Description == "Кава");
+        debit.Amount.Should().Be(42.50m); // -4250 kopecks → 42.50 absolute
+        debit.TransactionType.Should().Be("debit");
+        debit.TransactionDate.Should().Be(new DateTime(2019, 4, 5, 12, 12, 27, DateTimeKind.Utc));
+        debit.AccountId.Should().Be(AccountId);
+        debit.UserId.Should().Be(UserId);
+        debit.Mcc.Should().Be(5814);
+
+        var credit = candidates.Single(c => c.Description == "Поповнення");
+        credit.Amount.Should().Be(5000.00m); // 500000 kopecks → 5000.00
+        credit.TransactionType.Should().Be("credit");
+    }
+
+    [Fact]
+    public async Task SyncTransactionsAsync_NoCursor_Fetches90DaysInThreeWindows()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, "[]");
+
+        var (candidates, _) = await CreateSut(handler).SyncTransactionsAsync(
+            Token, ExternalAccountId, AccountId, UserId, since: null, default);
+
+        candidates.Should().BeEmpty();
+        handler.RequestPaths.Should().HaveCount(3); // 3 × 31-day windows for the initial import
+        handler.RequestPaths.Should().OnlyContain(p =>
+            p.StartsWith($"/personal/statement/{ExternalAccountId}/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SyncTransactionsAsync_HoldTransaction_IsPending()
+    {
+        const string holdBody = """
+            [
+              {
+                "id": "tx-hold-1",
+                "time": 1554466500,
+                "description": "Блокування",
+                "mcc": 5411,
+                "hold": true,
+                "amount": -1000,
+                "currencyCode": 980,
+                "operationAmount": -1000,
+                "operationCurrencyCode": 980,
+                "commissionRate": 0,
+                "cashbackAmount": 0,
+                "balance": 1729317
+              }
+            ]
+            """;
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, holdBody);
+
+        var (candidates, _) = await CreateSut(handler).SyncTransactionsAsync(
+            Token, ExternalAccountId, AccountId, UserId, DateTime.UtcNow.AddDays(-1), default);
+
+        candidates.Should().ContainSingle().Which.IsPending.Should().BeTrue();
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankClientInfoContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankClientInfoContractTests.cs
@@ -1,0 +1,106 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using System.Net;
+using FinanceSentry.Modules.BankSync.Infrastructure.Monobank;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Contract tests for Monobank GET /personal/client-info response mapping (T012).
+/// Mocked HTTP handler — no live Monobank calls.
+/// </summary>
+public class MonobankClientInfoContractTests
+{
+    private const string Token = "uTestToken123";
+
+    private const string ClientInfoBody = """
+        {
+          "clientId": "3MSaMMtczs",
+          "name": "Мазепа Іван",
+          "webHookUrl": "",
+          "permissions": "psfj",
+          "accounts": [
+            {
+              "id": "kKGVoZuHWzqVoZuH",
+              "sendId": "uHWzqVoZuH",
+              "balance": 10000000,
+              "creditLimit": 500000,
+              "type": "black",
+              "currencyCode": 980,
+              "cashbackType": "UAH",
+              "maskedPan": ["537541******1234"],
+              "iban": "UA733220010000026201234567890"
+            },
+            {
+              "id": "yellowAcct000001",
+              "sendId": "yellowSend",
+              "balance": 250000,
+              "creditLimit": 0,
+              "type": "yellow",
+              "currencyCode": 840,
+              "cashbackType": "None",
+              "maskedPan": [],
+              "iban": "UA733220010000026201234567891"
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task GetClientInfo_HappyPath_MapsClientAndAccounts()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, ClientInfoBody);
+
+        var result = await handler.BuildClient().GetClientInfoAsync(Token);
+
+        result.ClientId.Should().Be("3MSaMMtczs");
+        result.Name.Should().Be("Мазепа Іван");
+        result.Accounts.Should().HaveCount(2);
+
+        var black = result.Accounts[0];
+        black.Id.Should().Be("kKGVoZuHWzqVoZuH");
+        black.Name.Should().Be("black UAH");
+        black.Type.Should().Be("checking");
+        black.MaskedPan.Should().Be("537541******1234");
+        black.CurrencyCode.Should().Be(980);
+        black.Balance.Should().Be(10000000L); // raw kopecks at the client layer
+        black.CreditLimit.Should().Be(500000L);
+    }
+
+    [Fact]
+    public async Task GetClientInfo_MapsCardTypes_YellowIsCredit()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, ClientInfoBody);
+
+        var result = await handler.BuildClient().GetClientInfoAsync(Token);
+
+        var yellow = result.Accounts[1];
+        yellow.Type.Should().Be("credit");
+        yellow.Name.Should().Be("yellow USD");
+        yellow.MaskedPan.Should().Be("0000"); // empty maskedPan array falls back to "0000"
+    }
+
+    [Fact]
+    public async Task GetClientInfo_SendsTokenHeaderToClientInfoPath()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, ClientInfoBody);
+
+        await handler.BuildClient().GetClientInfoAsync(Token);
+
+        handler.RequestPaths.Should().ContainSingle().Which.Should().Be("/personal/client-info");
+        handler.RequestTokens.Should().ContainSingle().Which.Should().Be(Token);
+    }
+
+    [Fact]
+    public async Task GetClientInfo_Unauthorized_ThrowsTokenInvalidMappedTo400()
+    {
+        var handler = new MonobankStubHttpHandler()
+            .Enqueue(HttpStatusCode.Unauthorized, """{"errorDescription":"Unknown 'X-Token'"}""");
+
+        var act = () => handler.BuildClient().GetClientInfoAsync("bad-token");
+
+        (await act.Should().ThrowAsync<MonobankException>())
+            .Which.Should().Match<MonobankException>(e =>
+                e.ErrorCode == "MONOBANK_TOKEN_INVALID" && e.StatusCode == 400);
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankStatementContractTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankStatementContractTests.cs
@@ -1,0 +1,177 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using System.Net;
+using FinanceSentry.Modules.BankSync.Infrastructure.Monobank;
+using FinanceSentry.Tests.Unit.BankSync.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Contract tests for Monobank GET /personal/statement/{account}/{from}/{to}
+/// response mapping (T023): amount ÷ 100, numeric → alphabetic currency,
+/// Unix timestamp → UTC DateTime. Mocked HTTP handler — no live Monobank calls.
+/// </summary>
+public class MonobankStatementContractTests
+{
+    private const string Token = "uTestToken123";
+    private const string AccountId = "kKGVoZuHWzqVoZuH";
+    private const long FromUnix = 1554000000L;
+    private const long ToUnix = 1554466347L;
+
+    private static readonly DateTimeOffset From = DateTimeOffset.FromUnixTimeSeconds(FromUnix);
+    private static readonly DateTimeOffset To = DateTimeOffset.FromUnixTimeSeconds(ToUnix);
+
+    private const string StatementBody = """
+        [
+          {
+            "id": "ZuHWzqkKGVo=",
+            "time": 1554466347,
+            "description": "Покупка щастя",
+            "mcc": 7997,
+            "originalMcc": 7997,
+            "hold": false,
+            "amount": -95000,
+            "operationAmount": -95000,
+            "currencyCode": 980,
+            "operationCurrencyCode": 980,
+            "commissionRate": 0,
+            "cashbackAmount": 19000,
+            "balance": 10050000,
+            "comment": "За каву",
+            "receiptId": "XXXX-XXXX-XXXX-XXXX",
+            "counterName": "ТОВ «ВОРОНА»",
+            "counterIban": "UA898999980000355639201001404"
+          },
+          {
+            "id": "creditEntry0001=",
+            "time": 1554466400,
+            "description": "Зарахування",
+            "mcc": 4829,
+            "originalMcc": 4829,
+            "hold": true,
+            "amount": 1000000,
+            "operationAmount": 1000000,
+            "currencyCode": 980,
+            "operationCurrencyCode": 980,
+            "commissionRate": 0,
+            "cashbackAmount": 0,
+            "balance": 11050000
+          }
+        ]
+        """;
+
+    [Fact]
+    public async Task GetStatements_RequestsStatementPathWithUnixRange()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, "[]");
+
+        await handler.BuildClient().GetStatementsAsync(Token, AccountId, From, To);
+
+        handler.RequestPaths.Should().ContainSingle()
+            .Which.Should().Be($"/personal/statement/{AccountId}/{FromUnix}/{ToUnix}");
+        handler.RequestTokens.Should().ContainSingle().Which.Should().Be(Token);
+    }
+
+    [Fact]
+    public async Task GetStatements_ParsesRawEntryFields()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, StatementBody);
+
+        var result = await handler.BuildClient().GetStatementsAsync(Token, AccountId, From, To);
+
+        result.Should().HaveCount(2);
+        var debit = result[0];
+        debit.Id.Should().Be("ZuHWzqkKGVo=");
+        debit.Time.Should().Be(1554466347L);
+        debit.Description.Should().Be("Покупка щастя");
+        debit.MCC.Should().Be(7997);
+        debit.Hold.Should().BeFalse();
+        debit.Amount.Should().Be(-95000L); // raw kopecks at the client layer
+        debit.CurrencyCode.Should().Be(980);
+        debit.CashbackAmount.Should().Be(19000L);
+        debit.Balance.Should().Be(10050000L);
+        debit.Comment.Should().Be("За каву");
+        debit.CounterName.Should().Be("ТОВ «ВОРОНА»");
+        debit.CounterIban.Should().Be("UA898999980000355639201001404");
+    }
+
+    [Fact]
+    public async Task GetStatements_EmptyBody_ReturnsEmptyList()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, "[]");
+
+        var result = await handler.BuildClient().GetStatementsAsync(Token, AccountId, From, To);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatements_Unauthorized_ThrowsTokenInvalidMappedTo400()
+    {
+        var handler = new MonobankStubHttpHandler()
+            .Enqueue(HttpStatusCode.Unauthorized, """{"errorDescription":"Unknown 'X-Token'"}""");
+
+        var act = () => handler.BuildClient().GetStatementsAsync("bad-token", AccountId, From, To);
+
+        (await act.Should().ThrowAsync<MonobankException>())
+            .Which.Should().Match<MonobankException>(e =>
+                e.ErrorCode == "MONOBANK_TOKEN_INVALID" && e.StatusCode == 400);
+    }
+
+    // ── Statement → candidate conversions (amount ÷ 100, unix time → UTC) ────
+
+    [Fact]
+    public async Task GetCandidates_ConvertsKopecksToDecimalAndUnixTimeToUtc()
+    {
+        var handler = new MonobankStubHttpHandler().Enqueue(HttpStatusCode.OK, StatementBody);
+        var adapter = new MonobankAdapter(handler.BuildClient(), StubCategoryResolver.Instance);
+
+        var candidates = await adapter.GetCandidatesAsync(
+            Token, AccountId, Guid.NewGuid(), Guid.NewGuid(), From, To);
+
+        candidates.Should().HaveCount(2);
+
+        var debit = candidates[0];
+        debit.Amount.Should().Be(950.00m); // -95000 kopecks → 950.00 absolute
+        debit.TransactionType.Should().Be("debit");
+        debit.TransactionDate.Should().Be(new DateTime(2019, 4, 5, 12, 12, 27, DateTimeKind.Utc));
+        debit.TransactionDate.Kind.Should().Be(DateTimeKind.Utc);
+        debit.IsPending.Should().BeFalse();
+        debit.MerchantName.Should().Be("ТОВ «ВОРОНА»");
+        debit.Mcc.Should().Be(7997);
+
+        var credit = candidates[1];
+        credit.Amount.Should().Be(10000.00m); // 1000000 kopecks → 10000.00
+        credit.TransactionType.Should().Be("credit");
+        credit.IsPending.Should().BeTrue(); // hold = pending
+    }
+
+    // ── Currency + amount helper contracts ───────────────────────────────────
+
+    [Theory]
+    [InlineData(980, "UAH")]
+    [InlineData(840, "USD")]
+    [InlineData(978, "EUR")]
+    [InlineData(826, "GBP")]
+    [InlineData(985, "PLN")]
+    public void MapCurrency_KnownNumericCodes_MapToAlphabetic(int numeric, string expected)
+    {
+        MonobankHttpClient.MapCurrency(numeric).Should().Be(expected);
+    }
+
+    [Fact]
+    public void MapCurrency_UnknownNumericCode_ReturnsUnknownMarker()
+    {
+        MonobankHttpClient.MapCurrency(999).Should().Be("UNKNOWN_999");
+    }
+
+    [Theory]
+    [InlineData(12345L, 123.45)]
+    [InlineData(-50L, -0.50)]
+    [InlineData(0L, 0)]
+    [InlineData(1L, 0.01)]
+    public void KopecksToDecimal_DividesBy100(long kopecks, decimal expected)
+    {
+        MonobankHttpClient.KopecksToDecimal(kopecks).Should().Be(expected);
+    }
+}

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankStubHttpHandler.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankStubHttpHandler.cs
@@ -1,0 +1,45 @@
+namespace FinanceSentry.Tests.Unit.BankSync.Monobank;
+
+using System.Net;
+using System.Text;
+
+/// <summary>
+/// Test double for the Monobank REST API — records outgoing requests and replays
+/// canned responses. No live HTTP. Each enqueued response answers one request in
+/// order; the last enqueued response repeats for any further requests.
+/// </summary>
+internal sealed class MonobankStubHttpHandler : HttpMessageHandler
+{
+    private readonly Queue<(HttpStatusCode Status, string Body)> _responses = new();
+    private (HttpStatusCode Status, string Body)? _last;
+
+    public List<string> RequestPaths { get; } = [];
+    public List<string?> RequestTokens { get; } = [];
+
+    public MonobankStubHttpHandler Enqueue(HttpStatusCode status, string body)
+    {
+        _responses.Enqueue((status, body));
+        return this;
+    }
+
+    public FinanceSentry.Modules.BankSync.Infrastructure.Monobank.MonobankHttpClient BuildClient()
+        => new(new HttpClient(this) { BaseAddress = new Uri("https://api.monobank.ua") });
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestPaths.Add(request.RequestUri!.AbsolutePath);
+        RequestTokens.Add(request.Headers.TryGetValues("X-Token", out var values)
+            ? values.FirstOrDefault()
+            : null);
+
+        if (_responses.Count > 0)
+            _last = _responses.Dequeue();
+
+        var (status, body) = _last ?? (HttpStatusCode.OK, "{}");
+        return Task.FromResult(new HttpResponseMessage(status)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
+        });
+    }
+}

--- a/specs/007-monobank-adapter/tasks.md
+++ b/specs/007-monobank-adapter/tasks.md
@@ -45,8 +45,8 @@ No new project or dependency setup required. Monobank API is called via plain `H
 
 ### Contract Tests for User Story 1
 
-- [ ] T011 [P] [US1] Write contract test for `POST /api/v1/accounts/monobank/connect` (201, 400 invalid token, 409 duplicate, 429 rate limit) in `backend/tests/FinanceSentry.Tests/Monobank/ConnectMonobankContractTests.cs`
-- [ ] T012 [P] [US1] Write contract test for Monobank `GET /personal/client-info` response mapping (happy path + 401 error) using mocked HTTP handler in `backend/tests/FinanceSentry.Tests/Monobank/MonobankClientInfoContractTests.cs`
+- [X] T011 [P] [US1] Write contract test for `POST /api/v1/accounts/monobank/connect` (201, 400 invalid token, 409 duplicate, 429 rate limit) in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/ConnectMonobankContractTests.cs`
+- [X] T012 [P] [US1] Write contract test for Monobank `GET /personal/client-info` response mapping (happy path + 401 error) using mocked HTTP handler in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankClientInfoContractTests.cs`
 
 ### Implementation for User Story 1
 
@@ -73,7 +73,7 @@ No new project or dependency setup required. Monobank API is called via plain `H
 
 ### Contract Tests for User Story 2
 
-- [ ] T023 [P] [US2] Write contract test for Monobank `GET /personal/statement/{account}/{from}/{to}` response mapping (amount÷100, currency numeric→alphabetic, Unix timestamp→DateTime UTC) using mocked HTTP handler in `backend/tests/FinanceSentry.Tests/Monobank/MonobankStatementContractTests.cs`
+- [X] T023 [P] [US2] Write contract test for Monobank `GET /personal/statement/{account}/{from}/{to}` response mapping (amount÷100, currency numeric→alphabetic, Unix timestamp→DateTime UTC) using mocked HTTP handler in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankStatementContractTests.cs`
 
 ### Implementation for User Story 2
 
@@ -107,8 +107,8 @@ No new project or dependency setup required. Monobank API is called via plain `H
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T034 [P] Write unit tests for `MonobankAdapter` (connect happy path, invalid token, duplicate connect, SyncTransactions amount mapping) in `backend/tests/FinanceSentry.Tests/Monobank/MonobankAdapterTests.cs`
-- [ ] T035 [P] Write unit test for `BankProviderFactory` (resolves plaid for "plaid", monobank for "monobank", throws for unknown) in `backend/tests/FinanceSentry.Tests/Monobank/BankProviderFactoryTests.cs`
+- [X] T034 [P] Write unit tests for `MonobankAdapter` (connect happy path, invalid token, duplicate connect, SyncTransactions amount mapping) in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/MonobankAdapterTests.cs` — duplicate-connect 409 is owned by `ConnectMonobankAccountCommandHandler`, covered in `ConnectMonobankContractTests.cs`
+- [X] T035 [P] Write unit test for `BankProviderFactory` (resolves plaid for "plaid", monobank for "monobank", throws for unknown) in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/BankProviderFactoryTests.cs`
 - [X] T036 Bump backend minor version in `backend/src/FinanceSentry.API/FinanceSentry.API.csproj` (no `<Version>` tag present — N/A)
 - [X] T037 Bump frontend minor version in `frontend/package.json` → 0.6.0
 


### PR DESCRIPTION
Closes the last five unchecked tasks of spec 007-monobank-adapter — the never-written test tasks. 34 new test cases, all green; full `FinanceSentry.Tests.Unit` suite at 429/429. No production code touched.

All tests live in `backend/tests/FinanceSentry.Tests.Unit/BankSync/Monobank/` (the `FinanceSentry.Tests` project named in tasks.md no longer exists) and use a mocked `HttpMessageHandler` — no live Monobank calls, no database.

- **T011 — `ConnectMonobankContractTests`**: `POST /api/v1/accounts/monobank/connect` contract. 201 via the real `BankSyncController` action (mocked handler deps, claims principal); 400 invalid token / 409 duplicate / 429 rate limit via the real `ConnectMonobankAccountCommandHandler` run behind the real `ErrorHandlingMiddleware`, asserting status + `errorCode` body.
- **T012 — `MonobankClientInfoContractTests`**: `GET /personal/client-info` mapping — clientId/name/accounts, card-type mapping (black→checking, yellow→credit), maskedPan fallback, `X-Token` header + path, 401 → `MONOBANK_TOKEN_INVALID` (mapped to 400).
- **T023 — `MonobankStatementContractTests`**: `GET /personal/statement/{account}/{from}/{to}` — Unix-range URL, raw field parsing, empty body, 401; plus the conversion contracts: kopecks ÷ 100 (`KopecksToDecimal` theory), numeric→alphabetic currency (`MapCurrency` theory incl. unknown code), Unix timestamp → UTC `DateTime` through `MonobankAdapter.GetCandidatesAsync`.
- **T034 — `MonobankAdapterTests`**: provider name, connect happy path, invalid token, `IBankProvider.GetAccountsAsync` mapping (balance/currency/last4/owner), `SyncTransactionsAsync` amount/sign/date mapping with cursor, 3-window 90-day initial import without cursor, hold→pending. (Duplicate-connect 409 is owned by the command handler, covered in the T011 file — the adapter has no duplicate logic.)
- **T035 — `BankProviderFactoryTests`**: resolves `plaid` and `monobank` to their registered providers, throws `InvalidOperationException` for unknown.

Also ticks the five checkboxes in `specs/007-monobank-adapter/tasks.md` (paths updated to the current test project layout).

Note: the 429-retry path of `MonobankHttpClient` is asserted via the adapter contract (mocked `IMonobankAdapter` throwing `MONOBANK_RATE_LIMITED`), not through the real client — its retry back-off is a hard-coded 60s/120s `Task.Delay`, untestable in a unit suite without injectable delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)