### PR TITLE
feat(ibkr): surface uninvested cash from the IBKR ledger

### DIFF
--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRGatewayModels.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/IBKRGatewayModels.cs
@@ -24,3 +24,12 @@ public sealed record IBKRPositionResponse(
     [property: JsonPropertyName("mktValue")] decimal MktValue,
     [property: JsonPropertyName("avgCost")] decimal? AvgCost = null,
     [property: JsonPropertyName("avgPrice")] decimal? AvgPrice = null);
+
+/// <summary>
+/// One currency row of <c>/v1/api/portfolio/{accountId}/ledger</c> — the account's settled cash
+/// per currency. The response is keyed by currency code; the pseudo-key <c>"BASE"</c> aggregates
+/// every currency in the account's base currency, so it is skipped to avoid double-counting.
+/// </summary>
+public sealed record IBKRLedgerEntry(
+    [property: JsonPropertyName("cashbalance")] decimal CashBalance,
+    [property: JsonPropertyName("currency")] string? Currency = null);

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/OAuth/IbkrOAuthAdapter.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/OAuth/IbkrOAuthAdapter.cs
@@ -1,6 +1,8 @@
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BrokerageSync.Domain.Exceptions;
 using FinanceSentry.Modules.BrokerageSync.Domain.Interfaces;
 using FinanceSentry.Modules.BrokerageSync.Domain.Repositories;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR.OAuth;
 
@@ -13,8 +15,11 @@ namespace FinanceSentry.Modules.BrokerageSync.Infrastructure.IBKR.OAuth;
 public sealed class IbkrOAuthAdapter(
     IIBKRCredentialRepository credentialRepository,
     IIbkrCredentialResolver resolver,
-    IbkrOAuthClient client) : IBrokerAdapter
+    IbkrOAuthClient client,
+    ILogger<IbkrOAuthAdapter> logger) : IBrokerAdapter
 {
+    private const string BaseLedgerKey = "BASE";
+
     public string BrokerName => "IBKR";
 
     public async Task EnsureSessionAsync(Guid credentialId, CancellationToken ct = default)
@@ -40,7 +45,7 @@ public sealed class IbkrOAuthAdapter(
     {
         using var credentials = await ResolveAsync(credentialId, ct);
         var positions = await client.GetPositionsAsync(credentials, accountId, ct);
-        return positions
+        var result = positions
             .Select(p => new BrokerPosition(
                 Symbol: p.ContractDesc,
                 InstrumentType: p.AssetClass,
@@ -48,6 +53,43 @@ public sealed class IbkrOAuthAdapter(
                 UsdValue: p.MktValue,
                 AverageCostUsd: p.AvgPrice ?? p.AvgCost))
             .ToList();
+
+        result.AddRange(await GetCashPositionsAsync(credentials, accountId, ct));
+        return result;
+    }
+
+    /// <summary>
+    /// Uninvested cash from the IBKR ledger, surfaced as synthetic CASH positions so it shows in
+    /// holdings and net worth. Best-effort: the ledger endpoint can 403 on restricted read-only
+    /// sessions, and cash is supplementary, so a failure is logged and skipped rather than failing
+    /// the whole sync.
+    /// </summary>
+    private async Task<IReadOnlyList<BrokerPosition>> GetCashPositionsAsync(
+        IbkrOAuthCredentials credentials, string accountId, CancellationToken ct)
+    {
+        try
+        {
+            var ledger = await client.GetLedgerAsync(credentials, accountId, ct);
+            return ledger
+                .Where(kv => !string.Equals(kv.Key, BaseLedgerKey, StringComparison.OrdinalIgnoreCase)
+                             && kv.Value.CashBalance != 0m)
+                .Select(kv =>
+                {
+                    var currency = string.IsNullOrWhiteSpace(kv.Value.Currency) ? kv.Key : kv.Value.Currency!;
+                    return new BrokerPosition(
+                        Symbol: $"{currency} Cash",
+                        InstrumentType: "CASH",
+                        Quantity: kv.Value.CashBalance,
+                        UsdValue: CurrencyConverter.ToUsd(kv.Value.CashBalance, currency),
+                        AverageCostUsd: null);
+                })
+                .ToList();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "IBKR cash ledger fetch failed for account {AccountId}; skipping cash.", accountId);
+            return [];
+        }
     }
 
     private async Task<IbkrOAuthCredentials> ResolveAsync(Guid credentialId, CancellationToken ct)

--- a/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/OAuth/IbkrOAuthClient.cs
+++ b/backend/src/FinanceSentry.Modules.BrokerageSync/Infrastructure/IBKR/OAuth/IbkrOAuthClient.cs
@@ -53,6 +53,19 @@ public sealed class IbkrOAuthClient(
         return await response.Content.ReadFromJsonAsync<List<IBKRPositionResponse>>(ct) ?? [];
     }
 
+    /// <summary>
+    /// Reads the account's cash ledger (settled cash per currency). Keyed by currency code,
+    /// plus a <c>"BASE"</c> aggregate row the caller is expected to skip.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, IBKRLedgerEntry>> GetLedgerAsync(
+        IbkrOAuthCredentials credentials, string accountId, CancellationToken ct = default)
+    {
+        using var response = await SendSignedGetAsync(
+            credentials, $"/v1/api/portfolio/{accountId}/ledger", ct);
+        return await response.Content.ReadFromJsonAsync<Dictionary<string, IBKRLedgerEntry>>(ct)
+            ?? new Dictionary<string, IBKRLedgerEntry>();
+    }
+
     private async Task<HttpResponseMessage> SendSignedGetAsync(
         IbkrOAuthCredentials credentials, string path, CancellationToken ct)
     {


### PR DESCRIPTION
The IBKR adapter only read positions, so any settled cash at IBKR was invisible — the brokerage total and net worth understated it.

## Change
Added a ledger read (`/v1/api/portfolio/{account}/ledger`) and surface each currency's cash as a synthetic **`<CCY> Cash`** `CASH` position, so it flows through the existing holdings upsert/reconcile and totals — **no schema, DTO, or frontend change**.

- `IbkrOAuthClient.GetLedgerAsync` + `IBKRLedgerEntry` model.
- Adapter appends cash positions (USD-converted via `CurrencyConverter`), skipping the `"BASE"` aggregate row and zero balances.
- **Best-effort**: the ledger endpoint can `403` on restricted read-only sessions, so a failure is logged and skipped rather than failing the whole IBKR sync.

## Verification
Backend builds clean (0 warnings); 450 unit tests green. I'll confirm the cash row against live IBKR data after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)