### PR TITLE
fix(accounts): USD-correct monthly outflow; rebuild net-worth hero

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetAllTransactionsQuery.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetAllTransactionsQuery.cs
@@ -2,6 +2,7 @@ namespace FinanceSentry.Modules.BankSync.Application.Queries;
 
 using FinanceSentry.Core.Api;
 using FinanceSentry.Core.Cqrs;
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain.Repositories;
 
 // ── DTOs ─────────────────────────────────────────────────────────────────────
@@ -12,6 +13,7 @@ public record GlobalTransactionDto(
     string BankName,
     string Currency,
     decimal Amount,
+    decimal AmountUsd,
     DateTime Date,
     DateTime? PostedDate,
     string Description,
@@ -76,6 +78,7 @@ public class GetAllTransactionsQueryHandler(
                 meta.Item1,
                 meta.Item2,
                 t.Amount,
+                CurrencyConverter.ToUsd(t.Amount, meta.Item2),
                 t.TransactionDate,
                 t.PostedDate,
                 t.Description,

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/donut-chart/donut-chart.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/donut-chart/donut-chart.component.ts
@@ -35,18 +35,24 @@ const PERCENT_MULTIPLIER = 100;
   selector: 'cmn-donut-chart',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div
-      class="flex flex-col gap-cmn-3 rounded-cmn-lg border border-border-default bg-surface-card p-cmn-4"
-    >
-      <span
-        class="font-label text-cmn-xs font-semibold uppercase tracking-wide text-text-secondary"
+    @if (chrome()) {
+      <div
+        class="flex flex-col gap-cmn-3 rounded-cmn-lg border border-border-default bg-surface-card p-cmn-4"
       >
-        {{ label() }}
-      </span>
-      <div class="relative w-full" style="min-height: 280px">
+        <span
+          class="font-label text-cmn-xs font-semibold uppercase tracking-wide text-text-secondary"
+        >
+          {{ label() }}
+        </span>
+        <div class="relative w-full" style="min-height: 280px">
+          <canvas #chartCanvas></canvas>
+        </div>
+      </div>
+    } @else {
+      <div class="relative h-full w-full" style="min-height: 220px">
         <canvas #chartCanvas></canvas>
       </div>
-    </div>
+    }
   `,
 })
 export class DonutChartComponent implements AfterViewInit, OnDestroy {
@@ -56,6 +62,10 @@ export class DonutChartComponent implements AfterViewInit, OnDestroy {
   public readonly segments = input<DonutSegment[]>([]);
   public readonly label = input<string>('');
   public readonly currency = input<string>('USD');
+  /** When false, renders only the ring (no bordered card, no title) for embedding. */
+  public readonly chrome = input<boolean>(true);
+  /** When false, hides the chart's built-in legend (host renders its own). */
+  public readonly showLegend = input<boolean>(true);
 
   constructor() {
     effect(() => {
@@ -113,6 +123,7 @@ export class DonutChartComponent implements AfterViewInit, OnDestroy {
         cutout: '70%',
         plugins: {
           legend: {
+            display: this.showLegend(),
             position: 'bottom',
             labels: {
               color: textSecondary || '#464555',

--- a/frontend/src/app/modules/bank-sync/models/transaction/transaction.model.ts
+++ b/frontend/src/app/modules/bank-sync/models/transaction/transaction.model.ts
@@ -9,6 +9,7 @@ export interface GlobalTransactionDto extends Timestamped {
   bankName: string;
   currency: string;
   amount: number;
+  amountUsd: number;
   date: string;
   postedDate: Nullable<string>;
   description: string;

--- a/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/accounts-list/accounts-list.component.html
@@ -9,32 +9,59 @@
   </div>
 
   @if (!store.isLoading() && store.netWorthSegments().length > 1) {
-    <div class="mb-cmn-8 grid items-stretch gap-cmn-4 sm:grid-cols-2">
-      <cmn-card class="flex flex-col justify-center">
-        <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">Total Net Worth</p>
-        <p class="font-mono text-cmn-2xl font-bold tabular-nums text-text-primary">
-          {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
-        </p>
-        <p class="mt-cmn-2 text-cmn-sm text-text-secondary">
-          {{ store.totalConnections() }} connection{{
-            store.totalConnections() !== 1 ? 's' : ''
-          }}
-          across {{ store.netWorthSegments().length }} categories
-        </p>
-      </cmn-card>
-      <cmn-donut-chart
-        [segments]="store.netWorthSegments()"
-        [currency]="store.baseCurrency()"
-        label="Net worth by category"
-      />
-    </div>
+    <cmn-card class="block mb-cmn-8">
+      <div class="flex flex-col gap-cmn-6 md:flex-row md:items-center">
+        <div class="min-w-0 flex-1">
+          <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">Total Net Worth</p>
+          <p class="mt-cmn-1 font-mono text-cmn-3xl font-bold tabular-nums text-text-primary">
+            {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
+          </p>
+          <p class="mt-cmn-1 text-cmn-sm text-text-secondary">
+            {{ store.totalConnections() }} connection{{
+              store.totalConnections() !== 1 ? 's' : ''
+            }}
+            across {{ store.netWorthSegments().length }} categories
+          </p>
+
+          <div class="mt-cmn-5 space-y-cmn-3 border-t border-border-default pt-cmn-4">
+            @for (row of store.netWorthBreakdown(); track row.label) {
+              <div class="flex items-center gap-cmn-3">
+                <span
+                  [style.background-color]="row.color"
+                  class="h-2.5 w-2.5 shrink-0 rounded-full"
+                ></span>
+                <span class="text-cmn-sm text-text-primary">{{ row.label }}</span>
+                <span class="text-cmn-xs tabular-nums text-text-secondary"
+                  >{{ row.percent | number: '1.0-0' }}%</span
+                >
+                <span class="ml-auto font-mono text-cmn-sm tabular-nums text-text-primary">
+                  {{ store.baseCurrency() }} {{ row.value | number: '1.2-2' }}
+                </span>
+              </div>
+            }
+          </div>
+        </div>
+
+        <div class="w-full md:w-[240px] md:shrink-0">
+          <cmn-donut-chart
+            [segments]="store.netWorthSegments()"
+            [currency]="store.baseCurrency()"
+            [chrome]="false"
+            [showLegend]="false"
+          />
+        </div>
+      </div>
+    </cmn-card>
   } @else if (!store.isLoading() && store.totalNetWorth() !== 0) {
-    <div class="mb-cmn-8 text-right">
+    <cmn-card class="block mb-cmn-8">
       <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">Total Net Worth</p>
-      <p class="font-mono text-cmn-2xl font-bold tabular-nums text-text-primary">
+      <p class="mt-cmn-1 font-mono text-cmn-3xl font-bold tabular-nums text-text-primary">
         {{ store.baseCurrency() }} {{ store.totalNetWorth() | number: '1.2-2' }}
       </p>
-    </div>
+      <p class="mt-cmn-1 text-cmn-sm text-text-secondary">
+        {{ store.totalConnections() }} connection{{ store.totalConnections() !== 1 ? 's' : '' }}
+      </p>
+    </cmn-card>
   }
 
   @if (store.isLoading()) {

--- a/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/accounts/accounts.computed.ts
@@ -4,8 +4,11 @@ import {type DonutSegment} from '@dsdevq-common/ui';
 import {
   type AccountCategory,
   type CategorySummary,
+  type NetWorthBreakdownRow,
   type WealthSummaryResponse,
 } from '../../../../shared/models/wealth/wealth.model';
+
+const PERCENT = 100;
 
 interface StateSignals {
   summary: Signal<Nullable<WealthSummaryResponse>>;
@@ -54,5 +57,20 @@ export function accountsComputed(store: StateSignals) {
           color: CATEGORY_COLOR[cat.category],
         }))
     ),
+    netWorthBreakdown: computed((): NetWorthBreakdownRow[] => {
+      const positive = (store.summary()?.categories ?? []).filter(
+        cat => cat.totalInBaseCurrency > 0
+      );
+      const total = positive.reduce((sum, cat) => sum + cat.totalInBaseCurrency, 0);
+      return positive
+        .map(cat => ({
+          label: CATEGORY_LABEL[cat.category],
+          color: CATEGORY_COLOR[cat.category],
+          value: cat.totalInBaseCurrency,
+          institutionCount: cat.institutionCount,
+          percent: total > 0 ? (cat.totalInBaseCurrency / total) * PERCENT : 0,
+        }))
+        .sort((a, b) => b.value - a.value);
+    }),
   };
 }

--- a/frontend/src/app/modules/bank-sync/store/transaction-ledger/transaction-ledger.computed.ts
+++ b/frontend/src/app/modules/bank-sync/store/transaction-ledger/transaction-ledger.computed.ts
@@ -35,7 +35,7 @@ export function transactionLedgerComputed(store: StateSignals) {
           const date = new Date(t.postedDate ?? t.date);
           return t.transactionType === 'debit' && date >= monthStart;
         })
-        .reduce((sum, t) => sum + Math.abs(t.amount), 0);
+        .reduce((sum, t) => sum + Math.abs(t.amountUsd), 0);
     }),
     topCategory: computed(() => {
       const counts: Record<string, number> = {};

--- a/frontend/src/app/shared/models/wealth/wealth.model.ts
+++ b/frontend/src/app/shared/models/wealth/wealth.model.ts
@@ -64,3 +64,12 @@ export interface WealthSummaryResponse {
   categories: CategorySummary[];
   appliedFilters: AppliedFilters;
 }
+
+/** A single row in the net-worth-by-category breakdown shown on the accounts hero. */
+export interface NetWorthBreakdownRow {
+  label: string;
+  color: string;
+  value: number;
+  institutionCount: number;
+  percent: number;
+}


### PR DESCRIPTION
## Two fixes

### 1. Transactions "Monthly Outflow" was counting UAH as dollars
The `monthlyOutflow` stat summed native `amount` across every transaction, so UAH debits (tens of thousands of hryvnia) were added as if they were dollars → the false **$28k**. Fix follows the currency-aggregation convention:
- `GlobalTransactionDto` now carries `AmountUsd`, converted at the query boundary via `CurrencyConverter.ToUsd(amount, currency)`.
- Frontend aggregate sums `amountUsd`. Per-row displays keep native amount.

### 2. Accounts net-worth header rebuilt
Old block was a hollow tall card next to a donut card — mismatched, looked accidental. Now one cohesive hero: total + category breakdown (label · % · value) beside a bare integrated donut ring. `cmn-donut-chart` gains `chrome`/`showLegend` toggles (defaults unchanged; dashboard & holdings untouched).

Gates: backend build 0 warnings · ESLint clean · app unit tests green (3 pre-existing UI-lib spec failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)