### PR TITLE
fix(connect): reset error state on navigation, preserve form on failed submit, fix error-code resolution

### DIFF
--- a/frontend/src/app/core/errors/error-messages.registry.ts
+++ b/frontend/src/app/core/errors/error-messages.registry.ts
@@ -10,9 +10,13 @@ export const ERROR_MESSAGES_REGISTRY: ErrorMessagesMap = {
     'Binance rejected the provided credentials. Use a read-only API key with no IP restrictions.',
   BINANCE_DUPLICATE:
     'Binance account already connected. Disconnect the existing one to use new keys.',
+  BINANCE_ALREADY_CONNECTED:
+    'Binance account already connected. Disconnect the existing one to use new keys.',
   IBKR_INVALID_CREDENTIALS:
     'IB Gateway rejected the provided credentials. Confirm the 2FA push notification on your phone and try again.',
   IBKR_DUPLICATE: 'IBKR account already connected. Disconnect the existing one to reconnect.',
+  IBKR_ALREADY_CONNECTED:
+    'IBKR account already connected. Disconnect the existing one to reconnect.',
   IBKR_GATEWAY_UNAVAILABLE:
     'Could not reach the IBKR gateway. This is usually temporary — try again in a minute.',
   PLAID_DUPLICATE: 'This bank is already connected. View it in your accounts list.',

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/binance-form.component.spec.ts
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/binance-form.component.spec.ts
@@ -88,6 +88,14 @@ describe('BinanceFormComponent', () => {
     expect(fixture.componentInstance.isDuplicateError()).toBe(true);
   });
 
+  it('isDuplicateError flips when the backend emits ALREADY_CONNECTED', () => {
+    const store = buildConnectStore('ALREADY_CONNECTED');
+    configure(store, buildAccountsStore(), buildStrategy());
+
+    const fixture = TestBed.createComponent(BinanceFormComponent);
+    expect(fixture.componentInstance.isDuplicateError()).toBe(true);
+  });
+
   it('disconnectExisting calls accountsStore.disconnectBinance and resets error/form', () => {
     const store = buildConnectStore('BINANCE_DUPLICATE');
     const accounts = buildAccountsStore();

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/binance-form.component.ts
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/binance-form.component.ts
@@ -39,7 +39,12 @@ export class BinanceFormComponent {
 
   public readonly helpUrl = BINANCE_HELP_URL;
 
-  public readonly isDuplicateError = computed(() => this.store.errorCode() === 'BINANCE_DUPLICATE');
+  // Backend emits ALREADY_CONNECTED (409) for a duplicate Binance connection;
+  // BINANCE_DUPLICATE is kept for backwards compatibility.
+  public readonly isDuplicateError = computed(() => {
+    const code = this.store.errorCode();
+    return code === 'ALREADY_CONNECTED' || code === 'BINANCE_DUPLICATE';
+  });
 
   public submit(): void {
     if (this.form.invalid) {

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/connect-modal.component.html
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/connect-modal.component.html
@@ -1,6 +1,9 @@
 @if (store.isBusy()) {
   <fns-syncing-state />
-} @else {
+}
+<!-- Keep the current step alive (hidden) while busy so a failed submit returns
+     the user to their still-populated form instead of a fresh instance. -->
+<div [class.hidden]="store.isBusy()">
   @switch (store.modalStep()) {
     @case ('type-picker') {
       <fns-type-picker />
@@ -14,4 +17,4 @@
       }
     }
   }
-}
+</div>

--- a/frontend/src/app/modules/bank-sync/components/connect-modal/monobank-form.component.ts
+++ b/frontend/src/app/modules/bank-sync/components/connect-modal/monobank-form.component.ts
@@ -1,4 +1,5 @@
 import {ChangeDetectionStrategy, Component, computed, inject} from '@angular/core';
+import {toSignal} from '@angular/core/rxjs-interop';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {
   AlertComponent,
@@ -34,27 +35,32 @@ export class MonobankFormComponent {
   private readonly strategy = inject(CONNECT_STRATEGY);
   private readonly accountsStore = inject(AccountsStore, {optional: true});
 
+  private readonly token = new FormControl<string>('', {
+    nonNullable: true,
+    validators: [
+      Validators.required,
+      Validators.minLength(MONOBANK_TOKEN_MIN_LENGTH),
+      Validators.maxLength(MONOBANK_TOKEN_MAX_LENGTH),
+      Validators.pattern(MONOBANK_TOKEN_PATTERN),
+    ],
+  });
+
+  // FormControl.touched/invalid are not signals — bridge via the control's
+  // unified event stream so the computed re-evaluates on value/status/touched changes.
+  private readonly tokenControlEvents = toSignal(this.token.events);
+
   public readonly store = inject(ConnectStore);
 
-  public readonly form = new FormGroup({
-    token: new FormControl<string>('', {
-      nonNullable: true,
-      validators: [
-        Validators.required,
-        Validators.minLength(MONOBANK_TOKEN_MIN_LENGTH),
-        Validators.maxLength(MONOBANK_TOKEN_MAX_LENGTH),
-        Validators.pattern(MONOBANK_TOKEN_PATTERN),
-      ],
-    }),
-  });
+  public readonly form = new FormGroup({token: this.token});
 
   public readonly tokenControl = this.form.controls.token;
 
-  public readonly tokenError = computed(() =>
-    this.tokenControl.touched && this.tokenControl.invalid
+  public readonly tokenError = computed(() => {
+    this.tokenControlEvents();
+    return this.tokenControl.touched && this.tokenControl.invalid
       ? "This doesn't look like a Monobank token"
-      : ''
-  );
+      : '';
+  });
 
   public readonly isDuplicateError = computed(
     () => this.store.errorCode() === 'MONOBANK_TOKEN_DUPLICATE'

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.computed.spec.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.computed.spec.ts
@@ -83,6 +83,39 @@ describe('connectComputed', () => {
     });
   });
 
+  it('errorMessage resolves the real backend INVALID_CREDENTIALS code for binance', () => {
+    const store = build({
+      status: 'error',
+      errorCode: 'INVALID_CREDENTIALS',
+      selectedProvider: 'binance',
+    });
+    TestBed.runInInjectionContext(() => {
+      expect(connectComputed(store).errorMessage()).toContain('read-only API key');
+    });
+  });
+
+  it('errorMessage resolves the real backend INVALID_CREDENTIALS code for ibkr', () => {
+    const store = build({
+      status: 'error',
+      errorCode: 'INVALID_CREDENTIALS',
+      selectedProvider: 'ibkr',
+    });
+    TestBed.runInInjectionContext(() => {
+      expect(connectComputed(store).errorMessage()).toContain('IB Gateway');
+    });
+  });
+
+  it('errorMessage resolves the real backend ALREADY_CONNECTED code for binance', () => {
+    const store = build({
+      status: 'error',
+      errorCode: 'ALREADY_CONNECTED',
+      selectedProvider: 'binance',
+    });
+    TestBed.runInInjectionContext(() => {
+      expect(connectComputed(store).errorMessage()).toContain('Binance account already connected');
+    });
+  });
+
   it('errorMessage maps PLAID_LINK_FAILED to link-specific copy', () => {
     const store = build({
       status: 'error',

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.computed.ts
@@ -42,6 +42,19 @@ function mapErrorByProvider(
 
 const PROVIDER_SLUGS: readonly Provider[] = ['plaid', 'monobank', 'binance', 'ibkr'];
 
+function resolveForProvider(
+  errorMessages: ErrorMessageService,
+  code: Nullable<string>,
+  provider: Provider
+): Nullable<string> {
+  if (!code) {
+    return null;
+  }
+  // Backend emits generic codes (e.g. INVALID_CREDENTIALS from both Binance and
+  // IBKR) — try the provider-prefixed registry key first, then the raw code.
+  return errorMessages.resolve(`${provider.toUpperCase()}_${code}`) ?? errorMessages.resolve(code);
+}
+
 export function connectComputed(store: StateSignals) {
   const errorMessages = inject(ErrorMessageService);
   const accountsStore = inject(AccountsStore, {optional: true});
@@ -61,7 +74,7 @@ export function connectComputed(store: StateSignals) {
       return mapErrorByProvider(
         store.errorCode(),
         store.selectedProvider(),
-        errorMessages.resolve(store.errorCode())
+        resolveForProvider(errorMessages, store.errorCode(), store.selectedProvider())
       );
     }),
     connectedProviders: computed<ReadonlySet<Provider>>(() => {

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.effects.spec.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.effects.spec.ts
@@ -18,6 +18,7 @@ function buildStore() {
     setSuccess: vi.fn(),
     setError: vi.fn(),
     setInstitutionType: vi.fn(),
+    selectProvider: vi.fn(),
     status: vi.fn().mockReturnValue('idle' as const),
     institutionType: vi.fn().mockReturnValue(null),
   };
@@ -71,6 +72,7 @@ describe('connectEffects.connect', () => {
       connectEffects(store).connect({strategy, payload: undefined});
     });
 
+    expect(store.selectProvider).toHaveBeenCalledWith('plaid');
     expect(store.setInstitutionType).toHaveBeenCalledWith('bank');
     expect(store.setSyncing).toHaveBeenCalled();
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -94,6 +96,7 @@ describe('connectEffects.connect', () => {
       connectEffects(store).connect({strategy, payload: {apiKey: 'k', apiSecret: 's'}});
     });
 
+    expect(store.selectProvider).toHaveBeenCalledWith('binance');
     expect(store.setSuccess).toHaveBeenCalled();
     expect(store.setPolling).not.toHaveBeenCalled();
   });

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.effects.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.effects.ts
@@ -6,7 +6,10 @@ import {rxMethod} from '@ngrx/signals/rxjs-interop';
 import {catchError, EMPTY, filter, map, pipe, race, switchMap, take, tap, timer} from 'rxjs';
 
 import {AppRoute} from '../../../../shared/enums/app-route/app-route.enum';
-import {type InstitutionType} from '../../../../shared/models/provider/provider.model';
+import {
+  type InstitutionType,
+  type Provider,
+} from '../../../../shared/models/provider/provider.model';
 import {ErrorUtils} from '../../../../shared/utils/error.utils';
 import {AccountsStore} from '../accounts/accounts.store';
 import {type ConnectStatus} from './connect.state';
@@ -17,6 +20,7 @@ interface EffectsStore {
   setSuccess: () => void;
   setError: (code: Nullable<string>) => void;
   setInstitutionType: (type: InstitutionType) => void;
+  selectProvider: (provider: Provider) => void;
   status: () => ConnectStatus;
   institutionType: () => Nullable<InstitutionType>;
 }
@@ -90,6 +94,7 @@ export function connectEffects(store: EffectsStore) {
   const connect = rxMethod<ConnectInput>(
     pipe(
       tap(({strategy}) => {
+        store.selectProvider(strategy.slug);
         store.setInstitutionType(institutionTypeForSlug(strategy));
         store.setSyncing(`Connecting your ${strategy.slug} account...`);
       }),

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.methods.spec.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.methods.spec.ts
@@ -13,8 +13,74 @@ describe('connectMethods', () => {
     methods.selectProvider('monobank');
 
     expect(state.selectedProvider()).toBe('monobank');
+    expect(state.status()).toBe('idle');
     expect(state.errorCode()).toBeNull();
     expect(state.statusMessage()).toBeNull();
+  });
+
+  it('selectInstitutionType(crypto) resets error status and selects binance', () => {
+    const state = signalState(initialConnectState);
+    const methods = connectMethods(state);
+    methods.setError('X');
+
+    methods.selectInstitutionType('crypto');
+
+    expect(state.modalStep()).toBe('binance-form');
+    expect(state.selectedProvider()).toBe('binance');
+    expect(state.status()).toBe('idle');
+    expect(state.errorCode()).toBeNull();
+    expect(state.statusMessage()).toBeNull();
+  });
+
+  it('selectInstitutionType(broker) resets error status and selects ibkr', () => {
+    const state = signalState(initialConnectState);
+    const methods = connectMethods(state);
+    methods.setError('X');
+
+    methods.selectInstitutionType('broker');
+
+    expect(state.modalStep()).toBe('ibkr-form');
+    expect(state.selectedProvider()).toBe('ibkr');
+    expect(state.status()).toBe('idle');
+    expect(state.errorCode()).toBeNull();
+  });
+
+  it('selectInstitutionType(bank) keeps the current provider until a bank is picked', () => {
+    const state = signalState(initialConnectState);
+    const methods = connectMethods(state);
+    methods.selectProvider('monobank');
+
+    methods.selectInstitutionType('bank');
+
+    expect(state.modalStep()).toBe('bank-picker');
+    expect(state.selectedProvider()).toBe('monobank');
+    expect(state.status()).toBe('idle');
+  });
+
+  it('setModalStep resets error status on navigation between steps', () => {
+    const state = signalState(initialConnectState);
+    const methods = connectMethods(state);
+    methods.setError('MONOBANK_TOKEN_INVALID');
+
+    methods.setModalStep('bank-picker');
+
+    expect(state.modalStep()).toBe('bank-picker');
+    expect(state.status()).toBe('idle');
+    expect(state.errorCode()).toBeNull();
+    expect(state.statusMessage()).toBeNull();
+  });
+
+  it('selectBankProvider resets error status and sets the provider', () => {
+    const state = signalState(initialConnectState);
+    const methods = connectMethods(state);
+    methods.setError('X');
+
+    methods.selectBankProvider('truelayer');
+
+    expect(state.selectedProvider()).toBe('truelayer');
+    expect(state.modalStep()).toBe('truelayer-picker');
+    expect(state.status()).toBe('idle');
+    expect(state.errorCode()).toBeNull();
   });
 
   it('setInitializing clears error and statusMessage', () => {

--- a/frontend/src/app/modules/bank-sync/store/connect/connect.methods.ts
+++ b/frontend/src/app/modules/bank-sync/store/connect/connect.methods.ts
@@ -17,6 +17,11 @@ const STEP_FOR_BANK_PROVIDER: Record<BankProvider, ModalStep> = {
   truelayer: 'truelayer-picker',
 };
 
+const PROVIDER_FOR_TYPE: Partial<Record<InstitutionType, Provider>> = {
+  crypto: 'binance',
+  broker: 'ibkr',
+};
+
 export function connectMethods(store: WritableStateSource<ConnectState>) {
   return {
     openModal(): void {
@@ -39,21 +44,35 @@ export function connectMethods(store: WritableStateSource<ConnectState>) {
       });
     },
     selectInstitutionType(type: InstitutionType): void {
-      patchState(store, {institutionType: type, modalStep: STEP_FOR_TYPE[type], errorCode: null});
+      const provider = PROVIDER_FOR_TYPE[type];
+      patchState(store, {
+        institutionType: type,
+        modalStep: STEP_FOR_TYPE[type],
+        status: 'idle',
+        errorCode: null,
+        statusMessage: null,
+        ...(provider ? {selectedProvider: provider} : {}),
+      });
     },
     setInstitutionType(type: InstitutionType): void {
       patchState(store, {institutionType: type});
     },
     setModalStep(step: ModalStep): void {
-      patchState(store, {modalStep: step, errorCode: null});
+      patchState(store, {modalStep: step, status: 'idle', errorCode: null, statusMessage: null});
     },
     selectProvider(provider: Provider): void {
-      patchState(store, {selectedProvider: provider, errorCode: null, statusMessage: null});
+      patchState(store, {
+        selectedProvider: provider,
+        status: 'idle',
+        errorCode: null,
+        statusMessage: null,
+      });
     },
     selectBankProvider(slug: BankProvider): void {
       patchState(store, {
         selectedProvider: slug,
         modalStep: STEP_FOR_BANK_PROVIDER[slug],
+        status: 'idle',
         errorCode: null,
         statusMessage: null,
       });


### PR DESCRIPTION
Fixes the three verified connect-modal bugs from the QA sweep.

## Bug A — stale/wrong-provider error banner
- `selectInstitutionType` / `setModalStep` / `selectProvider` / `selectBankProvider` now reset `status` to `'idle'` (plus `errorCode`/`statusMessage`) so `errorMessage` can't survive navigation between steps/providers.
- `selectInstitutionType('crypto'|'broker')` now sets `selectedProvider` to `binance`/`ibkr`; the connect effect also stamps `selectedProvider` from `strategy.slug` at submit — the fallback message can no longer name the wrong provider.
- Error-code alignment with what the backend really emits: Binance sends `INVALID_CREDENTIALS` (422) and `ALREADY_CONNECTED` (409); IBKR sends `INVALID_CREDENTIALS` and `IBKR_DUPLICATE`. `connect.computed.ts` now resolves the provider-prefixed registry key first (`BINANCE_INVALID_CREDENTIALS`, `IBKR_INVALID_CREDENTIALS`, …) then the raw code, so the shared `INVALID_CREDENTIALS` maps to the right message per provider. Added `BINANCE_ALREADY_CONNECTED` / `IBKR_ALREADY_CONNECTED` registry entries; existing keys kept (specs and `isDuplicateError` checks still use them). `binance-form` duplicate detection now also recognizes the real `ALREADY_CONNECTED` code. No backend changes.

## Bug B — form state destroyed on failed submit
`connect-modal.component.html` no longer swaps the current step out via `@if` while busy — the step stays mounted inside a `[class.hidden]` container with `<fns-syncing-state/>` shown on top. A failed submit returns the user to their still-populated form with the error banner, ready to retry.

## Bug C — Monobank custom token error never renders
`tokenError` was a `computed()` over non-signal `FormControl.touched/invalid`. Bridged via `toSignal(control.events)` (the same unified-control-events pattern `cmn-form-field` uses internally), so the custom copy now renders on touch/status changes.

## Tests
- New/extended Vitest specs: status reset on step/provider navigation, `selectedProvider` set for crypto/broker (methods + effects), registry resolution for the real `INVALID_CREDENTIALS`/`ALREADY_CONNECTED` codes per provider, `ALREADY_CONNECTED` duplicate detection in the Binance form.
- App suite green: 158/158 (30 files). Pre-existing failures in the `@dsdevq-common/ui` library project (tab-group, page-container, editable-field — 7 tests) are untouched by this change.
- ESLint clean on all touched files; pre-commit lint + prettier gates passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)