### PR TITLE
fix(holdings): show only provider-backed P&L; fix Monobank card indent

### DIFF
--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -151,7 +151,7 @@
                       </tr>
                       @for (account of card.accounts; track account.accountId) {
                         <tr class="border-t border-border-default">
-                          <td class="py-cmn-3 pl-cmn-20 pr-cmn-4 w-full">
+                          <td class="py-cmn-3 pl-cmn-16 pr-cmn-4 w-full">
                             <p class="text-text-primary">{{ account.currency }}</p>
                             <p class="text-cmn-xs text-text-secondary">
                               •••• {{ account.accountNumberLast4 }}

--- a/frontend/src/app/modules/holdings/models/position/position.model.ts
+++ b/frontend/src/app/modules/holdings/models/position/position.model.ts
@@ -3,6 +3,8 @@ export interface BrokeragePositionDto {
   instrumentType: string;
   quantity: number;
   usdValue: number;
+  costBasisUsd: Nullable<number>;
+  averageCostUsd: Nullable<number>;
 }
 
 export interface BrokerageHoldingsDto {
@@ -34,5 +36,8 @@ export interface Position {
   quantity: number;
   currentValue: number;
   currentPrice: number;
-  mockPnlPercent: number;
+  // Provider-supplied P&L only (IBKR cost basis). Null when the provider gives
+  // us no cost basis (crypto cost basis is reconstructed on our side, so we do
+  // not surface a P&L we can't stand behind).
+  pnlPercent: Nullable<number>;
 }

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -227,11 +227,19 @@
                 </cmn-column>
                 <cmn-column key="pnl" header="P&L %" align="right">
                   <ng-template let-row cmnCell>
-                    <span
-                      [class]="row.pnlPercent >= 0 ? pnlPositiveClass : pnlNegativeClass"
-                      class="font-mono tabular-nums"
-                      >{{ row.pnlPercent | number: '1.2-2' }}%</span
-                    >
+                    @if (row.pnlPercent === null) {
+                      <span
+                        class="font-mono tabular-nums text-text-secondary"
+                        title="No cost basis reported by provider"
+                        >—</span
+                      >
+                    } @else {
+                      <span
+                        [class]="row.pnlPercent >= 0 ? pnlPositiveClass : pnlNegativeClass"
+                        class="font-mono tabular-nums"
+                        >{{ row.pnlPercent | number: '1.2-2' }}%</span
+                      >
+                    }
                   </ng-template>
                 </cmn-column>
                 <cmn-column key="weight" header="Weight" align="right">

--- a/frontend/src/app/modules/holdings/services/positions.service.ts
+++ b/frontend/src/app/modules/holdings/services/positions.service.ts
@@ -9,18 +9,18 @@ import {
   type Position,
 } from '../models/position/position.model';
 
-const HASH_MULTIPLIER = 31;
-const HASH_MASK = 0xfffff;
-const PNL_RANGE = 5000;
-const PNL_OFFSET = 2000;
-const PNL_SCALE = 100;
+const PERCENT_SCALE = 100;
 
-function mockPnl(symbol: string): number {
-  let hash = 0;
-  for (const c of symbol) {
-    hash = (hash * HASH_MULTIPLIER + c.charCodeAt(0)) & HASH_MASK;
+// P&L % from the provider's own cost basis. Returns null when no usable cost
+// basis is available, so callers render "no data" rather than a fabricated number.
+function providerPnlPercent(
+  currentValue: number,
+  costBasisUsd: Nullable<number>
+): Nullable<number> {
+  if (costBasisUsd == null || costBasisUsd <= 0) {
+    return null;
   }
-  return ((hash % PNL_RANGE) - PNL_OFFSET) / PNL_SCALE;
+  return ((currentValue - costBasisUsd) / costBasisUsd) * PERCENT_SCALE;
 }
 
 @Injectable({providedIn: 'root'})
@@ -38,15 +38,23 @@ export class PositionsService extends ApiService {
 
     return forkJoin([brokerage$, crypto$]).pipe(
       map(([brokerage, crypto]) => {
-        const brokeragePositions: Position[] = (brokerage?.positions ?? []).map(p => ({
-          symbol: p.symbol,
-          provider: brokerage?.provider ?? 'ibkr',
-          quantity: p.quantity,
-          currentValue: p.usdValue,
-          currentPrice: p.quantity > 0 ? p.usdValue / p.quantity : 0,
-          mockPnlPercent: mockPnl(p.symbol),
-        }));
+        const brokeragePositions: Position[] = (brokerage?.positions ?? []).map(p => {
+          // IBKR supplies avgCost directly; derive total cost basis when only the
+          // per-unit average is returned.
+          const costBasisUsd =
+            p.costBasisUsd ?? (p.averageCostUsd != null ? p.averageCostUsd * p.quantity : null);
+          return {
+            symbol: p.symbol,
+            provider: brokerage?.provider ?? 'ibkr',
+            quantity: p.quantity,
+            currentValue: p.usdValue,
+            currentPrice: p.quantity > 0 ? p.usdValue / p.quantity : 0,
+            pnlPercent: providerPnlPercent(p.usdValue, costBasisUsd),
+          };
+        });
 
+        // Binance returns no P&L, and our reconstructed crypto cost basis differs
+        // from the exchange's own figure — so we do not surface a crypto P&L.
         const cryptoPositions: Position[] = (crypto?.holdings ?? []).map(h => ({
           symbol: h.asset,
           provider: crypto?.provider ?? 'binance',
@@ -56,7 +64,7 @@ export class PositionsService extends ApiService {
             h.freeQuantity + h.lockedQuantity > 0
               ? h.usdValue / (h.freeQuantity + h.lockedQuantity)
               : 0,
-          mockPnlPercent: mockPnl(h.asset),
+          pnlPercent: null,
         }));
 
         return [...brokeragePositions, ...cryptoPositions];

--- a/frontend/src/app/modules/holdings/store/holdings.computed.ts
+++ b/frontend/src/app/modules/holdings/store/holdings.computed.ts
@@ -26,7 +26,7 @@ export interface PositionRow {
   quantity: number;
   currentPrice: number;
   currentValue: number;
-  pnlPercent: number;
+  pnlPercent: Nullable<number>;
   weightPercent: number;
 }
 
@@ -105,7 +105,7 @@ export function holdingsComputed(store: StateSignals) {
           quantity: p.quantity,
           currentPrice: p.currentPrice,
           currentValue: p.currentValue,
-          pnlPercent: p.mockPnlPercent,
+          pnlPercent: p.pnlPercent,
           weightPercent: totalValue > 0 ? (p.currentValue / totalValue) * WEIGHT_TO_PERCENT : 0,
         };
         const bucket = groups.get(assetClass);


### PR DESCRIPTION
## What
Two frontend-only bugs surfaced after yesterday's Monobank grouping change (#366).

### 1. Monobank nesting looked broken
Currency sub-rows used `pl-cmn-20`, but the spacing scale tops out at `cmn-16`, so Tailwind emitted **no padding** — rows rendered flush-left, *less* indented than their parent card header (`pl-cmn-12`), inverting the hierarchy. Now `pl-cmn-16` so nesting reads institution → card (48px) → currency (64px).

### 2. Holdings P&L was fabricated
`positions.service` computed `mockPnl(symbol)` — a **hash of the ticker** — for every row, never touching real cost basis. Every P&L % on the page was fake.

Per the rule "only show P&L the provider stands behind":
- **Equities (IBKR):** real P&L from IBKR's own `avgCost` cost basis.
- **Crypto (Binance):** Binance returns no P&L and our reconstructed cost basis differs from the exchange's, so render `—` instead of a number we can't defend.

The holdings DTOs already carried `costBasis`/`avgCost`; the frontend was ignoring them. No backend changes.

## Verification
- `npx eslint` clean on all touched files
- `ng lint` (app + libraries) clean
- `ng build --configuration production` clean
- Unit suite: only pre-existing `@dsdevq-common/ui` failures (tab-group / editable-field / page-container), untouched by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)