### PR TITLE
feat(wealth): surface stale bank connections; stop phantom net-worth swings

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/IBankingTotalsReader.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IBankingTotalsReader.cs
@@ -4,4 +4,11 @@ public interface IBankingTotalsReader
 {
     Task<IReadOnlyList<Guid>> GetActiveUserIdsAsync(CancellationToken ct = default);
     Task<decimal> GetTotalUsdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// The most recent <b>successful</b> sync time across the user's active banking accounts, or
+    /// null when none have ever synced. Used to decide whether the banking sleeve is fresh enough
+    /// to record as live, or stale (a lapsed connection) and better carried forward.
+    /// </summary>
+    Task<DateTime?> GetLatestSuccessfulSyncAsync(Guid userId, CancellationToken ct = default);
 }

--- a/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/INetWorthSnapshotService.cs
@@ -17,6 +17,7 @@ public record NetWorthSnapshotData(
     decimal BankingTotal,
     decimal BrokerageTotal,
     decimal CryptoTotal,
+    bool BankingFresh = true,
     bool BrokerageFresh = true,
     bool CryptoFresh = true,
     string Currency = "USD");

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingTotalsReader.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingTotalsReader.cs
@@ -4,9 +4,12 @@ using FinanceSentry.Core.Interfaces;
 using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
-public class BankingTotalsReader(IBankAccountRepository accounts) : IBankingTotalsReader
+public class BankingTotalsReader(
+    IBankAccountRepository accounts,
+    ISyncJobRepository syncJobs) : IBankingTotalsReader
 {
     private readonly IBankAccountRepository _accounts = accounts ?? throw new ArgumentNullException(nameof(accounts));
+    private readonly ISyncJobRepository _syncJobs = syncJobs ?? throw new ArgumentNullException(nameof(syncJobs));
 
     public async Task<IReadOnlyList<Guid>> GetActiveUserIdsAsync(CancellationToken ct = default)
     {
@@ -20,5 +23,21 @@ public class BankingTotalsReader(IBankAccountRepository accounts) : IBankingTota
         return accounts
             .Where(a => a.IsActive && a.CurrentBalance.HasValue)
             .Sum(a => CurrencyConverter.ToUsd(a.CurrentBalance!.Value, a.Currency));
+    }
+
+    public async Task<DateTime?> GetLatestSuccessfulSyncAsync(Guid userId, CancellationToken ct = default)
+    {
+        var accounts = await _accounts.GetByUserIdAsync(userId, ct);
+        var activeIds = accounts.Where(a => a.IsActive).Select(a => a.Id).ToHashSet();
+        if (activeIds.Count == 0)
+            return null;
+
+        var lastSuccessful = await _syncJobs.GetLastSuccessfulSyncTimesByUserAsync(userId, ct);
+        var times = lastSuccessful
+            .Where(kv => activeIds.Contains(kv.Key))
+            .Select(kv => kv.Value)
+            .ToList();
+
+        return times.Count > 0 ? times.Max() : null;
     }
 }

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/NetWorthSnapshotService.cs
@@ -20,7 +20,7 @@ public class NetWorthSnapshotService(INetWorthSnapshotRepository repository) : I
         var previous = await _repository.GetLatestByUserIdAsync(userId, ct);
         var stale = new List<string>();
 
-        var banking = ResolveSleeve("banking", data.BankingTotal, isFresh: true, previous?.BankingTotal, stale);
+        var banking = ResolveSleeve("banking", data.BankingTotal, data.BankingFresh, previous?.BankingTotal, stale);
         var brokerage = ResolveSleeve("brokerage", data.BrokerageTotal, data.BrokerageFresh, previous?.BrokerageTotal, stale);
         var crypto = ResolveSleeve("crypto", data.CryptoTotal, data.CryptoFresh, previous?.CryptoTotal, stale);
 

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
@@ -16,6 +16,10 @@ public class WealthAggregationService(
 
     private static readonly TimeSpan StaleThreshold = TimeSpan.FromHours(1);
 
+    // Banking feeds sync roughly daily (not tick-by-tick like crypto/brokerage prices), so a
+    // longer window before we call a bank account "stale". Matches the net-worth snapshot job.
+    private static readonly TimeSpan BankingStaleThreshold = TimeSpan.FromHours(36);
+
     private static readonly IReadOnlyDictionary<string, int> SyncStatusPriority =
         new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
@@ -146,7 +150,7 @@ public class WealthAggregationService(
                 a.AccountId, a.BankName, a.AccountType, a.AccountNumberLast4,
                 a.Provider, ProviderCategoryMapper.GetCategory(a.Provider),
                 a.Currency, a.CurrentBalance, a.BalanceUsd,
-                a.SyncStatus, a.LastSyncTimestamp)).ToList();
+                EffectiveBankingStatus(a.SyncStatus, a.LastSuccessfulSyncTimestamp), a.LastSyncTimestamp)).ToList();
 
             return new InstitutionDto(
                 InstitutionId: InstitutionIdFor(first),
@@ -154,7 +158,7 @@ public class WealthAggregationService(
                 Name: first.BankName,
                 Category: ProviderCategoryMapper.GetCategory(first.Provider),
                 TotalInBaseCurrency: accountDtos.Sum(a => a.BalanceInBaseCurrency ?? 0m),
-                SyncStatus: WorstSyncStatus(list.Select(a => a.SyncStatus)),
+                SyncStatus: WorstSyncStatus(list.Select(a => EffectiveBankingStatus(a.SyncStatus, a.LastSuccessfulSyncTimestamp))),
                 LastSyncTimestamp: list.Max(a => a.LastSyncTimestamp),
                 LastSuccessfulSyncTimestamp: list.Max(a => a.LastSuccessfulSyncTimestamp),
                 Accounts: accountDtos);
@@ -169,6 +173,22 @@ public class WealthAggregationService(
 
     private static Guid InstitutionIdFor(BankingAccountSummary s)
         => s.MonobankCredentialId ?? s.TrueLayerConnectionId ?? s.AccountId;
+
+    /// <summary>
+    /// Downgrades a banking account that <i>looks</i> synced but hasn't had a successful sync
+    /// within <see cref="BankingStaleThreshold"/> to "stale", so a lapsed connection (e.g. an
+    /// expired TrueLayer consent) shows a frozen balance as stale rather than current. Leaves
+    /// already-actionable states ("reauth_required", "failed") and in-progress ones untouched.
+    /// </summary>
+    private static string EffectiveBankingStatus(string status, DateTime? lastSuccessfulSync)
+    {
+        if (status is not ("synced" or "active"))
+            return status;
+
+        var isStale = lastSuccessfulSync is null
+            || DateTime.UtcNow - lastSuccessfulSync.Value > BankingStaleThreshold;
+        return isStale ? "stale" : status;
+    }
 
     private static string WorstSyncStatus(IEnumerable<string> statuses)
     {

--- a/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Infrastructure/Jobs/NetWorthSnapshotJob.cs
@@ -41,6 +41,12 @@ public class NetWorthSnapshotJob(
     {
         var now = DateTime.UtcNow;
         var bankingTotal = await _bankingTotals.GetTotalUsdAsync(userId, ct);
+        // Banking is fresh only if a successful sync landed within the window; a lapsed
+        // connection (stale Revolut/AIB) must carry forward, not record a phantom drop.
+        var bankingLastSync = await _bankingTotals.GetLatestSuccessfulSyncAsync(userId, ct);
+        var bankingFresh = bankingLastSync is null
+            ? bankingTotal == 0m
+            : bankingLastSync.Value >= now - StaleWindow;
 
         var cryptoHoldings = await _cryptoReader.GetHoldingsAsync(userId, ct);
         var cryptoTotal = cryptoHoldings.Sum(h => h.UsdValue);
@@ -54,6 +60,6 @@ public class NetWorthSnapshotJob(
 
         await _snapshotService.PersistSnapshotAsync(userId, new NetWorthSnapshotData(
             snapshotDate, bankingTotal, brokerageTotal, cryptoTotal,
-            BrokerageFresh: brokerageFresh, CryptoFresh: cryptoFresh), ct);
+            BankingFresh: bankingFresh, BrokerageFresh: brokerageFresh, CryptoFresh: cryptoFresh), ct);
     }
 }

--- a/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/CompanionFakes.cs
+++ b/backend/tests/FinanceSentry.Modules.Research.Tests/Companion/CompanionFakes.cs
@@ -106,6 +106,9 @@ internal sealed class FakeBankingTotalsReader(params Guid[] userIds) : IBankingT
 
     public Task<decimal> GetTotalUsdAsync(Guid userId, CancellationToken ct = default)
         => Task.FromResult(0m);
+
+    public Task<DateTime?> GetLatestSuccessfulSyncAsync(Guid userId, CancellationToken ct = default)
+        => Task.FromResult<DateTime?>(DateTime.UtcNow);
 }
 
 internal sealed class FakeBrokerageReader(IReadOnlyList<BrokerageHoldingSummary>? holdings = null)

--- a/backend/tests/FinanceSentry.Modules.Risk.Tests/BookSnapshotReaderTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Risk.Tests/BookSnapshotReaderTests.cs
@@ -29,6 +29,9 @@ public sealed class BookSnapshotReaderTests
 
         public Task<decimal> GetTotalUsdAsync(Guid userId, CancellationToken ct = default)
             => throws ? throw new InvalidOperationException("boom") : Task.FromResult(total);
+
+        public Task<DateTime?> GetLatestSuccessfulSyncAsync(Guid userId, CancellationToken ct = default)
+            => Task.FromResult<DateTime?>(DateTime.UtcNow);
     }
 
     [Fact]

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
@@ -11,9 +11,10 @@ public class WealthAggregationServiceTests
 {
     private static readonly Guid UserId = Guid.NewGuid();
 
-    private static BankingAccountSummary MakeAccount(string provider, string currency, decimal? balance)
+    private static BankingAccountSummary MakeAccount(string provider, string currency, decimal? balance, DateTime? lastSuccessfulSync = null)
         => new(Guid.NewGuid(), "Test Bank", "checking", "1234", provider, currency,
-               balance, balance.HasValue ? CurrencyConverter.ToUsd(balance.Value, currency) : null, "synced", null);
+               balance, balance.HasValue ? CurrencyConverter.ToUsd(balance.Value, currency) : null, "synced",
+               DateTime.UtcNow, lastSuccessfulSync ?? DateTime.UtcNow);
 
     private static BankingTransactionSummary MakeTx(Guid accountId, string provider, decimal amount, string type, DateTime date, bool isPending = false, string currency = "USD")
         => new(accountId, provider, type, amount, currency, CurrencyConverter.ToUsd(amount, currency), date, isPending);
@@ -49,6 +50,33 @@ public class WealthAggregationServiceTests
 
         result.TotalNetWorth.Should().Be(3400m);
         result.BaseCurrency.Should().Be("USD");
+    }
+
+    [Fact]
+    public async Task GetWealthSummary_BankingNotSyncedWithinWindow_MarkedStale()
+    {
+        // A bank account that looks synced but hasn't had a successful sync in >36h is stale —
+        // so the frozen balance shows as stale rather than current (Revolut/AIB lapse case).
+        var accounts = new[]
+        {
+            MakeAccount("plaid", "USD", 1000m, lastSuccessfulSync: DateTime.UtcNow.AddDays(-4)),
+        };
+
+        var svc = BuildService(accounts);
+        var result = await svc.GetWealthSummaryAsync(UserId, null, null);
+
+        result.Categories.Single().Institutions.Single().SyncStatus.Should().Be("stale");
+    }
+
+    [Fact]
+    public async Task GetWealthSummary_BankingSyncedRecently_NotStale()
+    {
+        var accounts = new[] { MakeAccount("plaid", "USD", 1000m, lastSuccessfulSync: DateTime.UtcNow.AddHours(-2)) };
+
+        var svc = BuildService(accounts);
+        var result = await svc.GetWealthSummaryAsync(UserId, null, null);
+
+        result.Categories.Single().Institutions.Single().SyncStatus.Should().Be("synced");
     }
 
     [Fact]

--- a/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/Wealth/NetWorthSnapshotServiceTests.cs
@@ -80,6 +80,23 @@ public class NetWorthSnapshotServiceTests
     }
 
     [Fact]
+    public async Task PersistSnapshotAsync_WhenBankingStale_CarriesForwardPreviousValueAndFlags()
+    {
+        // Regression for the misleading net-worth drop: a lapsed bank connection (Revolut/AIB)
+        // reports a reduced-but-nonzero balance. It must carry forward, not record a phantom drop.
+        var previous = new NetWorthSnapshot { BankingTotal = 5000m, BrokerageTotal = 9912m, CryptoTotal = 240m };
+        var (repo, captured) = SetupInsertCapture(previous);
+        var data = new NetWorthSnapshotData(
+            SnapshotDate, BankingTotal: 1000m, BrokerageTotal: 9912m, CryptoTotal: 240m,
+            BankingFresh: false, BrokerageFresh: true, CryptoFresh: true);
+
+        await new NetWorthSnapshotService(repo.Object).PersistSnapshotAsync(UserId, data, CancellationToken.None);
+
+        captured()!.BankingTotal.Should().Be(5000m); // carried forward, not the stale $1000
+        captured()!.StaleSleeves.Should().Be("banking");
+    }
+
+    [Fact]
     public async Task PersistSnapshotAsync_WhenBrokerageStale_CarriesForwardPreviousValueAndFlags()
     {
         var previous = new NetWorthSnapshot { BankingTotal = 900m, BrokerageTotal = 9912m, CryptoTotal = 240m };

--- a/frontend/src/app/modules/bank-sync/models/dashboard/dashboard.model.ts
+++ b/frontend/src/app/modules/bank-sync/models/dashboard/dashboard.model.ts
@@ -7,6 +7,9 @@ export interface NetWorthSnapshotDto {
   cryptoTotal: number;
   totalNetWorth: number;
   currency: string;
+  /** Comma-separated sleeves ('banking','brokerage','crypto') carried forward because their
+   * feed was stale that day — the value is estimated, not measured. Null when all fresh. */
+  staleSleeves?: string | null;
 }
 
 export interface NetWorthHistoryResponse {

--- a/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
@@ -133,6 +133,11 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
                 label="Total Net Worth"
                 currency="USD"
               />
+              @if (store.netWorthStaleNotice()) {
+                <div class="mt-cmn-2">
+                  <cmn-alert variant="warning">{{ store.netWorthStaleNotice() }}</cmn-alert>
+                </div>
+              }
             }
           </div>
 

--- a/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
@@ -104,6 +104,21 @@ export function dashboardComputed(store: StateSignals) {
       }));
     }),
 
+    netWorthStaleNotice: computed((): string | null => {
+      const history = store.netWorthHistory();
+      const latest = history[history.length - 1];
+      const sleeves = latest?.staleSleeves?.trim();
+      if (!sleeves) {
+        return null;
+      }
+      const names = sleeves
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .map(s => s.charAt(0).toUpperCase() + s.slice(1));
+      return `${names.join(' & ')} data is stale — carried forward from the last successful sync, not a real change.`;
+    }),
+
     isHistoryLoading: computed(() => store.historyLoading()),
     historyErrorMessage: computed(() => store.historyError()),
   };


### PR DESCRIPTION
## Problem
When a bank connection lapses (TrueLayer consent expiry on Revolut/AIB), its balance freezes at the last sync. The app treated that frozen number as **live** → phantom net-worth swings ("-\$4k since last sync") and no signal that the data was stale.

## Root cause — two asymmetries (crypto/brokerage already handled both; banking was exempt)
1. **Snapshots:** `NetWorthSnapshotService` hardcoded banking `isFresh: true`, so a stale bank balance was recorded as real movement.
2. **Status:** `WealthAggregationService` passed banking's raw `SyncStatus` through instead of deriving a time-based `stale` (which it already does for crypto/brokerage).

## Fix
- Snapshot job computes **banking freshness** (latest successful sync vs the existing 36h window); stale banking **carries forward** the last good value + flags `StaleSleeves` — no phantom drop.
- `WealthAggregationService` derives **`stale`** for a synced-looking bank account with no successful sync in 36h. The frontend already renders a yellow **"Stale"** badge for this status → accounts + holdings pages light up **with no template change**. `reauth_required`/`failed` left as-is.
- Dashboard net-worth chart shows a **"… data is stale — carried forward"** notice when the latest snapshot has stale sleeves.

## Tests
Banking-stale carry-forward + stale-status derivation added. Build 0 warnings; **438 unit + 29 Risk + 179 Research green**. Threshold 36h for banking (vs 1h for crypto/brokerage prices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)