### PR TITLE
fix(categorization): count external "Payment from" credits as income

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/TransferDescriptionClassifier.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Infrastructure/Categorization/TransferDescriptionClassifier.cs
@@ -3,11 +3,14 @@ namespace FinanceSentry.Modules.BankSync.Infrastructure.Categorization;
 using FinanceSentry.Modules.BankSync.Domain;
 
 /// <summary>
-/// Classifies bank-transfer transactions from their description prefix, for providers that
-/// give no structured category (TrueLayer) or whose MCC misleads (Monobank). Open-banking
+/// Classifies bank-transfer and income transactions from their description prefix, for providers
+/// that give no structured category (TrueLayer) or whose MCC misleads (Monobank). Open-banking
 /// feeds render peer/account transfers with a directional prefix — "To &lt;name/account&gt;" for
-/// outgoing, "From …" / "Payment from …" for incoming — which is a reliable signal that a
-/// merchant-keyword match is not. Monobank «банка» (savings-jar) operations are the same shape:
+/// outgoing, "From …" for incoming — which is a reliable signal that a merchant-keyword match is
+/// not. TrueLayer distinguishes an EXTERNAL incoming payment ("Payment from &lt;party&gt;" — salary,
+/// refunds, peer payments) from an internal own-account move (bare "From &lt;account&gt;", e.g.
+/// "From Instant Access Savings"): the former is income, not a transfer, so it must NOT be
+/// excluded from cash-flow. Monobank «банка» (savings-jar) operations are the same shape:
 /// "Поповнення «Jar»" (top-up, outgoing) and "З банки «Jar»" (withdrawal, incoming). Monobank
 /// tags them with the charity MCC 8398, so the description is the only trustworthy signal that
 /// they are internal transfers and not government/charity spend.
@@ -19,12 +22,16 @@ using FinanceSentry.Modules.BankSync.Domain;
 /// </summary>
 public static class TransferDescriptionClassifier
 {
+    // Checked before IncomingPrefixes: an external "Payment from <party>" is income, not an
+    // internal transfer, so it stays in cash-flow instead of being excluded like a bare "From".
+    private static readonly string[] IncomePrefixes = ["Payment from "];
     private static readonly string[] OutgoingPrefixes = ["To ", "Поповнення "];
-    private static readonly string[] IncomingPrefixes = ["From ", "Payment from ", "З банки "];
+    private static readonly string[] IncomingPrefixes = ["From ", "З банки "];
 
     /// <summary>
-    /// Returns <see cref="CategoryKeys.TransferOut"/> / <see cref="CategoryKeys.TransferIn"/>
-    /// for a directional-prefix description, or <c>null</c> when it is not a recognizable transfer.
+    /// Returns <see cref="CategoryKeys.Income"/> for an external incoming payment,
+    /// <see cref="CategoryKeys.TransferOut"/> / <see cref="CategoryKeys.TransferIn"/> for a
+    /// directional internal-transfer description, or <c>null</c> when it is neither.
     /// </summary>
     public static string? Resolve(string? description)
     {
@@ -32,6 +39,12 @@ public static class TransferDescriptionClassifier
             return null;
 
         var d = description.TrimStart();
+
+        foreach (var prefix in IncomePrefixes)
+        {
+            if (d.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return CategoryKeys.Income;
+        }
 
         foreach (var prefix in IncomingPrefixes)
         {

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TransferDescriptionClassifierTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Infrastructure/TransferDescriptionClassifierTests.cs
@@ -14,7 +14,9 @@ public class TransferDescriptionClassifierTests
     [InlineData("To Instant Access Savings", CategoryKeys.TransferOut)]
     [InlineData("From Instant Access Savings", CategoryKeys.TransferIn)]
     [InlineData("From investment account", CategoryKeys.TransferIn)]
-    [InlineData("Payment from Andrea Di Florio", CategoryKeys.TransferIn)]
+    // External incoming payments are income, NOT internal transfers — they must stay in cash-flow.
+    [InlineData("Payment from Andrea Di Florio", CategoryKeys.Income)]
+    [InlineData("Payment from Ss+c Wealth And Insurance", CategoryKeys.Income)]
     // Monobank «банка» (savings-jar) operations — charity MCC 8398, so the description is the
     // only reliable transfer signal. "Поповнення" = top-up (out), "З банки" = from jar (in).
     [InlineData("Поповнення «Поточний RUSORIZ»", CategoryKeys.TransferOut)]


### PR DESCRIPTION
Dashboard inflow read ~$0 and the savings/cash-flow charts were unusable — real income was excluded from cash-flow. Diagnosed against live data: the recurring **SS&C salary** (`Payment from Ss+c Wealth And Insurance`) and other external receipts were categorized `TRANSFER_IN` and dropped by the money-flow reader (which excludes all `TRANSFER_IN/OUT`).

## Root cause
`TransferDescriptionClassifier` lumped `"Payment from <party>"` together with bare `"From <account>"` as an incoming transfer. But TrueLayer uses them distinctly:
- **`Payment from X`** = external receipt (salary, refund, peer payment) → **income**
- **`From Instant Access Savings`** (bare `From`) = internal own-account move → transfer

## Fix
Split them in the classifier:
- `Payment from …` → **`INCOME`** (already a seeded category) → counts as inflow, displays as "Income".
- Bare `From …`, `З банки …`, `To …`, `Поповнення …` → unchanged (still internal transfers, still excluded).

No name list, no matcher loosening, **zero new false-positive risk**. Internal card moves (`З Білої картки`, via MCC) stay excluded. Spending is debit-only, so income credits can't pollute the category breakdown.

## Deploy note
Existing rows keep their stored category until `recategorize` is run once post-deploy — I'll trigger that and verify inflow against live data.

## Verification
450 unit tests green; backend builds clean (zero warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)