### PR TITLE
fix(bank-sync): detect cross-currency internal transfers

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/API/Controllers/DashboardController.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/API/Controllers/DashboardController.cs
@@ -11,10 +11,12 @@ using Microsoft.AspNetCore.Mvc;
 public class DashboardController(
     IDashboardQueryService dashboard,
     ITransactionRepository transactions,
+    IBankAccountRepository accounts,
     ITransferDetectionService transferDetection) : ControllerBase
 {
     private readonly IDashboardQueryService _dashboard = dashboard ?? throw new ArgumentNullException(nameof(dashboard));
     private readonly ITransactionRepository _transactions = transactions ?? throw new ArgumentNullException(nameof(transactions));
+    private readonly IBankAccountRepository _accounts = accounts ?? throw new ArgumentNullException(nameof(accounts));
     private readonly ITransferDetectionService _transferDetection = transferDetection ?? throw new ArgumentNullException(nameof(transferDetection));
 
     // ── GET /api/dashboard/aggregated ── T408 ─────────────────────────────────
@@ -31,8 +33,11 @@ public class DashboardController(
     [HttpGet("transfers")]
     public async Task<IActionResult> GetTransfers(CancellationToken ct)
     {
-        var allTx = (await _transactions.GetByUserIdAsync(User.RequireUserId(), ct)).ToList();
-        var transferIds = _transferDetection.DetectTransferTransactionIds(allTx);
+        var userId = User.RequireUserId();
+        var allTx = (await _transactions.GetByUserIdAsync(userId, ct)).ToList();
+        var accountCurrencies = (await _accounts.GetByUserIdAsync(userId, ct))
+            .ToDictionary(a => a.Id, a => a.Currency);
+        var transferIds = _transferDetection.DetectTransferTransactionIds(allTx, accountCurrencies);
 
         var byId = allTx.ToDictionary(t => t.Id);
         var consumedCredits = new HashSet<Guid>();
@@ -43,7 +48,10 @@ public class DashboardController(
             foreach (var credit in allTx.Where(t => t.TransactionType == "credit" && transferIds.Contains(t.Id)))
             {
                 if (consumedCredits.Contains(credit.Id)) continue;
-                if (!_transferDetection.IsLikelyTransfer(debit, credit)) continue;
+                if (!_transferDetection.IsLikelyTransfer(
+                        debit, credit,
+                        accountCurrencies.GetValueOrDefault(debit.AccountId),
+                        accountCurrencies.GetValueOrDefault(credit.AccountId))) continue;
 
                 pairs.Add(new TransferPairDto(
                     new TransferItemDto(

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
@@ -37,12 +37,13 @@ public class MerchantCategoryStatisticsService(
           Guid userId, int limit = 10, CancellationToken ct = default)
     {
         var txList = await _transactions.GetByUserIdAsync(userId, ct);
-        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList());
 
         // Convert each transaction to USD by its account currency — accounts span UAH/EUR/…,
         // so summing native Amount would mix currencies and inflate the spend total.
         var accountList = await _accounts.GetByUserIdAsync(userId, ct);
         var currencyByAccount = accountList.ToDictionary(a => a.Id, a => a.Currency);
+
+        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList(), currencyByAccount);
         decimal ToUsd(Transaction t) =>
             CurrencyConverter.ToUsd(t.Amount, currencyByAccount.TryGetValue(t.AccountId, out var c) ? c : "USD");
 

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MoneyFlowStatisticsService.cs
@@ -57,8 +57,9 @@ public class MoneyFlowStatisticsService(
         // 2. Fetch transactions in window
         var txList = await _transactions.GetByUserIdSinceAsync(userId, since, ct);
 
-        // 3. Detect internal transfer pairs so they don't inflate inflow / outflow
-        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList());
+        // 3. Detect internal transfer pairs so they don't inflate inflow / outflow.
+        // Currency map enables cross-currency pairing (e.g. Revolut EUR → Monobank UAH).
+        var transferIds = _transferDetection.DetectTransferTransactionIds(txList.ToList(), accountCurrencies);
 
         // 4. Group by (currency, year-month) and sum inflow/outflow
         var result = txList

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/TransferDetectionService.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Modules.BankSync.Application.Services;
 
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Domain;
 
 /// <summary>
@@ -11,16 +12,22 @@ public interface ITransferDetectionService
     /// Returns true if the two transactions are likely an internal transfer pair.
     /// Criteria: same absolute amount (±0.01), dates within 2 days, different accounts,
     /// and at least one is type "transfer" or the descriptions share similarity.
+    /// Without currency information only same-currency (exact-amount) pairs can match.
     /// </summary>
-    bool IsLikelyTransfer(Transaction debit, Transaction credit);
+    bool IsLikelyTransfer(Transaction debit, Transaction credit, string? debitCurrency = null, string? creditCurrency = null);
 
     /// <summary>
     /// Detects all likely internal transfers within a batch and returns the union of
     /// matched debit + credit transaction Ids. Each credit is consumed by at most one
     /// debit so an ambiguous credit is not double-counted. Pending / inactive rows are
     /// ignored — the caller does not need to pre-filter.
+    /// When <paramref name="accountCurrencies"/> is provided, cross-currency pairs
+    /// (e.g. a EUR debit funding a UAH credit) are also matched by comparing the
+    /// USD-converted amounts within an FX tolerance.
     /// </summary>
-    HashSet<Guid> DetectTransferTransactionIds(IReadOnlyCollection<Transaction> transactions);
+    HashSet<Guid> DetectTransferTransactionIds(
+        IReadOnlyCollection<Transaction> transactions,
+        IReadOnlyDictionary<Guid, string>? accountCurrencies = null);
 }
 
 /// <inheritdoc />
@@ -29,8 +36,13 @@ public class TransferDetectionService : ITransferDetectionService
     private const decimal AmountTolerance = 0.01m;
     private const int MaxDateDifferenceInDays = 2;
 
+    // Cross-currency legs never match exactly: the sending and receiving banks apply their
+    // own rates and spreads, and our rate table refreshes on its own schedule. 5% absorbs
+    // typical retail FX spread + a day of rate drift without pairing unrelated amounts.
+    private const decimal CrossCurrencyRelativeTolerance = 0.05m;
+
     /// <inheritdoc />
-    public bool IsLikelyTransfer(Transaction debit, Transaction credit)
+    public bool IsLikelyTransfer(Transaction debit, Transaction credit, string? debitCurrency = null, string? creditCurrency = null)
     {
         if (debit == null) throw new ArgumentNullException(nameof(debit));
         if (credit == null) throw new ArgumentNullException(nameof(credit));
@@ -41,9 +53,20 @@ public class TransferDetectionService : ITransferDetectionService
         if (debit.AccountId == credit.AccountId)
             return false;
 
-        // Amounts must match within tolerance
-        if (Math.Abs(debit.Amount - credit.Amount) > AmountTolerance)
+        // Without both currencies the legs are assumed same-currency (legacy behaviour).
+        var sameCurrency = debitCurrency is null || creditCurrency is null
+            || string.Equals(debitCurrency, creditCurrency, StringComparison.OrdinalIgnoreCase);
+
+        if (sameCurrency)
+        {
+            // Amounts must match within tolerance
+            if (Math.Abs(debit.Amount - credit.Amount) > AmountTolerance)
+                return false;
+        }
+        else if (!AmountsMatchAcrossCurrencies(debit.Amount, debitCurrency!, credit.Amount, creditCurrency!))
+        {
             return false;
+        }
 
         // Dates must be within 2 calendar days of each other
         var debitDate  = (debit.PostedDate  ?? debit.TransactionDate).Date;
@@ -59,12 +82,25 @@ public class TransferDetectionService : ITransferDetectionService
         if (eitherIsTransferType)
             return true;
 
+        // Cross-currency legs live at different banks, often in different languages
+        // ("To UAH account" vs «Від: …»), so shared wording is rare. A transfer category
+        // on either leg (MCC 4829, directional-prefix classification, …) is accepted as
+        // the confirming signal instead — the categorised leg is already excluded from
+        // cash-flow, and the match extends that exclusion to its uncategorised twin.
+        if (!sameCurrency &&
+            (CategoryKeys.IsTransfer(debit.MerchantCategory) || CategoryKeys.IsTransfer(credit.MerchantCategory)))
+        {
+            return true;
+        }
+
         // Fallback: check description similarity (shared significant words)
         return HaveSimilarDescriptions(debit.Description, credit.Description);
     }
 
     /// <inheritdoc />
-    public HashSet<Guid> DetectTransferTransactionIds(IReadOnlyCollection<Transaction> transactions)
+    public HashSet<Guid> DetectTransferTransactionIds(
+        IReadOnlyCollection<Transaction> transactions,
+        IReadOnlyDictionary<Guid, string>? accountCurrencies = null)
     {
         if (transactions == null) throw new ArgumentNullException(nameof(transactions));
 
@@ -85,13 +121,18 @@ public class TransferDetectionService : ITransferDetectionService
         if (debits.Count == 0 || credits.Count == 0)
             return matched;
 
+        string? CurrencyOf(Transaction tx) =>
+            accountCurrencies is not null && accountCurrencies.TryGetValue(tx.AccountId, out var currency)
+                ? currency
+                : null;
+
         var consumedCredits = new HashSet<Guid>();
         foreach (var debit in debits)
         {
             foreach (var credit in credits)
             {
                 if (consumedCredits.Contains(credit.Id)) continue;
-                if (!IsLikelyTransfer(debit, credit)) continue;
+                if (!IsLikelyTransfer(debit, credit, CurrencyOf(debit), CurrencyOf(credit))) continue;
 
                 matched.Add(debit.Id);
                 matched.Add(credit.Id);
@@ -101,6 +142,26 @@ public class TransferDetectionService : ITransferDetectionService
         }
 
         return matched;
+    }
+
+    /// <summary>
+    /// Compares two amounts in different currencies by converting both to USD. Unknown
+    /// currencies never match: <see cref="CurrencyConverter.ToUsd"/> silently falls back
+    /// to 1:1 for them, which would compare unrelated magnitudes as if equal.
+    /// </summary>
+    private static bool AmountsMatchAcrossCurrencies(
+        decimal debitAmount, string debitCurrency, decimal creditAmount, string creditCurrency)
+    {
+        if (!CurrencyConverter.IsKnown(debitCurrency) || !CurrencyConverter.IsKnown(creditCurrency))
+            return false;
+
+        var debitUsd = CurrencyConverter.ToUsd(debitAmount, debitCurrency);
+        var creditUsd = CurrencyConverter.ToUsd(creditAmount, creditCurrency);
+        var larger = Math.Max(debitUsd, creditUsd);
+        if (larger <= 0)
+            return false;
+
+        return Math.Abs(debitUsd - creditUsd) / larger <= CrossCurrencyRelativeTolerance;
     }
 
     private static bool HaveSimilarDescriptions(string a, string b)

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/TransferDetectionTests.cs
@@ -1,5 +1,6 @@
 namespace FinanceSentry.Tests.Unit.BankSync.Application;
 
+using FinanceSentry.Core.Utils;
 using FinanceSentry.Modules.BankSync.Application.Services;
 using FinanceSentry.Modules.BankSync.Domain;
 using FluentAssertions;
@@ -11,7 +12,8 @@ public class TransferDetectionTests
 
     private static Transaction MakeTx(
         Guid accountId, decimal amount, string type, DateTime date,
-        string description = "Transfer to savings", bool isPending = false, bool isActive = true)
+        string description = "Transfer to savings", bool isPending = false, bool isActive = true,
+        string? category = null)
     {
         var hash = Guid.NewGuid().ToString("N");
         var tx = new Transaction(accountId, UserId, amount, date, description, hash, isPending)
@@ -19,9 +21,14 @@ public class TransferDetectionTests
             TransactionType = type,
             PostedDate = isPending ? null : date,
             IsActive = isActive,
+            MerchantCategory = category,
         };
         return tx;
     }
+
+    /// <summary>The credit-side amount that exactly mirrors a debit across currencies at current rates.</summary>
+    private static decimal ConvertedAmount(decimal amount, string fromCurrency, string toCurrency) =>
+        Math.Round(CurrencyConverter.ToUsd(amount, fromCurrency) / CurrencyConverter.ToUsd(1m, toCurrency), 2);
 
     [Fact]
     public void DetectTransferTransactionIds_EmptyInput_ReturnsEmptySet()
@@ -153,5 +160,155 @@ public class TransferDetectionTests
         var result = sut.DetectTransferTransactionIds([tx1, tx2]);
 
         result.Should().BeEmpty(because: $"type '{txType}' is not a debit or credit bucket");
+    }
+
+    // ── Cross-currency pairing ────────────────────────────────────────────────
+
+    [Fact]
+    public void DetectTransferTransactionIds_CrossCurrencyPairWithTransferCategory_Matched()
+    {
+        // Revolut EUR → Monobank UAH: amounts differ in native currency, the Monobank leg
+        // carries a transfer category (MCC 4829), descriptions share no words.
+        var eurAccount = Guid.NewGuid();
+        var uahAccount = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit = MakeTx(eurAccount, 500m, "debit", date, description: "To UAH account");
+        var credit = MakeTx(uahAccount, ConvertedAmount(500m, "EUR", "UAH"), "credit", date,
+            description: "Від: Денис Сичов", category: CategoryKeys.TransferIn);
+
+        var currencies = new Dictionary<Guid, string> { [eurAccount] = "EUR", [uahAccount] = "UAH" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEquivalentTo(new[] { debit.Id, credit.Id });
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_CrossCurrencyWithinFxTolerance_Matched()
+    {
+        // The receiving bank's own FX rate differs slightly from our rate table.
+        var eurAccount = Guid.NewGuid();
+        var uahAccount = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var mirrored = ConvertedAmount(500m, "EUR", "UAH");
+        var debit = MakeTx(eurAccount, 500m, "debit", date, category: CategoryKeys.TransferOut);
+        var credit = MakeTx(uahAccount, Math.Round(mirrored * 1.03m, 2), "credit", date,
+            description: "Від: Денис Сичов");
+
+        var currencies = new Dictionary<Guid, string> { [eurAccount] = "EUR", [uahAccount] = "UAH" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEquivalentTo(new[] { debit.Id, credit.Id });
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_CrossCurrencyOutsideFxTolerance_NotMatched()
+    {
+        var eurAccount = Guid.NewGuid();
+        var uahAccount = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var mirrored = ConvertedAmount(500m, "EUR", "UAH");
+        var debit = MakeTx(eurAccount, 500m, "debit", date, category: CategoryKeys.TransferOut);
+        var credit = MakeTx(uahAccount, Math.Round(mirrored * 1.10m, 2), "credit", date,
+            description: "Від: Денис Сичов");
+
+        var currencies = new Dictionary<Guid, string> { [eurAccount] = "EUR", [uahAccount] = "UAH" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEmpty(because: "a 10% amount mismatch exceeds the FX tolerance");
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_CrossCurrencyWithoutAnySignal_NotMatched()
+    {
+        // Amounts align at current rates but nothing marks either leg as a transfer:
+        // no transfer type, no transfer category, no shared description words.
+        var eurAccount = Guid.NewGuid();
+        var uahAccount = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit = MakeTx(eurAccount, 50m, "debit", date, description: "Grocery Store");
+        var credit = MakeTx(uahAccount, ConvertedAmount(50m, "EUR", "UAH"), "credit", date,
+            description: "Refund from marketplace");
+
+        var currencies = new Dictionary<Guid, string> { [eurAccount] = "EUR", [uahAccount] = "UAH" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEmpty(because: "coincidentally aligned amounts alone must not pair");
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_UnknownCurrency_NotMatchedAcrossCurrencies()
+    {
+        // CurrencyConverter falls back to 1:1 for unknown currencies; matching on that
+        // would compare unrelated magnitudes, so unknown-currency legs never pair.
+        var eurAccount = Guid.NewGuid();
+        var otherAccount = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit = MakeTx(eurAccount, 500m, "debit", date, category: CategoryKeys.TransferOut);
+        var credit = MakeTx(otherAccount, 500m, "credit", date, category: CategoryKeys.TransferIn);
+
+        var currencies = new Dictionary<Guid, string> { [eurAccount] = "EUR", [otherAccount] = "XYZ" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEmpty(because: "no trustworthy rate exists for 'XYZ'");
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_MissingCurrencyInfo_KeepsLegacySameAmountMatching()
+    {
+        // Accounts absent from the currency map fall back to exact-amount matching.
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit = MakeTx(accountA, 500m, "debit", date);
+        var credit = MakeTx(accountB, 500m, "credit", date);
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], new Dictionary<Guid, string>());
+
+        result.Should().BeEquivalentTo(new[] { debit.Id, credit.Id });
+    }
+
+    [Fact]
+    public void DetectTransferTransactionIds_SameCurrency_TransferCategoryAloneDoesNotMatch()
+    {
+        // The category shortcut is deliberately cross-currency-only: within one currency a
+        // jar top-up (TRANSFER_OUT) must not consume an unrelated equal-amount credit.
+        var accountA = Guid.NewGuid();
+        var accountB = Guid.NewGuid();
+        var date = new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var debit = MakeTx(accountA, 1000m, "debit", date,
+            description: "Поповнення «Банка»", category: CategoryKeys.TransferOut);
+        var credit = MakeTx(accountB, 1000m, "credit", date, description: "Дяка від друга");
+
+        var currencies = new Dictionary<Guid, string> { [accountA] = "UAH", [accountB] = "UAH" };
+
+        var sut = new TransferDetectionService();
+
+        var result = sut.DetectTransferTransactionIds([debit, credit], currencies);
+
+        result.Should().BeEmpty(because: "same-currency pairs still require a type or description signal");
     }
 }


### PR DESCRIPTION
TransferDetectionService matched pairs only by native amount ±0.01, so a
Revolut EUR → Monobank UAH transfer never paired: the EUR debit stayed in
'spending' and the UAH credit in 'income', inflating both sides of the
savings-rate and income-vs-spending charts.

- IsLikelyTransfer / DetectTransferTransactionIds now take optional
  account-currency info; same-currency behaviour is unchanged
- Different-currency legs compare USD-converted amounts within a 5%
  relative tolerance (banks' own FX rates/spreads + our rate-table drift)
- Unknown currencies never match — CurrencyConverter's silent 1:1 fallback
  would compare unrelated magnitudes
- Cross-currency legs rarely share wording (different banks, different
  languages), so a transfer category on either leg (MCC 4829, directional
  prefix) counts as the confirming signal; same-currency pairs still
  require the stricter type-or-description signal so a jar top-up cannot
  consume an unrelated equal-amount credit
- MoneyFlowStatisticsService, MerchantCategoryStatisticsService, and
  DashboardController /transfers now pass their account-currency maps

457 unit tests green (7 new cross-currency cases), build clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
