### PR TITLE
feat(ui): subtle theme-aware scrollbars

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -12,6 +12,36 @@ body {
   box-sizing: border-box;
 }
 
+/* Subtle, theme-aware scrollbars everywhere (thin thumb, no track chrome). */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border-default) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--color-border-default);
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  background-clip: content-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-text-secondary);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 a {
   color: var(--color-accent-default);
   text-decoration: none;


### PR DESCRIPTION
Replaces the default OS scrollbars — most visibly the internal table/list scroll on Transactions and Alerts — with a thin, rounded, low-chrome scrollbar built from the border/text theme tokens, so it adapts to light and dark automatically.

Frontend-only (global `styles.scss`). Production build ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)