### PR TITLE
fix(ui): make cmn-dialog viewport-safe below 512px

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/dialog/dialog-container.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/dialog/dialog-container.component.ts
@@ -9,10 +9,13 @@ const SHELL_BASE =
   'rounded-cmn-lg border border-border-default shadow-cmn-lg overflow-hidden ' +
   'max-h-[90vh] w-full';
 
+// Min-widths are gated behind the first breakpoint where they fit inside the
+// panel's 1rem padding (viewport - 2rem >= min-width); below that the shell's
+// `w-full` makes the dialog full-width-with-margin instead of clipping.
 const SIZE_CLASSES: Record<CmnDialogSize, string> = {
-  sm: 'min-w-[24rem] max-w-md',
-  md: 'min-w-[32rem] max-w-xl',
-  lg: 'min-w-[40rem] max-w-3xl',
+  sm: 'min-w-0 sm:min-w-[24rem] max-w-md',
+  md: 'min-w-0 sm:min-w-[32rem] max-w-xl',
+  lg: 'min-w-0 md:min-w-[40rem] max-w-3xl',
   full: 'max-w-[95vw] h-[95vh]',
 };
 


### PR DESCRIPTION
## Bug

`SIZE_CLASSES` in `dialog-container.component.ts` set hard min-widths (`sm: 24rem`, `md: 32rem`, `lg: 40rem`) with no small-screen override. At a 360px viewport the md dialog rendered 448px wide (root font-size is 14px) and clipped ~44px on each side — "Connect account" title truncated, submit button cut off.

## Fix

Gate each min-width behind the first Tailwind breakpoint where it fits inside the panel's 1rem padding, with `min-w-0` below it so the shell's existing `w-full` gives full-width-with-margin on phones:

| Size | Before | After |
|---|---|---|
| `sm` | `min-w-[24rem] max-w-md` | `min-w-0 sm:min-w-[24rem] max-w-md` |
| `md` | `min-w-[32rem] max-w-xl` | `min-w-0 sm:min-w-[32rem] max-w-xl` |
| `lg` | `min-w-[40rem] max-w-3xl` | `min-w-0 md:min-w-[40rem] max-w-3xl` |
| `full` | `max-w-[95vw] h-[95vh]` | unchanged (already viewport-relative) |

`.cmn-dialog-panel--*` in `theme.css` (width 100% + 1rem padding, flex-centered) and the CDK overlay config in `dialog.service.ts` (default global strategy, no fixed width) were checked and are already viewport-safe — the min-widths were the sole cause.

## Verification

Served the fixed worktree build locally and drove the Connect Account dialog with scripted Playwright, comparing against the unfixed main-checkout build:

| Build | 360px viewport | 1440px viewport |
|---|---|---|
| main (old) | shell 448px, `x=-44` → **clipped both sides** | 504px |
| this branch | shell 332px, fully inside viewport, full title | 504px (**identical**) |

`ng build @dsdevq-common/ui` passes; ESLint/Prettier clean via pre-commit hook (full `ng lint` across app + libs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)