### PR TITLE
fix(039): register cross-module ports in the MCP host via shared FinanceSentry.Integration lib

### DIFF
--- a/backend/FinanceSentry.sln
+++ b/backend/FinanceSentry.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Gateway", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Gateway.Tests", "tests\FinanceSentry.Gateway.Tests\FinanceSentry.Gateway.Tests.csproj", "{0DA435C4-67D4-48F0-99AE-558819FB9880}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinanceSentry.Integration", "src\FinanceSentry.Integration\FinanceSentry.Integration.csproj", "{B998E621-FB3C-47AE-ACE0-D92D264FA076}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -423,6 +425,18 @@ Global
 		{0DA435C4-67D4-48F0-99AE-558819FB9880}.Release|x64.Build.0 = Release|Any CPU
 		{0DA435C4-67D4-48F0-99AE-558819FB9880}.Release|x86.ActiveCfg = Release|Any CPU
 		{0DA435C4-67D4-48F0-99AE-558819FB9880}.Release|x86.Build.0 = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|x64.Build.0 = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Debug|x86.Build.0 = Debug|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|x64.ActiveCfg = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|x64.Build.0 = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|x86.ActiveCfg = Release|Any CPU
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -457,5 +471,6 @@ Global
 		{795AF144-C2D9-4D60-BD1A-144E2A131EA0} = {2B36568E-4652-4C8F-9EBF-3998B38D64DA}
 		{FC58D173-3F5E-49DE-B38C-2FE94BEBF955} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
 		{0DA435C4-67D4-48F0-99AE-558819FB9880} = {2B36568E-4652-4C8F-9EBF-3998B38D64DA}
+		{B998E621-FB3C-47AE-ACE0-D92D264FA076} = {D9A5477F-5833-4DEE-8108-6F1E5B821F51}
 	EndGlobalSection
 EndGlobal

--- a/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
+++ b/backend/src/FinanceSentry.API/FinanceSentry.API.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="..\FinanceSentry.Modules.Companion\FinanceSentry.Modules.Companion.csproj" />
     <ProjectReference Include="..\FinanceSentry.Modules.Analytics\FinanceSentry.Modules.Analytics.csproj" />
     <ProjectReference Include="..\FinanceSentry.Modules.Retention\FinanceSentry.Modules.Retention.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Integration\FinanceSentry.Integration.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/FinanceSentry.API/Program.cs
+++ b/backend/src/FinanceSentry.API/Program.cs
@@ -1,7 +1,7 @@
 using Serilog;
 using FinanceSentry.API.Commands;
 using FinanceSentry.API.Conventions;
-using FinanceSentry.API.Integration;
+using FinanceSentry.Integration;
 using FinanceSentry.API.Hangfire;
 using FinanceSentry.API.Migrations;
 using FinanceSentry.API.Modules;

--- a/backend/src/FinanceSentry.Integration/CrossModulePortRegistration.cs
+++ b/backend/src/FinanceSentry.Integration/CrossModulePortRegistration.cs
@@ -1,7 +1,8 @@
-namespace FinanceSentry.API.Integration;
+namespace FinanceSentry.Integration;
 
 using FinanceSentry.Modules.Research.Domain.Ports;
 using FinanceSentry.Modules.Risk.Domain.Ports;
+using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// 039: wires the cross-module read ports whose adapters live in the host. The Risk and Research

--- a/backend/src/FinanceSentry.Integration/FinanceSentry.Integration.csproj
+++ b/backend/src/FinanceSentry.Integration/FinanceSentry.Integration.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinanceSentry.Core\FinanceSentry.Core.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Research\FinanceSentry.Modules.Research.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Modules.Risk\FinanceSentry.Modules.Risk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/src/FinanceSentry.Integration/IpsAllocationPolicySource.cs
+++ b/backend/src/FinanceSentry.Integration/IpsAllocationPolicySource.cs
@@ -1,4 +1,4 @@
-namespace FinanceSentry.API.Integration;
+namespace FinanceSentry.Integration;
 
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Modules.Research.API.Responses;

--- a/backend/src/FinanceSentry.Integration/RiskPositionCapSource.cs
+++ b/backend/src/FinanceSentry.Integration/RiskPositionCapSource.cs
@@ -1,4 +1,4 @@
-namespace FinanceSentry.API.Integration;
+namespace FinanceSentry.Integration;
 
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Modules.Research.Domain.Ports;

--- a/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
+++ b/backend/src/FinanceSentry.Mcp/FinanceSentry.Mcp.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\FinanceSentry.Modules.Risk\FinanceSentry.Modules.Risk.csproj" />
     <ProjectReference Include="..\FinanceSentry.Modules.Companion\FinanceSentry.Modules.Companion.csproj" />
     <ProjectReference Include="..\FinanceSentry.Modules.Analytics\FinanceSentry.Modules.Analytics.csproj" />
+    <ProjectReference Include="..\FinanceSentry.Integration\FinanceSentry.Integration.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/FinanceSentry.Mcp/McpServiceRegistration.cs
+++ b/backend/src/FinanceSentry.Mcp/McpServiceRegistration.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Core.Interfaces;
+using FinanceSentry.Integration;
 using FinanceSentry.Mcp.Abstractions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -52,6 +53,11 @@ public static class McpServiceRegistration
                 registrar.Register(services, config);
             }
         }
+
+        // 039: the cross-module read-port adapters (IPS↔Risk) live in the shared FinanceSentry.Integration
+        // composition lib so every host — API and this MCP host — registers them. Without this the MCP host
+        // leaves IAllocationPolicySource / IPositionCapSource unregistered and risk/allocation tools throw.
+        services.AddCrossModulePorts();
 
         services.AddHttpContextAccessor();
         services.AddSingleton<LocalMcpCredentialStore>();

--- a/backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs
+++ b/backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs
@@ -37,6 +37,7 @@ using FinanceSentry.Modules.Subscriptions.Domain;
 using FinanceSentry.Modules.Subscriptions.Domain.Repositories;
 using FinanceSentry.Modules.Subscriptions.Infrastructure.Persistence;
 using FinanceSentry.Modules.Subscriptions.Infrastructure.Persistence.Repositories;
+using FinanceSentry.Integration;
 using FinanceSentry.Modules.Wealth.Domain;
 using FinanceSentry.Modules.Wealth.Domain.Repositories;
 using FinanceSentry.Modules.Wealth.Infrastructure.Persistence;
@@ -121,6 +122,8 @@ public sealed class ToolParityTests
         services.AddScoped<IStructureQueryService, StructureQueryService>();
         services.AddScoped<IRadarSignalWriter, RadarSignalWriter>();
         services.AddScoped<IRadarSignalReader, RadarSignalReader>();
+        services.AddScoped<IMarketRegimeSource, MarketRegimeSource>();
+        services.AddScoped<IRegimeReadingRepository, RegimeReadingRepository>();
         services.AddSingleton<IMarketHistorySource>(new FakeMarketHistorySource());
         services.Configure<RadarOptions>(_ => { });
 
@@ -169,6 +172,10 @@ public sealed class ToolParityTests
         services.AddScoped<IRiskEvaluationService, RiskEvaluationService>();
         services.AddScoped<ITurnoverTracker, TurnoverTracker>();
         services.Configure<RiskOptions>(_ => { });
+
+        // 039: cross-module read-port adapters (IPS↔Risk) from the shared composition lib, matching the
+        // host graph so risk/allocation tools resolve IAllocationPolicySource / IPositionCapSource.
+        services.AddCrossModulePorts();
 
         // Domain service needed by GetBudgetSummaryQueryHandler.
         services.AddScoped<ICategoryNormalizationService, CategoryNormalizationService>();

--- a/backend/tests/FinanceSentry.Tests.Integration/CrossModulePorts/IpsAllocationPolicySourceTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Integration/CrossModulePorts/IpsAllocationPolicySourceTests.cs
@@ -1,6 +1,6 @@
 namespace FinanceSentry.Tests.Integration.CrossModulePorts;
 
-using FinanceSentry.API.Integration;
+using FinanceSentry.Integration;
 using FinanceSentry.Core.Cqrs;
 using FinanceSentry.Modules.Research.API.Responses;
 using FinanceSentry.Modules.Research.Application.Queries;


### PR DESCRIPTION
## Root cause

Feature 039 added two cross-module read-port adapters and their registrar:

- `IpsAllocationPolicySource` — implements Risk's `IAllocationPolicySource` via Research `GetIpsQuery`
- `RiskPositionCapSource` — implements Research's `IPositionCapSource` via Risk `GetRiskRuleSetQuery`
- `CrossModulePortRegistration.AddCrossModulePorts()`

These lived in the **`FinanceSentry.API` host project** and `AddCrossModulePorts()` was called only in the API's `Program.cs`. The **MCP host** (`FinanceSentry.Mcp`) does **not** reference `FinanceSentry.API`, so in the MCP server those two ports were left **unregistered**. Any MCP tool that resolves them (`get_allocation_vs_target`, the risk-cap reads inside `CheckRiskRulesQueryHandler`) threw `InvalidOperationException: Unable to resolve service for type '...IAllocationPolicySource'` at runtime.

## Fix — shared composition library

Introduced **`FinanceSentry.Integration`**, a small composition lib that both hosts reference, honoring 039's rule that Risk and Research never reference each other (only the composition root bridges them):

- References `FinanceSentry.Core`, `FinanceSentry.Modules.Research`, `FinanceSentry.Modules.Risk`.
- The three Integration files moved into it; namespace `FinanceSentry.API.Integration` → `FinanceSentry.Integration` (class names/behavior unchanged). Added an explicit `using Microsoft.Extensions.DependencyInjection;` (the Web SDK previously supplied it implicitly).
- `FinanceSentry.API` and `FinanceSentry.Mcp` both `ProjectReference` the new lib. API's `Program.cs` keeps `AddCrossModulePorts()`; MCP's `McpServiceRegistration.RegisterShared(...)` now calls it alongside the other registrations.
- Added the new project to `FinanceSentry.sln`.

## Test-graph gaps closed

`ToolParityTests` builds its own service graph by hand (it does not run module registrars). It was missing:
- the two cross-module ports (this bug), and
- a **pre-existing, separate** gap from feature 021 — `IMarketRegimeSource` / `IRegimeReadingRepository` (registered in production by `RadarModule` but never mirrored into this test helper).

Both are now registered in the helper so the parity graph matches the host graph. Production was never affected by the 021 gap (RadarModule registers it); it only surfaced in this hand-built test graph, which is why it was bundled into the same 7 red tests.

## Before / after — `FinanceSentry.Mcp.Tests`

| | Failed | Passed | Total |
|---|---|---|---|
| Before | 7 | 88 | 95 |
| After | **0** | **95** | 95 |

Of the original 7: 3 were the cross-module port bug (fixed by the shared-lib registration) and 4 were the separate 021 `IMarketRegimeSource` test-graph gap.

## Verification (in `mcr.microsoft.com/dotnet/sdk:10.0`)

- `dotnet build backend/FinanceSentry.sln` → **0 warnings, 0 errors**
- `FinanceSentry.Mcp.Tests` → 95/95 pass
- `FinanceSentry.Modules.Research.Tests` → 196 pass, 2 skipped
- `FinanceSentry.Modules.Risk.Tests` → 34/34 pass
- `FinanceSentry.Tests.Integration` `CrossModulePorts` filter → 5/5 pass (full Integration suite needs Testcontainers/docker-in-docker, not run here; solution build confirms API host composition compiles)
- `grep -rn "FinanceSentry.API.Integration" backend/src` → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)