### PR TITLE
fix: dashboard KPI layout-shift on range change; harden deploy against api race

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -119,8 +119,14 @@ services:
     ports:
       - "127.0.0.1:${FRONTEND_PORT:-4200}:4200"
     depends_on:
+      # Ordering only — NOT service_healthy. During a recreate the old and new api
+      # containers briefly overlap and contend on the ~14 per-context EF migration
+      # locks; a slow/transient-unhealthy api under service_healthy aborts the whole
+      # `compose up`, leaving the frontend never started (outage on 2026-08-07).
+      # deploy.sh gates real readiness with its own 120s api health-poll loop, so
+      # nginx just 502s for a few seconds until the api is up — no aborted deploy.
       api:
-        condition: service_healthy
+        condition: service_started
     networks:
       - finance-sentry
     logging:

--- a/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
@@ -90,7 +90,7 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
             />
             <cmn-stat-card
               [value]="store.netWorthChangeFormatted()"
-              [loading]="store.isHistoryLoading()"
+              [loading]="store.isLoading()"
               label="Change (period)"
               icon="TrendingUp"
             />


### PR DESCRIPTION
Two stability fixes.

## Dashboard: KPI row jumps on date-range change
The **Change (period)** card was the only KPI bound to `isHistoryLoading`, so every range switch (3M/6M/1Y/All) flipped just that card into its two-line skeleton (~3.5rem) vs the one-line value (~2rem). Grid rows size to the tallest card, so the whole KPI row — and every chart below — jumped down then back on each click. Now it gates on `isLoading()` like its three siblings: skeleton on initial load only.

**Playwright-verified** against live data: the area + spending charts hold `Y=313` / `Y=596` across every range, mid-load and settled (previously they shifted each click).

## Deploy: harden against the api-recreate race
The 2026-08-07 outage was `compose up` aborting with *"dependency failed to start: api is unhealthy"* — during a recreate the old and new api containers briefly overlap and contend on ~14 per-context EF migration locks; a transient-unhealthy api under the frontend's `condition: service_healthy` kills the whole `up`, leaving the frontend **never started**. Downgraded to `service_started` (ordering only). `deploy.sh` already gates real readiness with its own 120s api health-poll loop, so nginx just 502s briefly until the api is up — no aborted deploy.

## Verification
`ng lint` clean · `ng build --configuration production` clean · app suite 163/163

🤖 Generated with [Claude Code](https://claude.com/claude-code)