### PR TITLE
feat(investments): apply net-worth hero to the Investments header

### DIFF
--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.html
@@ -16,22 +16,52 @@
         </div>
       </cmn-card>
     } @else {
-      <div class="grid gap-cmn-4 sm:grid-cols-2 items-stretch">
-        <div class="grid content-start gap-cmn-4">
-          <cmn-stat-card
-            [value]="store.totalPositionsValue() | currencyAmount"
-            label="Total position value"
-          />
-          @for (group of store.positionsByAssetClass(); track group.assetClass) {
-            <cmn-stat-card [value]="group.totalValue | currencyAmount" [label]="group.label" />
-          }
+      <cmn-card class="block">
+        <div class="flex flex-col gap-cmn-6 md:flex-row md:items-center">
+          <div class="min-w-0 flex-1">
+            <p class="text-cmn-xs uppercase tracking-wide text-text-secondary">
+              Total position value
+            </p>
+            <p class="mt-cmn-1 font-mono text-cmn-3xl font-bold tabular-nums text-text-primary">
+              {{ store.totalPositionsValue() | currencyAmount }}
+            </p>
+            <p class="mt-cmn-1 text-cmn-sm text-text-secondary">
+              {{ store.positions().length }} position{{
+                store.positions().length !== 1 ? 's' : ''
+              }}
+              across {{ store.positionsByAssetClass().length }} asset
+              {{ store.positionsByAssetClass().length !== 1 ? 'classes' : 'class' }}
+            </p>
+
+            <div class="mt-cmn-5 space-y-cmn-3 border-t border-border-default pt-cmn-4">
+              @for (row of store.allocationBreakdown(); track row.label) {
+                <div class="flex items-center gap-cmn-3">
+                  <span
+                    [style.background-color]="row.color"
+                    class="h-2.5 w-2.5 shrink-0 rounded-full"
+                  ></span>
+                  <span class="text-cmn-sm text-text-primary">{{ row.label }}</span>
+                  <span class="text-cmn-xs tabular-nums text-text-secondary"
+                    >{{ row.percent | number: '1.0-0' }}%</span
+                  >
+                  <span class="ml-auto font-mono text-cmn-sm tabular-nums text-text-primary">
+                    {{ row.value | currencyAmount }}
+                  </span>
+                </div>
+              }
+            </div>
+          </div>
+
+          <div class="w-full md:w-[240px] md:shrink-0">
+            <cmn-donut-chart
+              [segments]="store.allocationSegments()"
+              [chrome]="false"
+              [showLegend]="false"
+              currency="USD"
+            />
+          </div>
         </div>
-        <cmn-donut-chart
-          [segments]="store.allocationSegments()"
-          label="Allocation"
-          currency="USD"
-        />
-      </div>
+      </cmn-card>
 
       @for (group of store.positionsByAssetClass(); track group.assetClass) {
         <cmn-card class="grid gap-cmn-4">

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.spec.ts
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.spec.ts
@@ -3,7 +3,8 @@ import {signal} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from 'vitest';
 
-import {type PositionAssetGroup} from '../../store/holdings.computed';
+import {type Position} from '../../models/position/position.model';
+import {type AllocationBreakdownRow, type PositionAssetGroup} from '../../store/holdings.computed';
 import {HoldingsStore} from '../../store/holdings.store';
 import {InvestmentsComponent} from './holdings.component';
 
@@ -45,18 +46,42 @@ describe('InvestmentsComponent — positions view', () => {
   let mockStore: {
     isPositionsLoading: ReturnType<typeof signal<boolean>>;
     positionsErrorMessage: ReturnType<typeof signal<string>>;
+    positions: ReturnType<typeof signal<Position[]>>;
     positionsByAssetClass: ReturnType<typeof signal<PositionAssetGroup[]>>;
     totalPositionsValue: ReturnType<typeof signal<number>>;
     allocationSegments: ReturnType<typeof signal<never[]>>;
+    allocationBreakdown: ReturnType<typeof signal<AllocationBreakdownRow[]>>;
   };
 
   beforeEach(async () => {
     mockStore = {
       isPositionsLoading: signal(false),
       positionsErrorMessage: signal(''),
+      positions: signal<Position[]>([
+        {
+          symbol: 'DRAM',
+          provider: 'ibkr',
+          quantity: 10,
+          currentValue: 100,
+          currentPrice: 10,
+          pnlPercent: 25.3,
+        },
+        {
+          symbol: 'SOL',
+          provider: 'binance',
+          quantity: 1,
+          currentValue: 50,
+          currentPrice: 50,
+          pnlPercent: null,
+        },
+      ]),
       positionsByAssetClass: signal<PositionAssetGroup[]>([EQUITY_GROUP, CRYPTO_GROUP]),
       totalPositionsValue: signal(150),
       allocationSegments: signal([]),
+      allocationBreakdown: signal<AllocationBreakdownRow[]>([
+        {label: 'Equities', color: '#6366f1', value: 100, percent: 67},
+        {label: 'Crypto', color: '#f59e0b', value: 50, percent: 33},
+      ]),
     };
 
     await TestBed.configureTestingModule({

--- a/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
+++ b/frontend/src/app/modules/holdings/pages/holdings/holdings.component.ts
@@ -9,7 +9,6 @@ import {
   DonutChartComponent,
   InstitutionAvatarComponent,
   PageHeaderComponent,
-  StatCardComponent,
 } from '@dsdevq-common/ui';
 
 import {AssetLogoPipe} from '../../../../shared/pipes/asset-logo.pipe';
@@ -30,7 +29,6 @@ import {HoldingsStore} from '../../store/holdings.store';
     DonutChartComponent,
     InstitutionAvatarComponent,
     PageHeaderComponent,
-    StatCardComponent,
   ],
   templateUrl: './holdings.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/modules/holdings/store/holdings.computed.ts
+++ b/frontend/src/app/modules/holdings/store/holdings.computed.ts
@@ -33,6 +33,13 @@ export interface PositionAssetGroup {
   totalValue: number;
 }
 
+export interface AllocationBreakdownRow {
+  label: string;
+  color: string;
+  value: number;
+  percent: number;
+}
+
 const ASSET_CLASS_ORDER: readonly AssetClass[] = ['equity', 'crypto'];
 
 const ASSET_CLASS_LABEL: Record<AssetClass, string> = {
@@ -111,5 +118,15 @@ export function holdingsComputed(store: StateSignals) {
         color: ASSET_CLASS_COLOR[group.assetClass],
       }))
     ),
+    allocationBreakdown: computed((): AllocationBreakdownRow[] => {
+      const groups = positionsByAssetClass();
+      const total = groups.reduce((sum, g) => sum + g.totalValue, 0);
+      return groups.map(group => ({
+        label: group.label,
+        color: ASSET_CLASS_COLOR[group.assetClass],
+        value: group.totalValue,
+        percent: total > 0 ? (group.totalValue / total) * WEIGHT_TO_PERCENT : 0,
+      }));
+    }),
   };
 }


### PR DESCRIPTION
Applies the same hero treatment shipped for the accounts page (#377) to the Investments page: the stat-card column + bordered donut becomes one cohesive hero — total position value, an asset-class breakdown (label · % · value), and a bare integrated donut ring. Adds an `allocationBreakdown` computed; drops the now-unused `StatCard` import.

Frontend-only. ESLint clean · app unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)