### PR TITLE
fix(currency): convert to USD before every cross-currency aggregation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,18 @@ Use `/csharp-quality` for a batch cleanup sweep across multiple files.
 
 ---
 
+## Currency / Money Aggregation Rule — mandatory
+
+Accounts span currencies (Monobank=UAH, Revolut/AIB=EUR, IBKR/Binance=USD, …). **Never sum a native `Amount`/`Balance` across accounts** — a raw `.Sum(x => x.Amount)` adds hryvnia to euros as if both were dollars (this caused the "$28k monthly outflow" and "Government $71k top spending" bugs).
+
+The convention, enforced structurally:
+- **Convert once at the reader/query boundary**, where the account currency is in scope, via `FinanceSentry.Core.Utils.CurrencyConverter.ToUsd(amount, currency)` (the single conversion primitive; the FX refresh job feeds its rate table).
+- **Every DTO that crosses an aggregation boundary carries a `…Usd` / `…InBaseCurrency` field** (e.g. `BankingTransactionSummary.AmountUsd`, `BankingAccountSummary.BalanceUsd`, `CryptoHoldingSummary.UsdValue`). Aggregations sum **only** that field, never the native one.
+- When you add a new totals/summary path over transaction-level data, thread the account currency in and expose a converted field — do not sum native amounts and "fix it later".
+- Unknown currency: `CurrencyConverter.ToUsd` falls back to 1:1. Use `CurrencyConverter.IsKnown(currency)` if you need to flag a total as approximate rather than trust a silent fallback.
+
+---
+
 ## UI Component Library Rule
 
 **Any new UI component MUST be created in `@dsdevq-common/ui` first.** Components are never built directly in the host Angular app (`frontend/`). This applies to all future features, starting with 005-ui-component-library. The `cmn-` selector prefix is reserved for library components.

--- a/backend/src/FinanceSentry.Core/Interfaces/IBankingTransactionReader.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IBankingTransactionReader.cs
@@ -6,10 +6,18 @@ public interface IBankingTransactionReader
         Guid userId, DateOnly from, DateOnly to, CancellationToken ct = default);
 }
 
+/// <param name="Amount">Native amount in the account's own currency — never sum this across accounts.</param>
+/// <param name="Currency">ISO code of the account the transaction belongs to.</param>
+/// <param name="AmountUsd">
+/// <paramref name="Amount"/> converted to USD at read time. Aggregations MUST sum this, not
+/// <paramref name="Amount"/>, so totals never mix currencies.
+/// </param>
 public record BankingTransactionSummary(
     Guid AccountId,
     string Provider,
     string TransactionType,
     decimal Amount,
+    string Currency,
+    decimal AmountUsd,
     DateTime EffectiveDate,
     bool IsPending);

--- a/backend/src/FinanceSentry.Core/Utils/CurrencyConverter.cs
+++ b/backend/src/FinanceSentry.Core/Utils/CurrencyConverter.cs
@@ -35,6 +35,14 @@ public static class CurrencyConverter
     }
 
     /// <summary>
+    /// True when a rate is available for <paramref name="currency"/>. Callers building a total
+    /// should check this to flag the result as approximate rather than trusting a silent 1:1
+    /// fallback for an unlisted currency.
+    /// </summary>
+    public static bool IsKnown(string? currency) =>
+        !string.IsNullOrWhiteSpace(currency) && _rates.ContainsKey(currency);
+
+    /// <summary>
     /// Replaces the live rate table (USD-per-unit multipliers). The hardcoded
     /// fallback is merged underneath so a currency briefly missing from the feed
     /// still resolves. Ignored when <paramref name="rates"/> is null/empty.

--- a/backend/src/FinanceSentry.Mcp/Tools/GetCashflowReportTool.cs
+++ b/backend/src/FinanceSentry.Mcp/Tools/GetCashflowReportTool.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using FinanceSentry.Core.Api;
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Mcp.Abstractions;
 using FinanceSentry.Modules.BankSync.Application.Queries;
 using Microsoft.Extensions.Logging;
@@ -68,12 +69,14 @@ public sealed class GetCashflowReportTool(
             .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.Month)
             .Select(g =>
             {
+                // Convert to USD by each transaction's currency — accounts span currencies and
+                // summing native magnitudes would mix hryvnia with euros/dollars.
                 var inflow = g
                     .Where(t => IsCredit(t.TransactionType))
-                    .Sum(t => Math.Abs(t.Amount));
+                    .Sum(t => CurrencyConverter.ToUsd(Math.Abs(t.Amount), t.Currency));
                 var outflow = g
                     .Where(t => IsDebit(t.TransactionType))
-                    .Sum(t => Math.Abs(t.Amount));
+                    .Sum(t => CurrencyConverter.ToUsd(Math.Abs(t.Amount), t.Currency));
                 return new CashflowReportEntry(
                     $"{g.Key.Year:D4}-{g.Key.Month:D2}",
                     inflow,

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetMerchantSpendingQuery.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetMerchantSpendingQuery.cs
@@ -1,15 +1,20 @@
 namespace FinanceSentry.Modules.BankSync.Application.Queries;
 
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
+/// <summary>Per-category spend for a window, keyed by merchant category, summed in USD.</summary>
 public record GetMerchantSpendingQuery(Guid UserId, DateOnly From, DateOnly To)
     : IQuery<IReadOnlyDictionary<string, decimal>>;
 
-public class GetMerchantSpendingQueryHandler(ITransactionRepository transactions)
+public class GetMerchantSpendingQueryHandler(
+    ITransactionRepository transactions,
+    IBankAccountRepository accounts)
     : IQueryHandler<GetMerchantSpendingQuery, IReadOnlyDictionary<string, decimal>>
 {
     private readonly ITransactionRepository _transactions = transactions;
+    private readonly IBankAccountRepository _accounts = accounts;
 
     public async Task<IReadOnlyDictionary<string, decimal>> Handle(
         GetMerchantSpendingQuery request, CancellationToken cancellationToken)
@@ -19,6 +24,11 @@ public class GetMerchantSpendingQueryHandler(ITransactionRepository transactions
 
         var all = await _transactions.GetByUserIdAsync(request.UserId, cancellationToken);
 
+        // Convert to USD by account currency before summing — spend feeds budget comparisons,
+        // which mix accounts in different currencies.
+        var accountList = await _accounts.GetByUserIdAsync(request.UserId, cancellationToken);
+        var currencyByAccount = accountList.ToDictionary(a => a.Id, a => a.Currency);
+
         var result = all
             .Where(t =>
                 t.IsActive &&
@@ -27,7 +37,10 @@ public class GetMerchantSpendingQueryHandler(ITransactionRepository transactions
                 t.PostedDate.Value >= fromUtc &&
                 t.PostedDate.Value <= toUtc)
             .GroupBy(t => t.MerchantCategory ?? string.Empty)
-            .ToDictionary(g => g.Key, g => g.Sum(t => t.Amount));
+            .ToDictionary(
+                g => g.Key,
+                g => g.Sum(t => CurrencyConverter.ToUsd(
+                    t.Amount, currencyByAccount.TryGetValue(t.AccountId, out var c) ? c : "USD")));
 
         return result;
     }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.BankSync.Application.Services;
 
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
@@ -24,9 +25,11 @@ public interface IMerchantCategoryStatisticsService
 /// <inheritdoc />
 public class MerchantCategoryStatisticsService(
     ITransactionRepository transactions,
+    IBankAccountRepository accounts,
     ITransferDetectionService transferDetection) : IMerchantCategoryStatisticsService
 {
     private readonly ITransactionRepository _transactions = transactions ?? throw new ArgumentNullException(nameof(transactions));
+    private readonly IBankAccountRepository _accounts = accounts ?? throw new ArgumentNullException(nameof(accounts));
     private readonly ITransferDetectionService _transferDetection = transferDetection ?? throw new ArgumentNullException(nameof(transferDetection));
 
     /// <inheritdoc />
@@ -35,6 +38,13 @@ public class MerchantCategoryStatisticsService(
     {
         var txList = await _transactions.GetByUserIdAsync(userId, ct);
         var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList());
+
+        // Convert each transaction to USD by its account currency — accounts span UAH/EUR/…,
+        // so summing native Amount would mix currencies and inflate the spend total.
+        var accountList = await _accounts.GetByUserIdAsync(userId, ct);
+        var currencyByAccount = accountList.ToDictionary(a => a.Id, a => a.Currency);
+        decimal ToUsd(Transaction t) =>
+            CurrencyConverter.ToUsd(t.Amount, currencyByAccount.TryGetValue(t.AccountId, out var c) ? c : "USD");
 
         var debits = txList
             .Where(t => !t.IsPending && t.IsActive && t.TransactionType == "debit"
@@ -45,13 +55,13 @@ public class MerchantCategoryStatisticsService(
         if (debits.Count == 0)
             return [];
 
-        var totalSpend = debits.Sum(t => t.Amount);
+        var totalSpend = debits.Sum(ToUsd);
 
         var result = debits
             .GroupBy(t => t.MerchantCategory ?? CategoryKeys.Uncategorized)
             .Select(g =>
             {
-                var spend = g.Sum(t => t.Amount);
+                var spend = g.Sum(ToUsd);
                 var pct = totalSpend > 0 ? Math.Round(spend / totalSpend * 100, 2) : 0m;
                 return new CategoryStat(g.Key, spend, pct);
             })

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/UnusualSpendDetectionJob.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Jobs/UnusualSpendDetectionJob.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.BankSync.Infrastructure.Jobs;
 
 using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -27,11 +28,21 @@ public sealed class UnusualSpendDetectionJob(
             .Select(t => new
             {
                 t.UserId,
+                t.AccountId,
                 t.MerchantCategory,
                 t.TransactionDate,
                 t.Amount,
             })
             .ToListAsync(ct);
+
+        // Convert to USD by account currency before the threshold math — a category funded from
+        // multiple-currency accounts would otherwise compare mixed native magnitudes.
+        var currencyByAccount = await db.BankAccounts
+            .AsNoTracking()
+            .Select(a => new { a.Id, a.Currency })
+            .ToDictionaryAsync(a => a.Id, a => a.Currency, ct);
+        decimal ToUsd(Guid accountId, decimal amount) =>
+            CurrencyConverter.ToUsd(Math.Abs(amount), currencyByAccount.TryGetValue(accountId, out var c) ? c : "USD");
 
         var grouped = rows.GroupBy(r => new {r.UserId, Category = r.MerchantCategory!});
 
@@ -39,7 +50,7 @@ public sealed class UnusualSpendDetectionJob(
         {
             var byMonth = group
                 .GroupBy(r => new {r.TransactionDate.Year, r.TransactionDate.Month})
-                .ToDictionary(g => g.Key, g => g.Sum(x => Math.Abs(x.Amount)));
+                .ToDictionary(g => g.Key, g => g.Sum(x => ToUsd(x.AccountId, x.Amount)));
 
             var historicMonths = byMonth
                 .Where(kv => new DateTime(kv.Key.Year, kv.Key.Month, 1) < currentMonthStart)

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingTransactionReader.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingTransactionReader.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.BankSync.Infrastructure.Services;
 
 using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
 public class BankingTransactionReader(
@@ -18,6 +19,7 @@ public class BankingTransactionReader(
 
         var accountList = await _accounts.GetByUserIdAsync(userId, ct);
         var providerByAccount = accountList.ToDictionary(a => a.Id, a => a.Provider);
+        var currencyByAccount = accountList.ToDictionary(a => a.Id, a => a.Currency);
 
         var txList = await _transactions.GetByUserIdAsync(userId, ct);
 
@@ -29,13 +31,19 @@ public class BankingTransactionReader(
                 return new { t, effectiveDate };
             })
             .Where(x => x.effectiveDate >= fromUtc && x.effectiveDate <= toUtc)
-            .Select(x => new BankingTransactionSummary(
-                x.t.AccountId,
-                providerByAccount.TryGetValue(x.t.AccountId, out var p) ? p : "unknown",
-                x.t.TransactionType ?? "debit",
-                x.t.Amount,
-                x.effectiveDate,
-                x.t.IsPending))
+            .Select(x =>
+            {
+                var currency = currencyByAccount.TryGetValue(x.t.AccountId, out var c) ? c : "USD";
+                return new BankingTransactionSummary(
+                    x.t.AccountId,
+                    providerByAccount.TryGetValue(x.t.AccountId, out var p) ? p : "unknown",
+                    x.t.TransactionType ?? "debit",
+                    x.t.Amount,
+                    currency,
+                    CurrencyConverter.ToUsd(x.t.Amount, currency),
+                    x.effectiveDate,
+                    x.t.IsPending);
+            })
             .ToList();
     }
 }

--- a/backend/src/FinanceSentry.Modules.Budgets/Application/Queries/GetBudgetSummaryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Budgets/Application/Queries/GetBudgetSummaryQuery.cs
@@ -1,6 +1,7 @@
 namespace FinanceSentry.Modules.Budgets.Application.Queries;
 
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Application.Queries;
 using FinanceSentry.Modules.Budgets.API.Responses;
 using FinanceSentry.Modules.Budgets.Application.Services;
@@ -45,19 +46,23 @@ public class GetBudgetSummaryQueryHandler(
             spentByCategory[normalized] = spentByCategory.GetValueOrDefault(normalized) + amount;
         }
 
+        // Spend arrives already in USD (GetMerchantSpendingQuery converts). Normalize each
+        // budget's limit to USD too so the comparison, remaining, and totals are apples-to-apples
+        // across budgets defined in different currencies. The summary is a single-currency (USD) view.
         var items = userBudgets.Select(b =>
         {
+            var limitUsd = CurrencyConverter.ToUsd(b.MonthlyLimit, b.Currency);
             var spent = spentByCategory.GetValueOrDefault(b.Category, 0m);
-            var remaining = b.MonthlyLimit - spent;
+            var remaining = limitUsd - spent;
             return new BudgetSummaryItemDto(
                 b.Id,
                 b.Category,
                 _normalization.GetLabel(b.Category),
-                b.MonthlyLimit,
+                limitUsd,
                 spent,
                 remaining,
-                spent > b.MonthlyLimit,
-                b.Currency);
+                spent > limitUsd,
+                "USD");
         }).ToList();
 
         return new BudgetSummaryResponse(

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
@@ -206,8 +206,10 @@ public class WealthAggregationService(
             .GroupBy(t => ProviderCategoryMapper.GetCategory(t.Provider))
             .Select(g =>
             {
-                var debits = g.Where(t => string.Equals(t.TransactionType, "debit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.Amount);
-                var credits = g.Where(t => string.Equals(t.TransactionType, "credit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.Amount);
+                // Sum AmountUsd — accounts span currencies (UAH/EUR/…); summing native Amount
+                // would add hryvnia to euros as if both were dollars.
+                var debits = g.Where(t => string.Equals(t.TransactionType, "debit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.AmountUsd);
+                var credits = g.Where(t => string.Equals(t.TransactionType, "credit", StringComparison.OrdinalIgnoreCase)).Sum(t => t.AmountUsd);
                 return new TransactionCategoryDto(g.Key, debits, credits, credits - debits, g.Count());
             })
             .ToList();

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
@@ -31,11 +31,25 @@ public class MerchantCategoryStatisticsTests
         return tx;
     }
 
+    private static MerchantCategoryStatisticsService BuildSut(
+        IEnumerable<Transaction> transactions, IEnumerable<BankAccount> accounts)
+    {
+        var txRepoMock = new Mock<ITransactionRepository>();
+        txRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(transactions.ToList());
+
+        var acctRepoMock = new Mock<IBankAccountRepository>();
+        acctRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(accounts.ToList());
+
+        return new MerchantCategoryStatisticsService(txRepoMock.Object, acctRepoMock.Object, new TransferDetectionService());
+    }
+
     [Fact]
     public async Task GetTopCategories_ExcludesInternalTransferDebit()
     {
-        var (_, accountAId) = MakeAccount();
-        var (_, accountBId) = MakeAccount();
+        var (accountA, accountAId) = MakeAccount();
+        var (accountB, accountBId) = MakeAccount();
         var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
 
         // Internal transfer pair carrying a category. Must NOT appear in spending.
@@ -51,11 +65,7 @@ public class MerchantCategoryStatisticsTests
             MakeTx(accountAId, 100m, "debit", date, category: "Travel"),
         };
 
-        var txRepoMock = new Mock<ITransactionRepository>();
-        txRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
-                  .ReturnsAsync(transactions);
-
-        var sut = new MerchantCategoryStatisticsService(txRepoMock.Object, new TransferDetectionService());
+        var sut = BuildSut(transactions, [accountA, accountB]);
 
         var result = await sut.GetTopCategoriesAsync(UserId, 10);
 
@@ -70,7 +80,7 @@ public class MerchantCategoryStatisticsTests
     {
         // A savings-jar top-up categorized TRANSFER_OUT has no synced counterpart, so the
         // pair-matcher can't catch it. It must still be excluded from spend by category name.
-        var (_, accountId) = MakeAccount();
+        var (account, accountId) = MakeAccount();
         var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
 
         var transactions = new List<Transaction>
@@ -79,15 +89,34 @@ public class MerchantCategoryStatisticsTests
             MakeTx(accountId, 40m,   "debit", date, category: "Food"),
         };
 
-        var txRepoMock = new Mock<ITransactionRepository>();
-        txRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
-                  .ReturnsAsync(transactions);
-
-        var sut = new MerchantCategoryStatisticsService(txRepoMock.Object, new TransferDetectionService());
+        var sut = BuildSut(transactions, [account]);
 
         var result = await sut.GetTopCategoriesAsync(UserId, 10);
 
         result.Should().NotContain(c => c.Category == CategoryKeys.TransferOut);
         result.Sum(c => c.TotalSpend).Should().Be(40m);
+    }
+
+    [Fact]
+    public async Task GetTopCategories_MixedCurrencies_SumsSpendInUsd()
+    {
+        // Spend must be converted by account currency before summing. A ₴10,000 Food debit on a
+        // UAH account is $240, not $10,000 — otherwise it would dwarf a real $100 USD Food spend.
+        var (usd, usdId) = MakeAccount("USD");
+        var (uah, uahId) = MakeAccount("UAH");
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var transactions = new List<Transaction>
+        {
+            MakeTx(usdId, 100m,   "debit", date, category: "Food"),
+            MakeTx(uahId, 10000m, "debit", date, category: "Food"),
+        };
+
+        var sut = BuildSut(transactions, [usd, uah]);
+
+        var result = await sut.GetTopCategoriesAsync(UserId, 10);
+
+        // 100 + (10000 × 0.024) = 340, not 10100
+        result.Single(c => c.Category == "Food").TotalSpend.Should().Be(340m);
     }
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
@@ -15,8 +15,8 @@ public class WealthAggregationServiceTests
         => new(Guid.NewGuid(), "Test Bank", "checking", "1234", provider, currency,
                balance, balance.HasValue ? CurrencyConverter.ToUsd(balance.Value, currency) : null, "synced", null);
 
-    private static BankingTransactionSummary MakeTx(Guid accountId, string provider, decimal amount, string type, DateTime date, bool isPending = false)
-        => new(accountId, provider, type, amount, date, isPending);
+    private static BankingTransactionSummary MakeTx(Guid accountId, string provider, decimal amount, string type, DateTime date, bool isPending = false, string currency = "USD")
+        => new(accountId, provider, type, amount, currency, CurrencyConverter.ToUsd(amount, currency), date, isPending);
 
     private WealthAggregationService BuildService(
         IEnumerable<BankingAccountSummary> accounts,
@@ -151,6 +151,26 @@ public class WealthAggregationServiceTests
         result.TotalDebits.Should().Be(300m);
         result.TotalCredits.Should().Be(300m);
         result.NetFlow.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task GetTransactionSummary_MixedCurrencies_SumsInUsdNotNativeMagnitudes()
+    {
+        // Regression: previously summed native Amount, so ₴10,000 + $100 read as $10,100.
+        // Correct is $100 + (10,000 × 0.024 UAH) = $340.
+        var usdAcct = Guid.NewGuid();
+        var uahAcct = Guid.NewGuid();
+        var date = new DateTime(2026, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+        var txs = new[]
+        {
+            MakeTx(usdAcct, "plaid", 100m, "debit", date),
+            MakeTx(uahAcct, "monobank", 10000m, "debit", date, currency: "UAH"),
+        };
+
+        var svc = BuildService([MakeAccount("plaid", "USD", 1000m), MakeAccount("monobank", "UAH", 50000m)], txs);
+        var result = await svc.GetTransactionSummaryAsync(UserId, new DateOnly(2026, 4, 1), new DateOnly(2026, 4, 30), null, null);
+
+        result.TotalDebits.Should().Be(340m);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
Transactions page showed **\$28,315 monthly outflow** (real ≈ \$1.7k). Root cause: transaction-level totals summed native `Amount` raw — Monobank ₴ added to Revolut/AIB € as if all dollars.

## Audit
Account/holdings paths already convert (thread `*Usd`). Every bug was at the **transaction level** where DTOs dropped/ignored currency. Fixed all 6:

| # | Site | Surfaces as |
|---|------|-------------|
| 1 | `GetTransactionSummaryAsync` | Transactions page \$28k |
| 2 | `MerchantCategoryStatisticsService` | Dashboard top-spending %s |
| 3 | `GetMerchantSpendingQuery` | feeds budgets |
| 4 | `GetBudgetSummaryQuery` | budget spent-vs-limit + totals |
| 5 | `UnusualSpendDetectionJob` | spend-threshold alerts |
| 6 | `GetCashflowReportTool` (MCP) | Ledger cashflow reports |

## Fix / convention (now in CLAUDE.md)
Convert once at the reader boundary via `CurrencyConverter.ToUsd`; DTOs crossing an aggregation carry a `*Usd` field; aggregations sum only that. `BankingTransactionSummary` gains `Currency` + `AmountUsd`. Added `CurrencyConverter.IsKnown` to surface unlisted currencies.

## Tests
Mixed-currency regression cases (₴10k + \$100 → \$340, not \$10,100). Build 0 warnings, **435/435 unit tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)