### PR TITLE
fix(dashboard): window Top Spending Categories to 6 months, not all-time

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetTopCategoriesQuery.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Queries/GetTopCategoriesQuery.cs
@@ -6,9 +6,10 @@ using FinanceSentry.Core.Cqrs;
 // ── Query ──────────────────────────────────────────────────────────────────────
 
 /// <summary>
-/// Returns the top spending categories for a user sorted by total spend DESC.
+/// Returns the top spending categories for a user over the last <see cref="Months"/>
+/// calendar months, sorted by total spend DESC.
 /// </summary>
-public record GetTopCategoriesQuery(Guid UserId, int Limit = 10) : IQuery<IReadOnlyList<CategoryStat>>;
+public record GetTopCategoriesQuery(Guid UserId, int Limit = 10, int Months = 6) : IQuery<IReadOnlyList<CategoryStat>>;
 
 // ── Handler ────────────────────────────────────────────────────────────────────
 
@@ -19,6 +20,6 @@ public class GetTopCategoriesQueryHandler(IMerchantCategoryStatisticsService ser
     public async Task<IReadOnlyList<CategoryStat>> Handle(
           GetTopCategoriesQuery request, CancellationToken cancellationToken)
     {
-        return await _service.GetTopCategoriesAsync(request.UserId, request.Limit, cancellationToken);
+        return await _service.GetTopCategoriesAsync(request.UserId, request.Limit, request.Months, cancellationToken);
     }
 }

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/DashboardQueryService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/DashboardQueryService.cs
@@ -51,7 +51,8 @@ public class DashboardQueryService(
         var bankTotalUsd = await _aggregation.GetTotalNetWorthUsdAsync(userId, ct);
         var byType = await _aggregation.GetAccountCountByTypeAsync(userId, ct);
         var flow = await _moneyFlow.GetMonthlyFlowAsync(userId, 6, ct);
-        var topCats = await _categories.GetTopCategoriesAsync(userId, 10, ct);
+        // Same 6-month window as the money-flow charts so the dashboard tells one story.
+        var topCats = await _categories.GetTopCategoriesAsync(userId, limit: 10, months: 6, ct);
         var lastSync = await _syncJobs.GetLatestSuccessfulByUserIdAsync(userId, ct);
 
         var cryptoHoldings = _cryptoHoldingsReader is not null

--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/MerchantCategoryStatisticsService.cs
@@ -15,11 +15,12 @@ public record CategoryStat(string Category, decimal TotalSpend, decimal PercentO
 public interface IMerchantCategoryStatisticsService
 {
     /// <summary>
-    /// Returns the top <paramref name="limit"/> spending categories sorted by TotalSpend DESC.
+    /// Returns the top <paramref name="limit"/> spending categories over the last
+    /// <paramref name="months"/> calendar months, sorted by TotalSpend DESC.
     /// Only posted (non-pending), active debit transactions are included.
     /// </summary>
     Task<IReadOnlyList<CategoryStat>> GetTopCategoriesAsync(
-        Guid userId, int limit = 10, CancellationToken ct = default);
+        Guid userId, int limit = 10, int months = 6, CancellationToken ct = default);
 }
 
 /// <inheritdoc />
@@ -34,9 +35,12 @@ public class MerchantCategoryStatisticsService(
 
     /// <inheritdoc />
     public async Task<IReadOnlyList<CategoryStat>> GetTopCategoriesAsync(
-          Guid userId, int limit = 10, CancellationToken ct = default)
+          Guid userId, int limit = 10, int months = 6, CancellationToken ct = default)
     {
-        var txList = await _transactions.GetByUserIdAsync(userId, ct);
+        // Windowed to match the money-flow charts — an all-time breakdown silently mixes
+        // years of history into what reads as a current spending mix.
+        var since = DateTime.UtcNow.AddMonths(-months);
+        var txList = await _transactions.GetByUserIdSinceAsync(userId, since, ct);
 
         // Convert each transaction to USD by its account currency — accounts span UAH/EUR/…,
         // so summing native Amount would mix currencies and inflate the spend total.

--- a/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
+++ b/backend/tests/FinanceSentry.Tests.Unit/BankSync/Application/MerchantCategoryStatisticsTests.cs
@@ -35,7 +35,7 @@ public class MerchantCategoryStatisticsTests
         IEnumerable<Transaction> transactions, IEnumerable<BankAccount> accounts)
     {
         var txRepoMock = new Mock<ITransactionRepository>();
-        txRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+        txRepoMock.Setup(r => r.GetByUserIdSinceAsync(UserId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
                   .ReturnsAsync(transactions.ToList());
 
         var acctRepoMock = new Mock<IBankAccountRepository>();
@@ -118,5 +118,35 @@ public class MerchantCategoryStatisticsTests
 
         // 100 + (10000 × 0.024) = 340, not 10100
         result.Single(c => c.Category == "Food").TotalSpend.Should().Be(340m);
+    }
+
+    [Fact]
+    public async Task GetTopCategories_QueriesOnlyTheRequestedMonthsWindow()
+    {
+        // The breakdown must be windowed, not all-time — the repository has to be asked
+        // for transactions since ~N months ago, not for the user's full history.
+        var (account, accountId) = MakeAccount();
+        var transactions = new List<Transaction>
+        {
+            MakeTx(accountId, 40m, "debit", DateTime.UtcNow.AddDays(-10), category: "Food"),
+        };
+
+        var txRepoMock = new Mock<ITransactionRepository>();
+        DateTime? capturedSince = null;
+        txRepoMock.Setup(r => r.GetByUserIdSinceAsync(UserId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+                  .Callback<Guid, DateTime, CancellationToken>((_, since, _) => capturedSince = since)
+                  .ReturnsAsync(transactions);
+
+        var acctRepoMock = new Mock<IBankAccountRepository>();
+        acctRepoMock.Setup(r => r.GetByUserIdAsync(UserId, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync([account]);
+
+        var sut = new MerchantCategoryStatisticsService(
+            txRepoMock.Object, acctRepoMock.Object, new TransferDetectionService());
+
+        await sut.GetTopCategoriesAsync(UserId, limit: 10, months: 3);
+
+        capturedSince.Should().NotBeNull();
+        capturedSince!.Value.Should().BeCloseTo(DateTime.UtcNow.AddMonths(-3), TimeSpan.FromDays(1));
     }
 }

--- a/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/modules/bank-sync/pages/dashboard/dashboard.component.ts
@@ -168,7 +168,7 @@ const HISTORY_RANGES: {label: string; value: HistoryRange}[] = [
             <div>
               <cmn-donut-chart
                 [segments]="store.categoryChartData()"
-                label="Top Spending Categories"
+                label="Top Spending Categories (6M)"
                 currency="USD"
               />
             </div>


### PR DESCRIPTION
GetTopCategoriesAsync aggregated every transaction ever synced, so the
'Top Spending Categories' donut and table silently mixed years of history
into what reads as a current spending mix. It now queries the same 6-month
window as the money-flow charts (GetByUserIdSinceAsync), with the window
as a parameter (GetTopCategoriesQuery gains Months = 6). The donut label
says '(6M)' so the period is visible.

458 backend unit tests green (new test pins the windowed repository call);
frontend suite 172 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
