### PR TITLE
fix(subscriptions): update list and summary in place on dismiss/restore

### DIFF
--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.computed.ts
@@ -9,7 +9,6 @@ import {
 interface StateSignals {
   subscriptions: Signal<Subscription[]>;
   sort: Signal<SubscriptionSort>;
-  dismissTargetId: Signal<Nullable<string>>;
   summary: Signal<Nullable<SubscriptionSummary>>;
 }
 
@@ -44,9 +43,6 @@ export function subscriptionsComputed(store: StateSignals) {
     ),
     completedInstallments: computed(() =>
       store.subscriptions().filter(s => s.status === 'completed' && isInstallment(s))
-    ),
-    dismissTarget: computed(
-      () => store.subscriptions().find(s => s.id === store.dismissTargetId()) ?? null
     ),
     sortedActive: computed((): Subscription[] =>
       sortBy(

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.spec.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.spec.ts
@@ -1,0 +1,117 @@
+import {TestBed} from '@angular/core/testing';
+import {of} from 'rxjs';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  type Subscription,
+  type SubscriptionsListResponse,
+  type SubscriptionSummary,
+} from '../../models/subscription/subscription.model';
+import {SubscriptionsService} from '../../services/subscriptions.service';
+import {subscriptionsEffects} from './subscriptions.effects';
+
+const SUBSCRIPTION: Subscription = {
+  id: 'sub-1',
+  merchantName: 'Netflix',
+  cadence: 'monthly',
+  averageAmount: 10,
+  lastKnownAmount: 10,
+  monthlyEquivalent: 10,
+  currency: 'EUR',
+  lastChargeDate: '2026-08-01',
+  nextExpectedDate: '2026-09-01',
+  status: 'active',
+  occurrenceCount: 3,
+  kind: 'subscription',
+  termCount: null,
+  remainingPayments: null,
+  isManual: false,
+};
+
+const LIST_RESPONSE: SubscriptionsListResponse = {
+  items: [SUBSCRIPTION],
+  totalCount: 1,
+  hasInsufficientHistory: false,
+};
+
+const SUMMARY: SubscriptionSummary = {
+  totalMonthlyEstimate: 10,
+  totalAnnualEstimate: 120,
+  activeCount: 1,
+  potentiallyCancelledCount: 0,
+  currency: 'EUR',
+};
+
+function buildStore() {
+  return {
+    setData: vi.fn(),
+    setSummary: vi.fn(),
+    dismissSubscription: vi.fn(),
+    restoreSubscription: vi.fn(),
+  };
+}
+
+function buildService() {
+  return {
+    getSubscriptions: vi.fn(),
+    getSummary: vi.fn(),
+    dismiss: vi.fn(),
+    restore: vi.fn(),
+  };
+}
+
+function configure(service: ReturnType<typeof buildService>) {
+  TestBed.configureTestingModule({
+    providers: [{provide: SubscriptionsService, useValue: service}],
+  });
+}
+
+describe('subscriptionsEffects', () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('load: stores list and summary', () => {
+    const store = buildStore();
+    const service = buildService();
+    service.getSubscriptions.mockReturnValue(of(LIST_RESPONSE));
+    service.getSummary.mockReturnValue(of(SUMMARY));
+    configure(service);
+
+    TestBed.runInInjectionContext(() => subscriptionsEffects(store).load());
+
+    expect(service.getSubscriptions).toHaveBeenCalledWith(true);
+    expect(store.setData).toHaveBeenCalledWith([SUBSCRIPTION], false);
+    expect(store.setSummary).toHaveBeenCalledWith(SUMMARY);
+  });
+
+  it('dismiss: updates the list row and refetches the summary', () => {
+    const store = buildStore();
+    const service = buildService();
+    service.dismiss.mockReturnValue(of(void 0));
+    service.getSummary.mockReturnValue(of(SUMMARY));
+    configure(service);
+
+    TestBed.runInInjectionContext(() => subscriptionsEffects(store).dismiss('sub-1'));
+
+    expect(service.dismiss).toHaveBeenCalledWith('sub-1');
+    expect(store.dismissSubscription).toHaveBeenCalledWith('sub-1');
+    expect(service.getSummary).toHaveBeenCalled();
+    expect(store.setSummary).toHaveBeenCalledWith(SUMMARY);
+  });
+
+  it('restore: updates the list row and refetches the summary', () => {
+    const store = buildStore();
+    const service = buildService();
+    service.restore.mockReturnValue(of(void 0));
+    service.getSummary.mockReturnValue(of(SUMMARY));
+    configure(service);
+
+    TestBed.runInInjectionContext(() => subscriptionsEffects(store).restore('sub-1'));
+
+    expect(service.restore).toHaveBeenCalledWith('sub-1');
+    expect(store.restoreSubscription).toHaveBeenCalledWith('sub-1');
+    expect(service.getSummary).toHaveBeenCalled();
+    expect(store.setSummary).toHaveBeenCalledWith(SUMMARY);
+  });
+});

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.effects.ts
@@ -13,7 +13,7 @@ import {SubscriptionsService} from '../../services/subscriptions.service';
 interface EffectsStore {
   setData: (subscriptions: Subscription[], hasInsufficientHistory: boolean) => void;
   setSummary: (summary: SubscriptionSummary) => void;
-  confirmDismiss: () => void;
+  dismissSubscription: (id: string) => void;
   restoreSubscription: (id: string) => void;
 }
 
@@ -31,13 +31,30 @@ export function subscriptionsEffects(store: EffectsStore) {
       })
     );
 
+  const refreshSummary = (): Observable<SubscriptionSummary> =>
+    service.getSummary().pipe(tap(summary => store.setSummary(summary)));
+
   return {
     load: rxMethod<void>(pipe(switchMap(() => refresh()))),
     dismiss: rxMethod<string>(
-      pipe(switchMap(id => service.dismiss(id).pipe(tap(() => store.confirmDismiss()))))
+      pipe(
+        switchMap(id =>
+          service.dismiss(id).pipe(
+            tap(() => store.dismissSubscription(id)),
+            switchMap(() => refreshSummary())
+          )
+        )
+      )
     ),
     restore: rxMethod<string>(
-      pipe(switchMap(id => service.restore(id).pipe(tap(() => store.restoreSubscription(id)))))
+      pipe(
+        switchMap(id =>
+          service.restore(id).pipe(
+            tap(() => store.restoreSubscription(id)),
+            switchMap(() => refreshSummary())
+          )
+        )
+      )
     ),
     setInstallmentTerm: rxMethod<{id: string; termCount: Nullable<number>}>(
       pipe(

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.methods.spec.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.methods.spec.ts
@@ -1,0 +1,122 @@
+import {signalState} from '@ngrx/signals';
+import {describe, expect, it} from 'vitest';
+
+import {
+  type Subscription,
+  type SubscriptionSummary,
+} from '../../models/subscription/subscription.model';
+import {subscriptionsMethods} from './subscriptions.methods';
+import {initialSubscriptionsState} from './subscriptions.state';
+
+function mkSubscription(overrides: Partial<Subscription> = {}): Subscription {
+  return {
+    id: 'sub-1',
+    merchantName: 'Netflix',
+    cadence: 'monthly',
+    averageAmount: 10,
+    lastKnownAmount: 10,
+    monthlyEquivalent: 10,
+    currency: 'EUR',
+    lastChargeDate: '2026-08-01',
+    nextExpectedDate: '2026-09-01',
+    status: 'active',
+    occurrenceCount: 3,
+    kind: 'subscription',
+    termCount: null,
+    remainingPayments: null,
+    isManual: false,
+    ...overrides,
+  };
+}
+
+function mkSummary(overrides: Partial<SubscriptionSummary> = {}): SubscriptionSummary {
+  return {
+    totalMonthlyEstimate: 25,
+    totalAnnualEstimate: 300,
+    activeCount: 2,
+    potentiallyCancelledCount: 0,
+    currency: 'EUR',
+    ...overrides,
+  };
+}
+
+describe('subscriptionsMethods', () => {
+  it('setData stores subscriptions and resets status', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+
+    methods.setData([mkSubscription()], true);
+
+    expect(state.subscriptions()).toHaveLength(1);
+    expect(state.hasInsufficientHistory()).toBe(true);
+    expect(state.status()).toBe('idle');
+  });
+
+  it('setSummary stores the summary', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+
+    methods.setSummary(mkSummary());
+
+    expect(state.summary()).toEqual(mkSummary());
+  });
+
+  it('dismissSubscription flips only the matching row to dismissed', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+    methods.setData([mkSubscription({id: 'a'}), mkSubscription({id: 'b'})], false);
+
+    methods.dismissSubscription('a');
+
+    expect(state.subscriptions().find(s => s.id === 'a')?.status).toBe('dismissed');
+    expect(state.subscriptions().find(s => s.id === 'b')?.status).toBe('active');
+  });
+
+  it('dismissSubscription keeps the summary intact', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+    methods.setData([mkSubscription({id: 'a'})], false);
+    methods.setSummary(mkSummary());
+
+    methods.dismissSubscription('a');
+
+    expect(state.summary()).toEqual(mkSummary());
+  });
+
+  it('restoreSubscription flips only the matching row back to active', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+    methods.setData(
+      [
+        mkSubscription({id: 'a', status: 'dismissed'}),
+        mkSubscription({id: 'b', status: 'dismissed'}),
+      ],
+      false
+    );
+
+    methods.restoreSubscription('a');
+
+    expect(state.subscriptions().find(s => s.id === 'a')?.status).toBe('active');
+    expect(state.subscriptions().find(s => s.id === 'b')?.status).toBe('dismissed');
+  });
+
+  it('restoreSubscription keeps the summary intact', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+    methods.setData([mkSubscription({id: 'a', status: 'dismissed'})], false);
+    methods.setSummary(mkSummary());
+
+    methods.restoreSubscription('a');
+
+    expect(state.summary()).toEqual(mkSummary());
+  });
+
+  it('setSort stores the sort', () => {
+    const state = signalState(initialSubscriptionsState);
+    const methods = subscriptionsMethods(state);
+
+    methods.setSort('amount');
+
+    expect(state.sort()).toBe('amount');
+  });
+});

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.methods.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.methods.ts
@@ -18,16 +18,11 @@ export function subscriptionsMethods(store: WritableStateSource<SubscriptionsSta
     setSort(sort: SubscriptionSort): void {
       patchState(store, {sort});
     },
-    setDismissTarget(id: Nullable<string>): void {
-      patchState(store, {dismissTargetId: id});
-    },
-    confirmDismiss(): void {
+    dismissSubscription(id: string): void {
       patchState(store, (s: SubscriptionsState) => ({
         subscriptions: s.subscriptions.map(sub =>
-          sub.id === s.dismissTargetId ? {...sub, status: 'dismissed' as const} : sub
+          sub.id === id ? {...sub, status: 'dismissed' as const} : sub
         ),
-        dismissTargetId: null,
-        summary: null,
       }));
     },
     restoreSubscription(id: string): void {
@@ -35,7 +30,6 @@ export function subscriptionsMethods(store: WritableStateSource<SubscriptionsSta
         subscriptions: s.subscriptions.map(sub =>
           sub.id === id ? {...sub, status: 'active' as const} : sub
         ),
-        summary: null,
       }));
     },
   };

--- a/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.state.ts
+++ b/frontend/src/app/modules/subscriptions/store/subscriptions/subscriptions.state.ts
@@ -7,7 +7,6 @@ import {
 export interface SubscriptionsState {
   subscriptions: Subscription[];
   sort: SubscriptionSort;
-  dismissTargetId: Nullable<string>;
   summary: Nullable<SubscriptionSummary>;
   hasInsufficientHistory: boolean;
   status: AsyncStatus;
@@ -16,7 +15,6 @@ export interface SubscriptionsState {
 export const initialSubscriptionsState: SubscriptionsState = {
   subscriptions: [],
   sort: 'date',
-  dismissTargetId: null,
   summary: null,
   hasInsufficientHistory: false,
   status: 'idle',


### PR DESCRIPTION
## Bug

Dismissing a subscription issued `PATCH /subscriptions/{id}/dismiss` (204, DB row flipped) but the row never left the Active list, and the Monthly/Annual summary cards blanked to "—" until a manual reload. Restore had the same summary-blanking problem.

## Root causes

1. **Dead `dismissTargetId` indirection** — `confirmDismiss()` updated the sub matching `dismissTargetId`, but `setDismissTarget()` was never called anywhere: the component runs its own confirm dialog (`CmnDialogService` + `ConfirmDialogComponent`) and calls `store.dismiss(sub.id)` directly. The target was always `null`, so no row was ever updated.
2. **`summary: null` without refetch** — both dismiss and restore nulled the summary, and nothing repopulated it, so the stat cards fell back to "—".

## Fix

- Dropped the dead `dismissTargetId` mechanism entirely (state field, `setDismissTarget`, `dismissTarget` computed). The dismiss effect now updates the row by the id it already receives via a new `dismissSubscription(id)` method — mirroring `restoreSubscription(id)`.
- Neither method touches `summary` anymore; the `dismiss`/`restore` effects refetch it (`GET /subscriptions/summary`) after the PATCH succeeds and patch it in place.

UX unchanged: confirm dialog on dismiss, immediate in-page list + summary update on both actions, no reload.

## Tests

- New `subscriptions.methods.spec.ts` (7 tests): dismiss/restore flip only the matching row, summary left intact, plus setData/setSummary/setSort.
- New `subscriptions.effects.spec.ts` (3 tests): dismiss and restore call the service, update the list row, and refetch + store the summary; load stores list + summary.
- `npx ng test --watch=false`: subscriptions suites green; 7 pre-existing failures in `@dsdevq-common/ui` (tab-group / page-container / editable-field) are unrelated.
- ESLint + Prettier clean (pre-commit hook lints all projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)