### PR TITLE
feat(ui): internal scroll + sticky header for data pages

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/card/card.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/card/card.component.ts
@@ -12,6 +12,11 @@ const PADDING_CLASSES: Record<CardPadding, string> = {
 @Component({
   selector: 'cmn-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.flex]': 'fill()',
+    '[class.flex-col]': 'fill()',
+    '[class.min-h-0]': 'fill()',
+  },
   template: `
     <div [class]="classes()">
       <ng-content />
@@ -21,6 +26,13 @@ const PADDING_CLASSES: Record<CardPadding, string> = {
 export class CardComponent {
   public readonly padding = input<CardPadding>('md');
   public readonly elevated = input<boolean>(false);
+  /**
+   * Fill mode: the card stretches to its flex parent and clips overflow, so a
+   * child marked `flex-1 min-h-0 overflow-auto` scrolls internally (with a
+   * sticky header) instead of growing the page. The host must be sized by its
+   * parent (e.g. `class="flex-1 min-h-0"`).
+   */
+  public readonly fill = input<boolean>(false);
 
   public readonly classes = computed(() => {
     const parts: string[] = [
@@ -35,6 +47,9 @@ export class CardComponent {
     }
     if (this.elevated()) {
       parts.push('shadow-cmn-md');
+    }
+    if (this.fill()) {
+      parts.push('flex', 'min-h-0', 'flex-1', 'flex-col', 'overflow-hidden');
     }
     return parts.join(' ');
   });

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.html
@@ -1,51 +1,51 @@
-<div class="p-cmn-6">
-  <div class="mx-auto max-w-[860px] space-y-cmn-5">
-    <cmn-page-header
-      [subtitle]="alertsSubtitle()"
-      [actionLabel]="store.unreadCount() > 0 ? 'Mark all read' : null"
-      (actionClick)="markAllRead()"
-      title="Alerts"
-      actionIcon="CheckCheck"
-    />
+<div class="mx-auto flex h-full w-full max-w-[860px] flex-col p-cmn-6">
+  <cmn-page-header
+    [subtitle]="alertsSubtitle()"
+    [actionLabel]="store.unreadCount() > 0 ? 'Mark all read' : null"
+    (actionClick)="markAllRead()"
+    title="Alerts"
+    actionIcon="CheckCheck"
+  />
 
-    <div class="flex flex-wrap gap-cmn-2">
-      @for (opt of filterOptions; track opt.id) {
-        <cmn-chip [selected]="store.filter() === opt.id" (clicked)="store.setFilter(opt.id)">
-          {{ opt.label() }}
-        </cmn-chip>
-      }
-    </div>
+  <div class="mt-cmn-5 flex flex-wrap gap-cmn-2">
+    @for (opt of filterOptions; track opt.id) {
+      <cmn-chip [selected]="store.filter() === opt.id" (clicked)="store.setFilter(opt.id)">
+        {{ opt.label() }}
+      </cmn-chip>
+    }
+  </div>
 
-    @if (filtered().length === 0) {
+  @if (filtered().length === 0) {
+    <div class="flex min-h-0 flex-1 items-center justify-center">
       <cmn-empty-state
         [message]="emptyTitle()"
         [subMessage]="emptySubtext()"
         icon="CheckCircle2"
         iconClass="text-status-success"
       />
-    } @else {
-      <div class="space-y-cmn-2">
-        @for (alert of filtered(); track alert.id) {
-          <button
-            (click)="openAlert(alert)"
-            class="block w-full text-left rounded-cmn-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
-            type="button"
-          >
-            <cmn-alert-item
-              [title]="alert.title"
-              [message]="alert.message"
-              [severity]="severityFor(alert.severity)"
-              [icon]="iconFor(alert.type)"
-              [badgeLabel]="typeLabel(alert.type)"
-              [description]="typeDescription(alert.type)"
-              [referenceLabel]="alert.referenceLabel"
-              [timestamp]="alert.createdAt"
-              [isRead]="alert.isRead"
-              (dismissed)="dismiss(alert.id)"
-            />
-          </button>
-        }
-      </div>
-    }
-  </div>
+    </div>
+  } @else {
+    <div class="mt-cmn-5 min-h-0 flex-1 space-y-cmn-2 overflow-auto pr-cmn-1">
+      @for (alert of filtered(); track alert.id) {
+        <button
+          (click)="openAlert(alert)"
+          class="block w-full text-left rounded-cmn-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-focus"
+          type="button"
+        >
+          <cmn-alert-item
+            [title]="alert.title"
+            [message]="alert.message"
+            [severity]="severityFor(alert.severity)"
+            [icon]="iconFor(alert.type)"
+            [badgeLabel]="typeLabel(alert.type)"
+            [description]="typeDescription(alert.type)"
+            [referenceLabel]="alert.referenceLabel"
+            [timestamp]="alert.createdAt"
+            [isRead]="alert.isRead"
+            (dismissed)="dismiss(alert.id)"
+          />
+        </button>
+      }
+    </div>
+  }
 </div>

--- a/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
+++ b/frontend/src/app/modules/alerts/pages/alerts/alerts.component.ts
@@ -39,6 +39,7 @@ function severityFor(severity: AlertSeverity): AlertItemSeverity {
   selector: 'fns-alerts',
   imports: [AlertItemComponent, ChipComponent, EmptyStateComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {class: 'block h-full'},
   templateUrl: './alerts.component.html',
 })
 export class AlertsComponent {

--- a/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
+++ b/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.html
@@ -1,4 +1,4 @@
-<div class="p-cmn-8 max-w-[1200px] mx-auto">
+<div class="mx-auto flex h-full w-full max-w-[1200px] flex-col p-cmn-8">
   <div class="mb-cmn-8">
     <h1 class="font-headline text-cmn-2xl font-bold text-text-primary">Transaction Ledger</h1>
     <p class="text-cmn-sm text-text-secondary mt-cmn-1">
@@ -51,7 +51,7 @@
   }
 
   @if (store.isLoading()) {
-    <cmn-card>
+    <cmn-card class="min-h-0 flex-1">
       <div class="p-cmn-4 space-y-cmn-3">
         @for (_ of skeletonRows; track $index) {
           <div class="flex gap-cmn-4">
@@ -64,62 +64,62 @@
         }
       </div>
     </cmn-card>
-  }
-
-  @if (!store.isLoading() && store.isEmpty()) {
-    <cmn-empty-state
-      message="No transactions found"
-      subMessage="Connect an account to see your transaction history."
-    />
-  }
-
-  @if (!store.isLoading() && !store.isEmpty()) {
-    <cmn-card>
-      <table class="w-full text-cmn-sm" aria-label="Transaction ledger">
-        <thead>
-          <tr
-            class="border-b border-border-default text-cmn-xs text-text-secondary uppercase tracking-wide"
-          >
-            <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Date</th>
-            <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Description</th>
-            <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Category</th>
-            <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Account</th>
-            <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">Amount</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (t of displayedTransactions(); track t.transactionId) {
+  } @else if (store.isEmpty()) {
+    <div class="flex min-h-0 flex-1 items-center justify-center">
+      <cmn-empty-state
+        message="No transactions found"
+        subMessage="Connect an account to see your transaction history."
+      />
+    </div>
+  } @else {
+    <cmn-card [fill]="true" padding="none" class="min-h-0 flex-1">
+      <div class="min-h-0 flex-1 overflow-auto">
+        <table class="w-full text-cmn-sm" aria-label="Transaction ledger">
+          <thead class="sticky top-0 z-10">
             <tr
-              (click)="openDrawer(t)"
-              class="cursor-pointer border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"
+              class="border-b border-border-default bg-surface-card text-cmn-xs text-text-secondary uppercase tracking-wide"
             >
-              <td class="py-cmn-4 px-cmn-4 text-text-secondary whitespace-nowrap">
-                {{ t.postedDate ?? t.date | date: 'MMM d, y' }}
-                @if (t.isPending) {
-                  <span class="ml-1 text-cmn-xs text-amber-500">Pending</span>
-                }
-              </td>
-              <td class="py-cmn-4 px-cmn-4 text-text-primary max-w-[280px] truncate">
-                {{ t.description }}
-              </td>
-              <td class="py-cmn-4 px-cmn-4">
-                @if (t.merchantCategory) {
-                  <cmn-tag variant="neutral">{{ t.merchantCategory | merchantCategory }}</cmn-tag>
-                } @else {
-                  <span class="text-text-secondary text-cmn-xs">—</span>
-                }
-              </td>
-              <td class="py-cmn-4 px-cmn-4 text-text-secondary">{{ t.bankName }}</td>
-              <td
-                [class]="t | transactionAmountClass"
-                class="py-cmn-4 px-cmn-4 text-right font-mono tabular-nums font-medium"
-              >
-                {{ t | transactionAmount }}
-              </td>
+              <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Date</th>
+              <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Description</th>
+              <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Category</th>
+              <th class="text-left py-cmn-3 px-cmn-4 font-medium" scope="col">Account</th>
+              <th class="text-right py-cmn-3 px-cmn-4 font-medium" scope="col">Amount</th>
             </tr>
-          }
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            @for (t of displayedTransactions(); track t.transactionId) {
+              <tr
+                (click)="openDrawer(t)"
+                class="cursor-pointer border-b border-border-default last:border-0 hover:bg-surface-bg transition-colors"
+              >
+                <td class="py-cmn-4 px-cmn-4 text-text-secondary whitespace-nowrap">
+                  {{ t.postedDate ?? t.date | date: 'MMM d, y' }}
+                  @if (t.isPending) {
+                    <span class="ml-1 text-cmn-xs text-amber-500">Pending</span>
+                  }
+                </td>
+                <td class="py-cmn-4 px-cmn-4 text-text-primary max-w-[280px] truncate">
+                  {{ t.description }}
+                </td>
+                <td class="py-cmn-4 px-cmn-4">
+                  @if (t.merchantCategory) {
+                    <cmn-tag variant="neutral">{{ t.merchantCategory | merchantCategory }}</cmn-tag>
+                  } @else {
+                    <span class="text-text-secondary text-cmn-xs">—</span>
+                  }
+                </td>
+                <td class="py-cmn-4 px-cmn-4 text-text-secondary">{{ t.bankName }}</td>
+                <td
+                  [class]="t | transactionAmountClass"
+                  class="py-cmn-4 px-cmn-4 text-right font-mono tabular-nums font-medium"
+                >
+                  {{ t | transactionAmount }}
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
 
       @if (store.hasMore()) {
         <div class="flex justify-center p-cmn-4 border-t border-border-default">

--- a/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/transaction-ledger/transaction-ledger.component.ts
@@ -44,6 +44,7 @@ const SKELETON_ROWS = 8;
   ],
   templateUrl: './transaction-ledger.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {class: 'block h-full'},
   providers: [TransactionLedgerStore],
 })
 export class TransactionLedgerComponent {


### PR DESCRIPTION
Addresses "I don't want to scroll the whole page — the table should take the free space and scroll inside, with a sticky header."

The shell already fixes the sidebar/top bar and scrolls only `<main>`; the gap was that data pages let their table grow, forcing header + stat cards + table to scroll together.

- **`cmn-card` `fill` mode** (reusable): the card stretches to its flex parent and clips overflow, so a `flex-1 min-h-0 overflow-auto` child scrolls internally.
- **Transactions**: header + 3 stat cards stay fixed; the table fills the remaining height and scrolls inside the card with a **sticky `<thead>`**.
- **Alerts**: header + filter chips stay fixed; the alert list scrolls internally.

Opt-in per data-heavy page — Dashboard/Settings keep normal page scroll within the fixed shell.

Frontend-only. Production build ✔ · app unit tests green (163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)