### PR TITLE
feat(categorization): seed common IE merchants for TrueLayer no-MCC fallback

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/MerchantKeywordSeedData.cs
@@ -190,5 +190,15 @@ public static class MerchantKeywordSeedData
         ("klarna", CategoryKeys.GeneralMerchandise),
         ("carrolls irish", CategoryKeys.GeneralMerchandise),
         ("fee-qtr", CategoryKeys.BankFees),
+
+        // --- TrueLayer description fallbacks: common IE merchants that arrive with no MCC ---
+        ("popeyes", CategoryKeys.FoodAndDrink),
+        ("cineworld", CategoryKeys.Entertainment),
+        ("free-now", CategoryKeys.Transportation),
+        ("veolia", CategoryKeys.Transportation),
+        ("dublin express", CategoryKeys.Transportation),
+        ("lego", CategoryKeys.GeneralMerchandise),
+        ("makeup", CategoryKeys.PersonalCare),
+        ("clubwise", CategoryKeys.Medical),
     ];
 }

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/MerchantKeywordSeedDataTests.cs
@@ -33,6 +33,15 @@ public class MerchantKeywordSeedDataTests
     [InlineData("Sq *olives Room Cafe 1", CategoryKeys.FoodAndDrink)]
     [InlineData("*MOBI TOP-UP 0857860057", CategoryKeys.RentAndUtilities)]
     [InlineData("Klarna*mstore.ie", CategoryKeys.GeneralMerchandise)]
+    // TrueLayer no-MCC merchants (observed uncategorized in prod)
+    [InlineData("Popeyes", CategoryKeys.FoodAndDrink)]
+    [InlineData("Cineworld", CategoryKeys.Entertainment)]
+    [InlineData("Frn* Hold.free-Now.com", CategoryKeys.Transportation)]
+    [InlineData("veoliatransport.com", CategoryKeys.Transportation)]
+    [InlineData("Dt Dublin Express", CategoryKeys.Transportation)]
+    [InlineData("Lego Blanchardstown", CategoryKeys.GeneralMerchandise)]
+    [InlineData("Makeup", CategoryKeys.PersonalCare)]
+    [InlineData("Clubwise Software Ltd", CategoryKeys.Medical)]
     public void Resolve_KnownMerchantDescriptions_MapToExpectedCategory(string description, string expected)
     {
         MerchantKeywordMatcher.Resolve(description, Prepared).Should().Be(expected);


### PR DESCRIPTION
AIB-over-TrueLayer returns no classification/MCC/merchant_name for some transactions (only free text) → UNCATEGORIZED. Adds recurring global brands (Popeyes, Cineworld, Free Now, Veolia, Lego, Dublin Express, Makeup, Clubwise) to the merchant-keyword bridge — the last-resort fallback after provider signal is exhausted. Canonical taxonomy stays Plaid PFC; we don't own it. 33 seed tests green.