### PR TITLE
test(frontend): revive the frontend unit suite — fix 7 stale UI specs, seed core lib spec

### DIFF
--- a/frontend/projects/dsdevq-common/core/src/lib/errors/extract-error-code.spec.ts
+++ b/frontend/projects/dsdevq-common/core/src/lib/errors/extract-error-code.spec.ts
@@ -1,0 +1,37 @@
+import {HttpErrorResponse} from '@angular/common/http';
+import {describe, expect, it} from 'vitest';
+
+import {extractErrorCode} from './extract-error-code';
+
+describe('extractErrorCode', () => {
+  it('should return the errorCode from an HttpErrorResponse body', () => {
+    const err = new HttpErrorResponse({error: {errorCode: 'invalid_credentials'}, status: 401});
+    expect(extractErrorCode(err)).toBe('invalid_credentials');
+  });
+
+  it('should return null when the body has no errorCode', () => {
+    const err = new HttpErrorResponse({error: {message: 'boom'}, status: 500});
+    expect(extractErrorCode(err)).toBeNull();
+  });
+
+  it('should return null when errorCode is not a string', () => {
+    const err = new HttpErrorResponse({error: {errorCode: 42}, status: 422});
+    expect(extractErrorCode(err)).toBeNull();
+  });
+
+  it('should return null when the error body is a string', () => {
+    const err = new HttpErrorResponse({error: 'plain text', status: 502});
+    expect(extractErrorCode(err)).toBeNull();
+  });
+
+  it('should return null for a null body', () => {
+    const err = new HttpErrorResponse({error: null, status: 0});
+    expect(extractErrorCode(err)).toBeNull();
+  });
+
+  it('should return null for non-HttpErrorResponse values', () => {
+    expect(extractErrorCode(new Error('boom'))).toBeNull();
+    expect(extractErrorCode(undefined)).toBeNull();
+    expect(extractErrorCode({errorCode: 'not_an_http_error'})).toBeNull();
+  });
+});

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/editable-field/editable-field.component.spec.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
 import {type ComponentFixture, TestBed} from '@angular/core/testing';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -140,7 +140,9 @@ describe('EditableFieldComponent', () => {
   template: '<cmn-editable-field [(value)]="label" ariaLabel="label" />',
 })
 class TwoWayHostComponent {
-  public label = 'Initial';
+  // A signal, not a plain property: under zoneless change detection a mutated plain
+  // property never marks the OnPush host dirty, so the view would not re-render.
+  public readonly label = signal('Initial');
 }
 
 describe('EditableFieldComponent — two-way model binding', () => {
@@ -162,11 +164,11 @@ describe('EditableFieldComponent — two-way model binding', () => {
     const saveButton: HTMLButtonElement = fixture.nativeElement.querySelectorAll('button')[0];
     saveButton.click();
     fixture.detectChanges();
-    expect(fixture.componentInstance.label).toBe('Updated');
+    expect(fixture.componentInstance.label()).toBe('Updated');
   });
 
   it('should reflect host property changes in view mode', () => {
-    fixture.componentInstance.label = 'External update';
+    fixture.componentInstance.label.set('External update');
     fixture.detectChanges();
     const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('button');
     expect(button?.textContent).toContain('External update');

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/page-container/page-container.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/page-container/page-container.component.spec.ts
@@ -26,8 +26,10 @@ describe('PageContainerComponent', () => {
     expect(outer?.classList).toContain('p-cmn-6');
   });
 
+  // Inner queries anchor on the padding class rather than 'div > div': the Vitest runner
+  // mounts the fixture on a <div> host, which makes a bare div-hierarchy selector ambiguous.
   it('should apply default max-width and spacing to the inner container', () => {
-    const inner: HTMLElement | null = fixture.nativeElement.querySelector('div > div');
+    const inner: HTMLElement | null = fixture.nativeElement.querySelector('.p-cmn-6 > div');
     expect(inner?.classList).toContain('mx-auto');
     expect(inner?.classList).toContain('max-w-screen-lg');
     expect(inner?.classList).toContain('space-y-cmn-5');
@@ -36,7 +38,7 @@ describe('PageContainerComponent', () => {
   it('should apply a custom maxWidth class to the inner container', () => {
     fixture.componentRef.setInput('maxWidth', 'max-w-[900px]');
     fixture.detectChanges();
-    const inner: HTMLElement | null = fixture.nativeElement.querySelector('div > div');
+    const inner: HTMLElement | null = fixture.nativeElement.querySelector('.p-cmn-6 > div');
     expect(inner?.classList).toContain('max-w-[900px]');
     expect(inner?.classList).not.toContain('max-w-screen-lg');
   });
@@ -44,7 +46,7 @@ describe('PageContainerComponent', () => {
   it('should apply lg spacing class when spacing is "lg"', () => {
     fixture.componentRef.setInput('spacing', 'lg');
     fixture.detectChanges();
-    const inner: HTMLElement | null = fixture.nativeElement.querySelector('div > div');
+    const inner: HTMLElement | null = fixture.nativeElement.querySelector('.p-cmn-6 > div');
     expect(inner?.classList).toContain('space-y-cmn-10');
     expect(inner?.classList).not.toContain('space-y-cmn-5');
   });
@@ -52,7 +54,7 @@ describe('PageContainerComponent', () => {
   it('should apply md spacing class when spacing is "md"', () => {
     fixture.componentRef.setInput('spacing', 'md');
     fixture.detectChanges();
-    const inner: HTMLElement | null = fixture.nativeElement.querySelector('div > div');
+    const inner: HTMLElement | null = fixture.nativeElement.querySelector('.p-cmn-6 > div');
     expect(inner?.classList).toContain('space-y-cmn-5');
   });
 });

--- a/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.spec.ts
+++ b/frontend/projects/dsdevq-common/ui/src/lib/components/tab-group/tab-group.component.spec.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, signal} from '@angular/core';
 import {type ComponentFixture, TestBed} from '@angular/core/testing';
 import {beforeEach, describe, expect, it} from 'vitest';
 
@@ -129,7 +129,9 @@ describe('TabGroupComponent', () => {
 })
 class TwoWayHostComponent {
   public tabs: CmnTab[] = SAMPLE_TABS;
-  public current = 'overview';
+  // A signal, not a plain property: under zoneless change detection a mutated plain
+  // property never marks the OnPush host dirty, so the view would not re-render.
+  public readonly current = signal('overview');
 }
 
 describe('TabGroupComponent — two-way model binding', () => {
@@ -146,11 +148,11 @@ describe('TabGroupComponent — two-way model binding', () => {
       fixture.nativeElement.querySelectorAll('[role="tab"]');
     buttons[2].click();
     fixture.detectChanges();
-    expect(fixture.componentInstance.current).toBe('history');
+    expect(fixture.componentInstance.current()).toBe('history');
   });
 
   it('should reflect host property change in the rendered active tab', () => {
-    fixture.componentInstance.current = 'details';
+    fixture.componentInstance.current.set('details');
     fixture.detectChanges();
     const buttons: NodeListOf<HTMLButtonElement> =
       fixture.nativeElement.querySelectorAll('[role="tab"]');
@@ -193,7 +195,12 @@ describe('TabGroupComponent — content projection', () => {
     const host: HTMLElement = fixture.nativeElement.querySelector('cmn-tab-group');
     const allChildren = Array.from(host.children);
     const tablistIdx = allChildren.findIndex(el => el.getAttribute('role') === 'tablist');
-    const panelIdx = allChildren.findIndex(el => el.querySelector('[data-testid="panel"]'));
+    // The projected <p> is itself the child element, so match it directly —
+    // querySelector alone only searches descendants and would miss it.
+    const panelIdx = allChildren.findIndex(
+      el =>
+        el.matches('[data-testid="panel"]') || el.querySelector('[data-testid="panel"]') !== null
+    );
     expect(tablistIdx).toBeGreaterThanOrEqual(0);
     expect(panelIdx).toBeGreaterThanOrEqual(0);
     expect(tablistIdx).toBeLessThan(panelIdx);


### PR DESCRIPTION
The suite had been silently dead: node_modules/.vite was a dangling symlink
into a cleaned-up /tmp scratchpad (a cache workaround from an earlier
session), so Vite's dep optimizer crashed and Vitest reported 'no tests'
for every project. With the symlink removed (local-only fix), 7 pre-existing
spec failures surfaced — all test-side, the components render correctly:

- page-container: 'div > div' selectors matched one level too shallow now
  that the fixture mounts on a <div> host; anchor on .p-cmn-6 instead
- tab-group + editable-field two-way hosts: mutating a plain property on an
  OnPush host never marks it dirty under zoneless CD; use signal() hosts
- tab-group projection: panel index used querySelector (descendants only)
  on the element that IS the panel; match the element itself too

@dsdevq-common/core had zero spec files, which made bare 'ng test' throw
'No tests found' — seed it with a real spec for extractErrorCode.

finance-sentry 172 ✓ | @dsdevq-common/ui 219 ✓ | @dsdevq-common/core 6 ✓

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
