### PR TITLE
fix(025): SPA routes through gateway in dev (allowedHosts)

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -82,7 +82,8 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "options": {
-            "proxyConfig": "proxy.conf.json"
+            "proxyConfig": "proxy.conf.json",
+            "allowedHosts": ["frontend", "localhost"]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
Follow-up to #383, from live smoke-testing the merged edge gateway.

## Bug found
SPA returned **403 through the gateway** (`:8080/`). YARP rewrites the `Host` header to the destination authority (`frontend`); Angular's Vite dev-server host-check rejects it: *"Blocked request. This host (\"frontend\") is not allowed."* This broke dev parity (FR-008) **and** flapped the gateway's active frontend health probe (probes `/`, got 403 → destination marked Unhealthy).

## Fix
Add `allowedHosts: ["frontend", "localhost"]` to the `serve` target in `angular.json`. **Dev-only** — production serves a static build with no host-check, so the catch-all→frontend route was already fine there.

## Verified live
- `:8080/` → **200** (was 403)
- frontend active health probe → **200, destination 'Healthy'** (was Unhealthy)
- direct `:4200/` → 200 (unchanged)

## Not addressed here (separate finding — see PR discussion)
Fast-fail on a down backend does **not** meet SC-004 (<2s 503): the `api` cluster's long `ActivityTimeout` also governs connect, so a stopped api hangs during the health-detection window instead of returning a fast 503. Fixing it properly needs a connect-timeout via a custom forwarder HTTP client (or splitting long-poll routes into their own cluster) — a design decision, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)