### PR TITLE
fix(040): render <deep-chat> only after its bundle defines the element

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/chat/chat.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/chat/chat.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   CUSTOM_ELEMENTS_SCHEMA,
   input,
+  signal,
 } from '@angular/core';
 import {type Subscription} from 'rxjs';
 
@@ -37,9 +38,12 @@ const UNAVAILABLE_ERROR = 'The agent is unavailable right now. Please try again.
  * shadow root, so CSS custom properties (`var(--color-*)`) inherit through and keep it theme-aware.
  *
  * The `<deep-chat>` custom element is registered by a lazy `import()` in the constructor, so its
- * ~300&nbsp;kB bundle is a separate chunk fetched only when a chat surface first mounts (custom
- * elements upgrade retroactively once defined). The self-contained bundle also sidesteps Deep Chat's
- * package `.d.ts`, whose transitive `speech-to-element` subpath type won't resolve here.
+ * ~400&nbsp;kB bundle is a separate chunk fetched only when a chat surface first mounts. Crucially the
+ * element is rendered only AFTER that import resolves (`ready`): Deep Chat doesn't reclaim properties
+ * set before upgrade, so binding `connect`/`introMessage`/`messageStyles` to a not-yet-defined element
+ * would be silently dropped and it would boot with its default (unthemed, no-connect) demo state. The
+ * self-contained bundle also sidesteps Deep Chat's package `.d.ts`, whose transitive `speech-to-element`
+ * subpath type won't resolve here.
  */
 @Component({
   selector: 'cmn-chat',
@@ -47,21 +51,23 @@ const UNAVAILABLE_ERROR = 'The agent is unavailable right now. Please try again.
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   host: {class: 'block h-full w-full min-h-0'},
   template: `
-    <deep-chat
-      [style.width]="'100%'"
-      [style.height]="'100%'"
-      [style.border]="'none'"
-      [style.borderRadius]="'0'"
-      [style.backgroundColor]="'transparent'"
-      [connect]="connect"
-      [history]="history()"
-      [introMessage]="introMessageObj()"
-      [messageStyles]="messageStyles"
-      [textInput]="textInput()"
-      [inputAreaStyle]="inputAreaStyle"
-      [submitButtonStyles]="submitButtonStyles"
-      [auxiliaryStyle]="auxiliaryStyle"
-    />
+    @if (ready()) {
+      <deep-chat
+        [style.width]="'100%'"
+        [style.height]="'100%'"
+        [style.border]="'none'"
+        [style.borderRadius]="'0'"
+        [style.backgroundColor]="'transparent'"
+        [connect]="connect"
+        [history]="history()"
+        [introMessage]="introMessageObj()"
+        [messageStyles]="messageStyles"
+        [textInput]="textInput()"
+        [inputAreaStyle]="inputAreaStyle"
+        [submitButtonStyles]="submitButtonStyles"
+        [auxiliaryStyle]="auxiliaryStyle"
+      />
+    }
   `,
 })
 export class ChatComponent {
@@ -137,11 +143,14 @@ export class ChatComponent {
     this.introMessage() ? {text: this.introMessage()} : undefined
   );
 
+  // Only true once <deep-chat> is defined, so bindings hit an upgraded element (see class docs).
+  protected readonly ready = signal(false);
+
   constructor() {
     // Register the <deep-chat> element on demand — a separate lazy chunk (see class docs).
     // @ts-expect-error - the self-contained bundle ships no type declarations; used only for its
     // custom-element registration side effect, so an untyped module is correct here.
-    void import('deep-chat/dist/deepChat.bundle.js');
+    void import('deep-chat/dist/deepChat.bundle.js').then(() => this.ready.set(true));
   }
 
   private runTurn(body: DeepChatRequestBody, signals: DeepChatSignals): void {


### PR DESCRIPTION
## Problem
After #392, the Ledger chat booted into Deep Chat's **default unthemed "demo" state** — the "Connect to any API using the connect property…" placeholder, a plain white input, no theming. None of the property bindings (`connect` / `introMessage` / `messageStyles` / `textInput`) took effect, so typing never called our backend.

## Cause — custom-element upgrade race
`cmn-chat` lazy-imports Deep Chat. Angular created `<deep-chat>` and set `.connect` / `.introMessage` / … as instance properties **before** the bundle ran `customElements.define('deep-chat')`. Deep Chat doesn't reclaim pre-upgrade properties, so on upgrade its own accessors shadowed the already-set values and they were lost — it ran with all defaults and never invoked our `connect.handler`.

## Fix
Gate the element behind a `ready` signal flipped in the `import().then()`, so `<deep-chat>` is only created once the element is defined — bindings then hit the real setters. Bundle stays lazy (initial bundle unchanged); just a tiny post-load render.

## Verification (Playwright, live VPS data)
Dev build + real login through a Playwright script:
- Widget now renders the **Ledger intro** ("Hi, I'm Ledger — your finance agent…") and the themed **"Ask Ledger…"** input — the demo placeholder is gone.
- A sent message renders as a correctly-sized **accent bubble** (no 1-char collapse), and Deep Chat calls our `connect.handler`.

(The end-to-end reply text couldn't be exercised locally because `--disable-web-security` blocks the SameSite=Strict session cookie cross-origin; same-origin on the VPS it authenticates — which is how the earlier browser test got a real response through this same fetch path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)