### PR TITLE
fix(040): make <deep-chat> fill its container (input at bottom)

### DIFF
--- a/frontend/projects/dsdevq-common/ui/src/lib/components/chat/chat.component.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/chat/chat.component.ts
@@ -53,6 +53,7 @@ const UNAVAILABLE_ERROR = 'The agent is unavailable right now. Please try again.
   template: `
     @if (ready()) {
       <deep-chat
+        [style.display]="'block'"
         [style.width]="'100%'"
         [style.height]="'100%'"
         [style.border]="'none'"


### PR DESCRIPTION
## Problem
The Ledger chat rendered at ~132px content height — the "Ask Ledger…" input jammed right under the intro with a large dead area below, instead of filling the widget / `/ledger` page.

## Cause
Deep Chat's host element defaults to **`display: table-cell`**, so the inline `height: 100%` never resolved against the (definite-height) `cmn-chat` host — a `table-cell` outside a table falls back to content height. Measured via Playwright: `deep-chat` clientHeight **132** while `cmn-chat` was **517**.

## Fix
Force `display: block` on `<deep-chat>` so `height: 100%` resolves. Deep Chat's internal `#container` (which is `height: 100%`) then fills, and its flex column pins the input to the bottom with the message list growing above.

## Verification (Playwright, dev build)
- Widget: `deep-chat` now **517px**, input at the bottom.
- `/ledger` page: **849px**, input at the bottom.
- Screenshots confirm the intended layout on both surfaces.

Follow-up to #391 / #392 / #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)