### PR TITLE
fix(024): retention module governs its own run-record tables

### DIFF
--- a/backend/src/FinanceSentry.Modules.Retention/Application/RetentionPolicyRegistry.cs
+++ b/backend/src/FinanceSentry.Modules.Retention/Application/RetentionPolicyRegistry.cs
@@ -25,6 +25,7 @@ public static class RetentionPolicyRegistry
     private const string Budgets = "budgets";
     private const string Auth = "auth";
     private const string Public = "public";
+    private const string Retention = "retention";
 
     /// <summary>
     /// Every <c>DbContext</c> the retention policy set must account for. The coverage-guard test
@@ -52,6 +53,10 @@ public static class RetentionPolicyRegistry
         Purge(Research, "macro_events", "EventDate", 365, "Past macro-calendar entries."),
         Purge(Research, "recommendation_trends", "IngestedAt", 365, "Monthly consensus; stale once a ticker stops being covered."),
         Purge(Risk, "holding_snapshots", "CapturedAt", 180, "Risk holding time-series."),
+        // The retention module governs its own run-record tables (one row per run; drill rows aren't
+        // artifact-pruned). 180d keeps a recent Verified backup_runs row for the SC-002 query.
+        Purge(Retention, "retention_runs", "StartedAt", 180, "Retention/downsample run history."),
+        Purge(Retention, "backup_runs", "CreatedAt", 180, "Backup + restore-drill history (artifact prune handles live backups)."),
 
         // ── Downsample (US3, P2 — job gated off by default) ──────────────────────────────────────
         Downsample(Radar, "daily_bars", "Date", 365, "Daily OHLC → weekly beyond a year."),

--- a/backend/tests/FinanceSentry.Modules.Retention.Tests/RetentionPolicyRegistryTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Retention.Tests/RetentionPolicyRegistryTests.cs
@@ -3,6 +3,7 @@ namespace FinanceSentry.Modules.Retention.Tests;
 using System.Reflection;
 using FinanceSentry.Modules.Retention.Application;
 using FinanceSentry.Modules.Retention.Domain;
+using FinanceSentry.Modules.Retention.Infrastructure.Persistence;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -118,7 +119,29 @@ public sealed class RetentionPolicyRegistryTests
     public void Generic_purge_set_matches_expected_count()
     {
         // Guards against accidental additions/removals to the actively-purged set.
-        RetentionPolicyRegistry.GenericPurgePolicies.Should().HaveCount(9);
+        RetentionPolicyRegistry.GenericPurgePolicies.Should().HaveCount(11);
+    }
+
+    [Fact]
+    public void Retention_module_governs_its_own_tables()
+    {
+        // Per-table coverage for the retention schema: the module that enforces retention must not
+        // leave its own run-record tables ungoverned (the gap this test closes). Instantiating the
+        // context reads its EF model without a database connection.
+        var options = new DbContextOptionsBuilder<RetentionDbContext>()
+            .UseNpgsql("Host=unused;Database=unused")
+            .Options;
+        using var ctx = new RetentionDbContext(options);
+
+        var mapped = ctx.Model.GetEntityTypes()
+            .Select(e => (Schema: e.GetSchema() ?? RetentionDbContext.Schema, Table: e.GetTableName()))
+            .ToList();
+
+        mapped.Should().NotBeEmpty();
+        foreach (var (schema, table) in mapped)
+            Policies.Should().Contain(
+                p => p.Schema == schema && p.Table == table,
+                "retention table {0}.{1} must have a policy", schema, table);
     }
 
     private static IEnumerable<Type> SafeTypes(Assembly a)


### PR DESCRIPTION
Follow-up to #367. The retention module enforced retention for every table **except its own** — `retention_runs` and `backup_runs` had no policy, so they grew unbounded (one `retention_runs` row per run; weekly restore-drill `backup_runs` rows never pruned — live backup rows already prune alongside their R2 artifact).

## Changes
- **Registry**: add `retention.retention_runs` (StartedAt, 180d) + `retention.backup_runs` (CreatedAt, 180d) as generic purge policies. 180d always leaves a recent `Verified` row for the SC-002 "last provably-restorable backup" query (the restore drill runs weekly).
- **Guard**: new per-table coverage test instantiates `RetentionDbContext`, reads its EF model, and asserts every mapped table has a policy — so the retention schema can't silently regress to ungoverned again. The original coverage guard only checked per-`DbContext`, which is how this slipped through.

Generic purge set 9 → 11. **37 unit tests green; zero-warning build.**

Backups themselves were already bounded (nightly prune keeps 30 daily + 8 weekly in R2) — this only closes the metadata-table gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)