### PR TITLE
fix(ui): premium theme + honest dashboard (Playwright-verified)

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/area-chart/area-chart.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/area-chart/area-chart.component.ts
@@ -173,17 +173,20 @@ export class AreaChartComponent implements AfterViewInit, OnDestroy {
         scales: {
           x: {
             stacked: true,
-            grid: {color: borderDefault},
+            grid: {display: false},
+            border: {display: false},
             ticks: {
               color: textSecondary,
               font: {family: 'Inter', size: 11},
               maxRotation: 0,
               autoSkip: true,
+              maxTicksLimit: 8,
             },
           },
           y: {
             stacked: true,
             grid: {color: borderDefault},
+            border: {display: false},
             ticks: {
               color: textSecondary,
               font: {family: 'Inter', size: 11},

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/bar-chart/bar-chart.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/bar-chart/bar-chart.component.ts
@@ -158,16 +158,19 @@ export class BarChartComponent implements AfterViewInit, OnDestroy {
           x: {
             stacked: this.stacked(),
             grid: {display: false},
+            border: {display: false},
             ticks: {
               color: textSecondary,
               font: {family: 'Inter', size: 11},
               maxRotation: 0,
               autoSkip: true,
+              maxTicksLimit: 12,
             },
           },
           y: {
             stacked: this.stacked(),
             grid: {color: borderDefault},
+            border: {display: false},
             ticks: {
               color: textSecondary,
               font: {family: 'Inter', size: 11},

--- a/frontend/projects/dsdevq-common/ui/src/styles/theme.css
+++ b/frontend/projects/dsdevq-common/ui/src/styles/theme.css
@@ -7,15 +7,15 @@
 /* ─── Light theme (default) ─────────────────────────────────────────────── */
 :root,
 [data-theme='light'] {
-  /* Surface */
-  --color-surface-bg: #f5f2ff;
+  /* Surface — cool neutral ground (a whisper of the indigo accent, not a lavender wash) */
+  --color-surface-bg: #f7f8fa;
   --color-surface-card: #ffffff;
-  --color-surface-raised: #eae6f4;
+  --color-surface-raised: #eef0f4;
 
   /* Text */
-  --color-text-primary: #1b1b24;
-  --color-text-secondary: #464555;
-  --color-text-disabled: #9a9aaa;
+  --color-text-primary: #101828;
+  --color-text-secondary: #556070;
+  --color-text-disabled: #98a2b3;
   --color-text-inverse: #ffffff;
 
   /* Accent — indigo palette */
@@ -54,9 +54,9 @@
   --color-status-warning: #f59e0b;
   --color-status-error: #ef4444;
 
-  /* Border */
-  --color-border-default: #c7c4d8;
-  --color-border-strong: #777587;
+  /* Border — neutral grey */
+  --color-border-default: #e4e7ec;
+  --color-border-strong: #98a2b3;
   --color-border-focus: #4f46e5;
 
   /* Shadow — dual-layer per Finance Sentry design tokens */

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -6,23 +6,34 @@
       subtitle="All connected financial accounts"
       actionLabel="Connect Account"
     />
-    @if (!store.isLoading() && store.totalNetWorth() !== 0) {
-      <div class="mt-cmn-3 text-right">
-        <p class="text-cmn-xs text-text-secondary uppercase tracking-wide">Total Net Worth</p>
-        <p class="font-mono text-cmn-2xl font-bold text-text-primary tabular-nums">
-          {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
-        </p>
-      </div>
-    }
   </div>
 
   @if (!store.isLoading() && store.netWorthSegments().length > 1) {
-    <div class="mb-cmn-8 sm:max-w-sm sm:ml-auto">
+    <div class="mb-cmn-8 grid items-stretch gap-cmn-4 sm:grid-cols-2">
+      <cmn-card class="flex flex-col justify-center">
+        <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">Total Net Worth</p>
+        <p class="font-mono text-cmn-2xl font-bold tabular-nums text-text-primary">
+          {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
+        </p>
+        <p class="mt-cmn-2 text-cmn-sm text-text-secondary">
+          {{ store.totalConnections() }} connection{{
+            store.totalConnections() !== 1 ? 's' : ''
+          }}
+          across {{ store.netWorthSegments().length }} categories
+        </p>
+      </cmn-card>
       <cmn-donut-chart
         [segments]="store.netWorthSegments()"
         [currency]="store.baseCurrency()"
         label="Net worth by category"
       />
+    </div>
+  } @else if (!store.isLoading() && store.totalNetWorth() !== 0) {
+    <div class="mb-cmn-8 text-right">
+      <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">Total Net Worth</p>
+      <p class="font-mono text-cmn-2xl font-bold tabular-nums text-text-primary">
+        {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
+      </p>
     </div>
   }
 

--- a/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
@@ -89,22 +89,22 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
               icon="Wallet"
             />
             <cmn-stat-card
-              [value]="store.latestInflowFormatted()"
-              [loading]="store.isLoading()"
-              label="Monthly Inflow"
+              [value]="store.netWorthChangeFormatted()"
+              [loading]="store.isHistoryLoading()"
+              label="Change (period)"
               icon="TrendingUp"
             />
             <cmn-stat-card
-              [value]="store.latestOutflowFormatted()"
+              [value]="store.monthlySpendingFormatted()"
               [loading]="store.isLoading()"
-              label="Monthly Outflow"
+              label="Spending this month"
               icon="TrendingDown"
             />
             <cmn-stat-card
-              [value]="store.savingsRateFormatted()"
+              [value]="store.topCategoryFormatted()"
               [loading]="store.isLoading()"
-              label="Savings Rate"
-              icon="PiggyBank"
+              [label]="store.topCategoryLabel()"
+              icon="ChartPie"
             />
           </div>
 
@@ -143,19 +143,12 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
             }
           </div>
 
-          @if (store.hasCashFlow()) {
-            <div class="grid grid-cols-1 gap-cmn-4 lg:grid-cols-2">
-              <cmn-bar-chart
-                [series]="store.cashFlowBars()"
-                label="Income vs Spending"
-                currency="USD"
-              />
-              <cmn-bar-chart
-                [series]="store.savingsRateBars()"
-                label="Monthly Savings Rate"
-                valueFormat="percent"
-              />
-            </div>
+          @if (store.hasSpending()) {
+            <cmn-bar-chart
+              [series]="store.monthlySpendingBars()"
+              label="Monthly Spending"
+              currency="USD"
+            />
           }
 
           <div class="grid grid-cols-1 gap-cmn-4 lg:grid-cols-3">

--- a/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/dashboard/dashboard.computed.ts
@@ -33,22 +33,15 @@ const DAY_FORMATTER = new Intl.DateTimeFormat('en-US', {month: 'short', day: 'nu
 const SHORT_SPAN_DAYS = 92;
 const MS_PER_DAY = 86_400_000;
 
-const MONTH_KEY_PAD = 2;
-const PERCENT = 100;
-
 const SLEEVE_COLOR = {banking: '#10b981', brokerage: '#6366f1', crypto: '#f59e0b'} as const;
-const INCOME_COLOR = '#10b981';
-const SPENDING_COLOR = '#ef4444';
-const SAVINGS_COLOR = '#6366f1';
+const SPENDING_COLOR = '#6366f1';
 
-interface MonthTotals {
-  inflow: number;
-  outflow: number;
-  net: number;
-}
+// Need at least a start and end snapshot to state a change over the window.
+const MIN_POINTS_FOR_DELTA = 2;
 
 function currentMonthKey(): string {
   const now = new Date();
+  const MONTH_KEY_PAD = 2;
   return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(MONTH_KEY_PAD, '0')}`;
 }
 
@@ -57,41 +50,34 @@ function formatMonthKey(key: string): string {
   return MONTH_FORMATTER.format(new Date(Date.UTC(year, month - 1, 1)));
 }
 
-/** Collapse the per-currency monthly rows into one USD total per month, sorted chronologically. */
-function groupMonthlyFlow(rows: MonthlyFlow[]): [string, MonthTotals][] {
-  const byMonth = new Map<string, MonthTotals>();
+/** Collapse the per-currency monthly rows into one USD outflow per month, sorted chronologically. */
+function groupMonthlyOutflow(rows: MonthlyFlow[]): [string, number][] {
+  const byMonth = new Map<string, number>();
   for (const r of rows) {
-    const cur = byMonth.get(r.month) ?? {inflow: 0, outflow: 0, net: 0};
-    cur.inflow += r.inflowUsd;
-    cur.outflow += r.outflowUsd;
-    cur.net += r.netUsd;
-    byMonth.set(r.month, cur);
+    byMonth.set(r.month, (byMonth.get(r.month) ?? 0) + r.outflowUsd);
   }
   return [...byMonth.entries()].sort(([a], [b]) => a.localeCompare(b));
 }
 
-function sumCurrentMonthUsd(rows: MonthlyFlow[]): Nullable<MonthTotals> {
+function currentMonthOutflow(rows: MonthlyFlow[]): Nullable<number> {
   const key = currentMonthKey();
   const forMonth = rows.filter(r => r.month === key);
   if (forMonth.length === 0) {
     return null;
   }
-  return forMonth.reduce<MonthTotals>(
-    (acc, r) => ({
-      inflow: acc.inflow + r.inflowUsd,
-      outflow: acc.outflow + r.outflowUsd,
-      net: acc.net + r.netUsd,
-    }),
-    {inflow: 0, outflow: 0, net: 0}
-  );
+  return forMonth.reduce((sum, r) => sum + r.outflowUsd, 0);
 }
 
 export function dashboardComputed(store: StateSignals) {
   const currency = inject(CurrencyPipe);
   const categoryStore = inject(CategoryStore);
 
+  // Snapshots with a real total; days with a missing feed land as 0 and would otherwise
+  // render as a cliff down to the axis, reading as if net worth briefly vanished.
+  const validHistory = computed(() => store.netWorthHistory().filter(s => s.totalNetWorth > 0));
+
   const snapshotLabeller = computed((): ((s: NetWorthSnapshotDto) => string) => {
-    const history = store.netWorthHistory();
+    const history = validHistory();
     if (history.length === 0) {
       return s => s.snapshotDate;
     }
@@ -106,86 +92,92 @@ export function dashboardComputed(store: StateSignals) {
       () => currency.transform(store.data()?.totalNetWorthUsd ?? 0) ?? ''
     ),
 
-    latestInflowFormatted: computed(() => {
-      const current = sumCurrentMonthUsd(store.data()?.monthlyFlow ?? []);
-      return current ? COMPACT_FORMATTER.format(current.inflow) : '—';
-    }),
-
-    latestOutflowFormatted: computed(() => {
-      const current = sumCurrentMonthUsd(store.data()?.monthlyFlow ?? []);
-      return current ? COMPACT_FORMATTER.format(current.outflow) : '—';
-    }),
-
-    savingsRateFormatted: computed(() => {
-      const current = sumCurrentMonthUsd(store.data()?.monthlyFlow ?? []);
-      if (!current || current.inflow <= 0) {
+    // Signed net-worth change across the loaded window.
+    netWorthChangeFormatted: computed(() => {
+      const history = validHistory();
+      if (history.length < MIN_POINTS_FOR_DELTA) {
         return '—';
       }
-      return `${((current.net / current.inflow) * PERCENT).toFixed(0)}%`;
+      const delta = history[history.length - 1].totalNetWorth - history[0].totalNetWorth;
+      const sign = delta >= 0 ? '+' : '−';
+      return `${sign}${COMPACT_FORMATTER.format(Math.abs(delta))}`;
+    }),
+
+    monthlySpendingFormatted: computed(() => {
+      const spend = currentMonthOutflow(store.data()?.monthlyFlow ?? []);
+      return spend != null ? COMPACT_FORMATTER.format(spend) : '—';
+    }),
+
+    topCategoryLabel: computed(() => {
+      const top = store.data()?.topCategories?.[0];
+      if (!top) {
+        return 'Top Category';
+      }
+      return categoryStore.labelMap()[top.category] ?? MerchantCategoryUtils.format(top.category);
+    }),
+
+    topCategoryFormatted: computed(() => {
+      const top = store.data()?.topCategories?.[0];
+      return top ? (currency.transform(top.totalSpend) ?? '—') : '—';
     }),
 
     // Stacked net-worth composition (banking / brokerage / crypto) over time — the snapshots
     // already carry each sleeve, so we plot the mix rather than throwing it away for one line.
     netWorthAreaSeries: computed((): AreaSeries[] => {
-      const history = store.netWorthHistory();
+      const history = validHistory();
       if (history.length === 0) {
         return [];
       }
       const labelOf = snapshotLabeller();
+      const labels = history.map(labelOf);
+      // A sleeve reading 0 on a given day means its feed was missing, not that the
+      // balance vanished — carry the last-known value forward so the stack doesn't
+      // collapse to the axis and read as a crash.
+      const carryForward = (pick: (s: NetWorthSnapshotDto) => number): number[] => {
+        let last = 0;
+        return history.map(s => {
+          const value = pick(s);
+          if (value > 0) {
+            last = value;
+          }
+          return last;
+        });
+      };
+      const toPoints = (values: number[]) => values.map((value, i) => ({label: labels[i], value}));
       return [
         {
           label: 'Banking',
           color: SLEEVE_COLOR.banking,
-          points: history.map(s => ({label: labelOf(s), value: s.bankingTotal})),
+          points: toPoints(carryForward(s => s.bankingTotal)),
         },
         {
           label: 'Brokerage',
           color: SLEEVE_COLOR.brokerage,
-          points: history.map(s => ({label: labelOf(s), value: s.brokerageTotal})),
+          points: toPoints(carryForward(s => s.brokerageTotal)),
         },
         {
           label: 'Crypto',
           color: SLEEVE_COLOR.crypto,
-          points: history.map(s => ({label: labelOf(s), value: s.cryptoTotal})),
+          points: toPoints(carryForward(s => s.cryptoTotal)),
         },
       ];
     }),
 
-    cashFlowBars: computed((): BarSeries[] => {
-      const grouped = groupMonthlyFlow(store.data()?.monthlyFlow ?? []);
+    monthlySpendingBars: computed((): BarSeries[] => {
+      const grouped = groupMonthlyOutflow(store.data()?.monthlyFlow ?? []);
       if (grouped.length === 0) {
         return [];
       }
       return [
-        {
-          label: 'Income',
-          color: INCOME_COLOR,
-          points: grouped.map(([key, v]) => ({label: formatMonthKey(key), value: v.inflow})),
-        },
         {
           label: 'Spending',
           color: SPENDING_COLOR,
-          points: grouped.map(([key, v]) => ({label: formatMonthKey(key), value: v.outflow})),
+          points: grouped.map(([key, value]) => ({label: formatMonthKey(key), value})),
         },
       ];
     }),
 
-    savingsRateBars: computed((): BarSeries[] => {
-      const grouped = groupMonthlyFlow(store.data()?.monthlyFlow ?? []);
-      if (grouped.length === 0) {
-        return [];
-      }
-      return [
-        {
-          label: 'Savings rate',
-          color: SAVINGS_COLOR,
-          points: grouped.map(([key, v]) => ({
-            label: formatMonthKey(key),
-            value: v.inflow > 0 ? (v.net / v.inflow) * PERCENT : 0,
-          })),
-        },
-      ];
-    }),
+    hasSpending: computed(() => (store.data()?.monthlyFlow ?? []).length > 0),
 
     categoryChartData: computed((): DonutSegment[] =>
       (store.data()?.topCategories ?? []).map(c => ({
@@ -193,8 +185,6 @@ export function dashboardComputed(store: StateSignals) {
         value: c.totalSpend,
       }))
     ),
-
-    hasCashFlow: computed(() => (store.data()?.monthlyFlow ?? []).length > 0),
 
     netWorthStaleNotice: computed((): string | null => {
       const history = store.netWorthHistory();

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -16,11 +16,16 @@
         </div>
       </cmn-card>
     } @else {
-      <div class="grid gap-cmn-4 sm:grid-cols-2 items-start">
-        <cmn-stat-card
-          [value]="store.totalPositionsValue() | currencyAmount"
-          label="Total position value"
-        />
+      <div class="grid gap-cmn-4 sm:grid-cols-2 items-stretch">
+        <div class="grid content-start gap-cmn-4">
+          <cmn-stat-card
+            [value]="store.totalPositionsValue() | currencyAmount"
+            label="Total position value"
+          />
+          @for (group of store.positionsByAssetClass(); track group.assetClass) {
+            <cmn-stat-card [value]="group.totalValue | currencyAmount" [label]="group.label" />
+          }
+        </div>
         <cmn-donut-chart
           [segments]="store.allocationSegments()"
           label="Allocation"


### PR DESCRIPTION
Addresses the "looks awful" feedback. **Playwright-verified** against live VPS data (local frontend → tunneled remote API), iterated on screenshots — not a blind restyle.

## Theme (app-wide)
The light theme was purple-tinted throughout (`surface #f5f2ff`, borders `#c7c4d8`) — the "cheap wash." Now a cool neutral ground (`#f7f8fa`), real grey borders (`#e4e7ec`), higher-contrast text. Dark theme untouched.

## Dashboard — stop showing analytics we can't stand behind
- **Removed the Savings Rate chart** (it rendered **−500,000%** — `net/inflow` with ~$0 income) **and Income vs Spending** — income isn't classified yet, so both were built on data that doesn't exist. This is a real backend gap, flagged separately.
- **Net worth area no longer collapses to the axis** on missing-feed days — per-sleeve carry-forward (last-known balance) smooths the gaps instead of drawing crashes.
- **KPI row now all meaningful**: Net Worth · Change (period) · Spending this month · Top category.
- Kept: stacked net-worth-by-sleeve area, monthly spending bars, category donut + table.
- Charts: dropped vertical gridlines + axis borders for a cleaner read.

## Layout balance
- **Investments**: lone short stat card beside a tall donut → a stacked Total / Equities / Crypto KPI column that matches the donut height.
- **Accounts**: orphaned floating donut → a Net Worth summary card paired with the donut, filling the header.

## Verification
- Playwright screenshots of Dashboard / Investments / Accounts against live data (before → after)
- `ng lint` (app + libs) clean · `ng build --configuration production` clean · app suite 163/163

## Follow-up (not in this PR)
Income/transfers aren't classified, so income-based analytics (savings rate, cash-flow in/out) are deferred until that's fixed on the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)