### PR TITLE
feat(monobank): group currency sub-accounts under their physical card

### DIFF
--- a/backend/src/FinanceSentry.Core/Interfaces/IBankingAccountsReader.cs
+++ b/backend/src/FinanceSentry.Core/Interfaces/IBankingAccountsReader.cs
@@ -18,4 +18,5 @@ public record BankingAccountSummary(
     DateTime? LastSyncTimestamp,
     DateTime? LastSuccessfulSyncTimestamp = null,
     Guid? MonobankCredentialId = null,
-    Guid? TrueLayerConnectionId = null);
+    Guid? TrueLayerConnectionId = null,
+    string? ProductType = null);

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/ConnectMonobankAccountCommand.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Commands/ConnectMonobankAccountCommand.cs
@@ -79,7 +79,8 @@ public class ConnectMonobankAccountCommandHandler(
                 provider: "monobank")
             {
                 MonobankCredentialId = credential.Id,
-                CurrentBalance = MonobankHttpClient.KopecksToDecimal(a.Balance)
+                CurrentBalance = MonobankHttpClient.KopecksToDecimal(a.Balance),
+                ProductType = a.ProductType
             };
 
             await accounts.AddAsync(account, cancellationToken);

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -287,7 +287,13 @@ public class ScheduledSyncService(
                     if (fa.CurrentBalance.HasValue)
                         _monobankBalanceCache.Set(plainToken, fa.ExternalAccountId, fa.CurrentBalance.Value);
                 }
-                latestBalance = freshAccounts.FirstOrDefault(a => a.ExternalAccountId == account.ExternalAccountId)?.CurrentBalance;
+                var freshSelf = freshAccounts.FirstOrDefault(a => a.ExternalAccountId == account.ExternalAccountId);
+                latestBalance = freshSelf?.CurrentBalance;
+
+                // Backfill / refresh the card product type (black/white/…) from client-info so
+                // pre-existing accounts (connected before ProductType was captured) get grouped.
+                if (freshSelf?.ProductType is { Length: > 0 } productType && account.ProductType != productType)
+                    account.ProductType = productType;
             }
             catch (Infrastructure.Monobank.MonobankException)
             {

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
@@ -18,6 +18,14 @@ public class BankAccount : Entity
 
     public string AccountType { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Provider-specific product/card type, preserved verbatim (e.g. Monobank "black" / "white" /
+    /// "platinum" / "fop"). Lets currency sub-accounts of the same physical card be grouped and
+    /// labelled. Null for providers that don't expose a card product. <see cref="AccountType"/>
+    /// stays the generic normalized type.
+    /// </summary>
+    public string? ProductType { get; set; }
+
     public string AccountNumberLast4 { get; set; } = string.Empty;
 
     public string OwnerName { get; set; } = string.Empty;

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/Interfaces/IBankProvider.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/Interfaces/IBankProvider.cs
@@ -9,7 +9,8 @@ public record BankAccountInfo(
     string AccountNumberLast4,
     decimal? CurrentBalance,
     string Currency,
-    string OwnerName);
+    string OwnerName,
+    string? ProductType = null);
 
 public interface IBankProvider
 {

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankAdapter.cs
@@ -48,7 +48,8 @@ public class MonobankAdapter(MonobankHttpClient client, ICategoryResolver catego
                 ? a.MaskedPan[^4..] : a.MaskedPan.PadLeft(4, '0'),
             CurrentBalance: MonobankHttpClient.KopecksToDecimal(a.Balance),
             Currency: MonobankHttpClient.MapCurrency(a.CurrencyCode),
-            OwnerName: info.Name)).ToList();
+            OwnerName: info.Name,
+            ProductType: a.ProductType)).ToList();
     }
 
     public async Task<(IReadOnlyList<TransactionCandidate> Candidates, DateTime? NextSyncFrom)> SyncTransactionsAsync(

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankAdapterModels.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankAdapterModels.cs
@@ -7,7 +7,8 @@ public record MonobankAccountInfo(
     string MaskedPan,
     int CurrencyCode,
     long Balance,
-    long CreditLimit);
+    long CreditLimit,
+    string? ProductType = null);
 
 public record MonobankClientInfo(
     string ClientId,

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankHttpClient.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Monobank/MonobankHttpClient.cs
@@ -40,6 +40,7 @@ public class MonobankHttpClient(HttpClient http)
             MaskedPan: a.MaskedPan?.LastOrDefault() ?? "0000",
             CurrencyCode: a.CurrencyCode,
             Balance: a.Balance,
+            ProductType: a.Type,
             CreditLimit: a.CreditLimit)).ToList();
 
         return new MonobankClientInfo(raw.ClientId, raw.Name, accounts);

--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingAccountsReader.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Services/BankingAccountsReader.cs
@@ -30,7 +30,8 @@ public class BankingAccountsReader(
             a.UpdatedAt,
             lastSuccessful.TryGetValue(a.Id, out var lastOk) ? lastOk : null,
             a.MonobankCredentialId,
-            a.TrueLayerConnectionId))
+            a.TrueLayerConnectionId,
+            a.ProductType))
         .ToList();
     }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260806201710_M007_MonobankProductType.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260806201710_M007_MonobankProductType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.BankSync.Migrations
 {
     [DbContext(typeof(BankSyncDbContext))]
-    partial class BankSyncDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806201710_M007_MonobankProductType")]
+    partial class M007_MonobankProductType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260806201710_M007_MonobankProductType.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260806201710_M007_MonobankProductType.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.BankSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class M007_MonobankProductType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ProductType",
+                schema: "bank_sync",
+                table: "BankAccounts",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProductType",
+                schema: "bank_sync",
+                table: "BankAccounts");
+        }
+    }
+}

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetWealthSummaryQuery.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Queries/GetWealthSummaryQuery.cs
@@ -20,7 +20,19 @@ public record AccountBalanceDto(
     decimal? CurrentBalance,
     decimal? BalanceInBaseCurrency,
     string SyncStatus,
-    DateTime? LastSyncTimestamp);
+    DateTime? LastSyncTimestamp,
+    string? ProductType = null);
+
+/// <summary>
+/// A physical card within an institution, grouping its per-currency sub-accounts. Populated
+/// only for providers that expose a card product (Monobank black/white/…); null elsewhere.
+/// </summary>
+public record CardGroupDto(
+    string CardType,
+    string DisplayName,
+    decimal TotalInBaseCurrency,
+    string SyncStatus,
+    IReadOnlyList<AccountBalanceDto> Accounts);
 
 /// <summary>
 /// An institution the user has connected: one Monobank customer, one
@@ -36,7 +48,8 @@ public record InstitutionDto(
     string SyncStatus,
     DateTime? LastSyncTimestamp,
     DateTime? LastSuccessfulSyncTimestamp,
-    IReadOnlyList<AccountBalanceDto> Accounts);
+    IReadOnlyList<AccountBalanceDto> Accounts,
+    IReadOnlyList<CardGroupDto>? Cards = null);
 
 public record CategorySummaryDto(
     string Category,

--- a/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
+++ b/backend/src/FinanceSentry.Modules.Wealth/Application/Services/WealthAggregationService.cs
@@ -150,7 +150,15 @@ public class WealthAggregationService(
                 a.AccountId, a.BankName, a.AccountType, a.AccountNumberLast4,
                 a.Provider, ProviderCategoryMapper.GetCategory(a.Provider),
                 a.Currency, a.CurrentBalance, a.BalanceUsd,
-                EffectiveBankingStatus(a.SyncStatus, a.LastSuccessfulSyncTimestamp), a.LastSyncTimestamp)).ToList();
+                EffectiveBankingStatus(a.SyncStatus, a.LastSuccessfulSyncTimestamp), a.LastSyncTimestamp,
+                a.ProductType)).ToList();
+
+            // Monobank returns one account per card × currency. Group them into physical cards
+            // (black/white/…) with empty sub-accounts hidden, so the UI can nest currencies under
+            // the card instead of showing a flat, mostly-empty list.
+            var cards = string.Equals(first.Provider, "monobank", StringComparison.OrdinalIgnoreCase)
+                ? BuildMonobankCards(accountDtos)
+                : null;
 
             return new InstitutionDto(
                 InstitutionId: InstitutionIdFor(first),
@@ -161,7 +169,8 @@ public class WealthAggregationService(
                 SyncStatus: WorstSyncStatus(list.Select(a => EffectiveBankingStatus(a.SyncStatus, a.LastSuccessfulSyncTimestamp))),
                 LastSyncTimestamp: list.Max(a => a.LastSyncTimestamp),
                 LastSuccessfulSyncTimestamp: list.Max(a => a.LastSuccessfulSyncTimestamp),
-                Accounts: accountDtos);
+                Accounts: accountDtos,
+                Cards: cards);
         }).OrderByDescending(i => i.TotalInBaseCurrency)];
     }
 
@@ -173,6 +182,40 @@ public class WealthAggregationService(
 
     private static Guid InstitutionIdFor(BankingAccountSummary s)
         => s.MonobankCredentialId ?? s.TrueLayerConnectionId ?? s.AccountId;
+
+    /// <summary>
+    /// Groups Monobank currency sub-accounts into physical cards by product type, hiding
+    /// zero-balance sub-accounts (and cards left entirely empty). A missing product type (rows
+    /// connected before it was captured) collapses into one "Card" group until the next sync
+    /// backfills it.
+    /// </summary>
+    private static IReadOnlyList<CardGroupDto> BuildMonobankCards(IReadOnlyList<AccountBalanceDto> accounts)
+    {
+        return [.. accounts
+            .GroupBy(a => a.ProductType ?? "card")
+            .Select(g => new
+            {
+                CardType = g.Key,
+                NonEmpty = g.Where(a => (a.CurrentBalance ?? 0m) != 0m).ToList(),
+            })
+            .Where(x => x.NonEmpty.Count > 0)
+            .Select(x => new CardGroupDto(
+                CardType: x.CardType,
+                DisplayName: FormatCardName(x.CardType),
+                TotalInBaseCurrency: x.NonEmpty.Sum(a => a.BalanceInBaseCurrency ?? 0m),
+                SyncStatus: WorstSyncStatus(x.NonEmpty.Select(a => a.SyncStatus)),
+                Accounts: x.NonEmpty))
+            .OrderByDescending(c => c.TotalInBaseCurrency)];
+    }
+
+    private static string FormatCardName(string productType) => productType.ToLowerInvariant() switch
+    {
+        "fop" => "FOP",
+        "eaid" => "eAid",
+        "card" => "Card",
+        var s when s.Length > 0 => char.ToUpperInvariant(s[0]) + s[1..],
+        _ => productType,
+    };
 
     /// <summary>
     /// Downgrades a banking account that <i>looks</i> synced but hasn't had a successful sync

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Wealth/WealthAggregationServiceTests.cs
@@ -19,6 +19,45 @@ public class WealthAggregationServiceTests
     private static BankingTransactionSummary MakeTx(Guid accountId, string provider, decimal amount, string type, DateTime date, bool isPending = false, string currency = "USD")
         => new(accountId, provider, type, amount, currency, CurrencyConverter.ToUsd(amount, currency), date, isPending);
 
+    private static BankingAccountSummary MakeMonobankAccount(string currency, decimal? balance, string? productType, Guid credId)
+        => new(Guid.NewGuid(), "Monobank", "checking", "1234", "monobank", currency,
+               balance, balance.HasValue ? CurrencyConverter.ToUsd(balance.Value, currency) : null, "synced",
+               DateTime.UtcNow, DateTime.UtcNow, MonobankCredentialId: credId, ProductType: productType);
+
+    [Fact]
+    public async Task GetWealthSummary_Monobank_GroupsByCard_HidesEmptySubAccountsAndEmptyCards()
+    {
+        var cred = Guid.NewGuid();
+        var accounts = new[]
+        {
+            MakeMonobankAccount("UAH", 10000m, "black", cred),  // black card — has money
+            MakeMonobankAccount("USD", 0m, "black", cred),      // black card — empty currency, hidden
+            MakeMonobankAccount("UAH", 5000m, "white", cred),   // white card — has money
+            MakeMonobankAccount("UAH", 0m, "platinum", cred),   // platinum — all empty, whole card hidden
+        };
+
+        var svc = BuildService(accounts);
+        var result = await svc.GetWealthSummaryAsync(UserId, null, null);
+
+        var inst = result.Categories.Single(c => c.Category == "banking").Institutions.Single();
+        inst.Cards.Should().NotBeNull();
+        inst.Cards!.Select(c => c.CardType).Should().BeEquivalentTo(["black", "white"]); // platinum dropped
+
+        var black = inst.Cards!.Single(c => c.CardType == "black");
+        black.DisplayName.Should().Be("Black");
+        black.Accounts.Should().HaveCount(1);                 // empty USD hidden
+        black.Accounts.Single().Currency.Should().Be("UAH");
+    }
+
+    [Fact]
+    public async Task GetWealthSummary_NonMonobank_HasNoCardGrouping()
+    {
+        var svc = BuildService([MakeAccount("plaid", "USD", 1000m)]);
+        var result = await svc.GetWealthSummaryAsync(UserId, null, null);
+
+        result.Categories.Single().Institutions.Single().Cards.Should().BeNull();
+    }
+
     private WealthAggregationService BuildService(
         IEnumerable<BankingAccountSummary> accounts,
         IEnumerable<BankingTransactionSummary>? transactions = null)

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -73,9 +73,17 @@
                   />
                   <div class="min-w-0">
                     <p class="font-medium text-text-primary">{{ inst.name }}</p>
-                    <p class="text-cmn-xs text-text-secondary">
-                      {{ inst.accounts.length }} account{{ inst.accounts.length !== 1 ? 's' : '' }}
-                    </p>
+                    @if (inst.cards && inst.cards.length > 0) {
+                      <p class="text-cmn-xs text-text-secondary">
+                        {{ inst.cards.length }} card{{ inst.cards.length !== 1 ? 's' : '' }}
+                      </p>
+                    } @else {
+                      <p class="text-cmn-xs text-text-secondary">
+                        {{ inst.accounts.length }} account{{
+                          inst.accounts.length !== 1 ? 's' : ''
+                        }}
+                      </p>
+                    }
                   </div>
                 </div>
                 <cmn-status-indicator
@@ -128,24 +136,59 @@
 
               <table class="w-full text-cmn-sm bg-surface-bg" aria-label="Accounts">
                 <tbody>
-                  @for (account of inst.accounts; track account.accountId) {
-                    <tr class="border-t border-border-default">
-                      <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full">
-                        <p class="text-text-primary">{{ account.accountType }}</p>
-                        <p class="text-cmn-xs text-text-secondary">
-                          •••• {{ account.accountNumberLast4 }}
-                        </p>
-                      </td>
-                      <td
-                        class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
-                      >
-                        @let bal = account | accountBalance;
-                        <div>{{ bal.native }}</div>
-                        @if (bal.usd) {
-                          <div class="text-cmn-xs text-text-secondary">{{ bal.usd }}</div>
-                        }
-                      </td>
-                    </tr>
+                  @if (inst.cards && inst.cards.length > 0) {
+                    @for (card of inst.cards; track card.cardType) {
+                      <tr class="border-t border-border-default">
+                        <td class="py-cmn-2 pl-cmn-12 pr-cmn-4 w-full">
+                          <p class="font-medium text-text-primary">{{ card.displayName }}</p>
+                        </td>
+                        <td
+                          class="py-cmn-2 px-cmn-4 text-right font-mono tabular-nums text-cmn-xs text-text-secondary min-w-[7rem]"
+                        >
+                          {{ store.baseCurrency() }}
+                          {{ card.totalInBaseCurrency | number: '1.2-2' }}
+                        </td>
+                      </tr>
+                      @for (account of card.accounts; track account.accountId) {
+                        <tr class="border-t border-border-default">
+                          <td class="py-cmn-3 pl-cmn-20 pr-cmn-4 w-full">
+                            <p class="text-text-primary">{{ account.currency }}</p>
+                            <p class="text-cmn-xs text-text-secondary">
+                              •••• {{ account.accountNumberLast4 }}
+                            </p>
+                          </td>
+                          <td
+                            class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
+                          >
+                            @let cardBal = account | accountBalance;
+                            <div>{{ cardBal.native }}</div>
+                            @if (cardBal.usd) {
+                              <div class="text-cmn-xs text-text-secondary">{{ cardBal.usd }}</div>
+                            }
+                          </td>
+                        </tr>
+                      }
+                    }
+                  } @else {
+                    @for (account of inst.accounts; track account.accountId) {
+                      <tr class="border-t border-border-default">
+                        <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full">
+                          <p class="text-text-primary">{{ account.accountType }}</p>
+                          <p class="text-cmn-xs text-text-secondary">
+                            •••• {{ account.accountNumberLast4 }}
+                          </p>
+                        </td>
+                        <td
+                          class="py-cmn-3 px-cmn-4 text-right font-mono tabular-nums text-text-primary min-w-[7rem]"
+                        >
+                          @let bal = account | accountBalance;
+                          <div>{{ bal.native }}</div>
+                          @if (bal.usd) {
+                            <div class="text-cmn-xs text-text-secondary">{{ bal.usd }}</div>
+                          }
+                        </td>
+                      </tr>
+                    }
                   }
                 </tbody>
               </table>

--- a/frontend/src/app/shared/models/wealth/wealth.model.ts
+++ b/frontend/src/app/shared/models/wealth/wealth.model.ts
@@ -11,6 +11,20 @@ export interface AccountBalanceItem extends AccountIdentity {
   balanceInBaseCurrency: Nullable<number>;
   syncStatus: SyncStatus;
   lastSyncTimestamp: Nullable<string>;
+  productType?: Nullable<string>;
+}
+
+/**
+ * A physical card within an institution, grouping its per-currency sub-accounts.
+ * Populated by the backend only for providers with a card product (Monobank
+ * black/white/…); absent otherwise. Zero-balance sub-accounts are already excluded.
+ */
+export interface CardGroup {
+  cardType: string;
+  displayName: string;
+  totalInBaseCurrency: number;
+  syncStatus: SyncStatus;
+  accounts: AccountBalanceItem[];
 }
 
 /**
@@ -29,6 +43,7 @@ export interface Institution {
   lastSyncTimestamp: Nullable<string>;
   lastSuccessfulSyncTimestamp: Nullable<string>;
   accounts: AccountBalanceItem[];
+  cards?: Nullable<CardGroup[]>;
 }
 
 export interface CategorySummary {


### PR DESCRIPTION
## Problem
Monobank returns one account per **card × currency**. We flattened them: every row was *"Monobank · checking · ••XXXX"* (card type collapsed to `checking`), a single card's currency balances showed as separate accounts, and 4/6 empty sub-accounts cluttered the list + inflated the account count.

## Fix (nested Monobank → cards → currencies, empties hidden)
- **M007**: `BankAccount.ProductType`; `MonobankHttpClient`/`Adapter` preserve the raw card type (black/white/platinum/fop/…) instead of discarding it.
- **Backfill**: `ScheduledSyncService` refreshes `ProductType` from `client-info` during sync, so pre-existing accounts get typed without a reconnect (collapse into one "Card" group meanwhile).
- **Grouping**: `WealthAggregationService` groups Monobank accounts by card, hides zero-balance sub-accounts and fully-empty cards; `InstitutionDto` gains `Cards`.
- **Frontend**: accounts page renders Institution → Cards → currency balances for Monobank (flat list unchanged for other providers); header shows card count.

## Tests
Card grouping + hide-empties + non-Monobank-has-no-cards. **449 unit green**, frontend lint + prod build clean. M007 generated with Designer + snapshot (no repeat of the prior migration incident).

## Note
Existing 6 accounts get their real card types on the next Monobank sync; until then they show as one "Card" group with empties already hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)