### PR TITLE
fix(bank-sync): per-account transaction-sync watermark — white card never synced

### DIFF
--- a/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Application/Services/ScheduledSyncService.cs
@@ -261,13 +261,18 @@ public class ScheduledSyncService(
 
         var provider = _providerFactory.Resolve("monobank");
 
-        var since = cred.LastSyncAt;
+        // Per-account watermark, NOT cred.LastSyncAt: the credential is shared by every card
+        // on the token, so a shared timestamp lets the first-synced card starve the others'
+        // fetch windows (cards added later never received their initial history import).
+        var since = account.LastTransactionSyncAt;
         var (candidates, _) = await provider.SyncTransactionsAsync(
             plainToken, account.ExternalAccountId, account.Id, account.UserId, since, ct);
 
         var entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
 
-        // T031: update last sync timestamp on credential
+        account.LastTransactionSyncAt = DateTime.UtcNow;
+
+        // T031: update last sync timestamp on credential (kept for display/reaper purposes)
         cred.LastSyncAt = DateTime.UtcNow;
         await _monobankCredentials.UpdateAsync(cred, ct);
 
@@ -342,7 +347,10 @@ public class ScheduledSyncService(
             ?? throw new InvalidOperationException($"TrueLayer connection {connectionId} not found.");
 
         var provider = _providerFactory.Resolve("truelayer");
-        var since = connection.LastSyncAt;
+        // Per-account watermark, NOT connection.LastSyncAt: a connection can back several
+        // accounts, and a shared timestamp lets the first-synced account starve the others'
+        // fetch windows (accounts added later never received their initial history import).
+        var since = account.LastTransactionSyncAt;
 
         IReadOnlyList<Domain.Transaction> entities;
         int candidateCount;
@@ -354,6 +362,9 @@ public class ScheduledSyncService(
             entities = await PersistAndReconcileAsync(account.Id, candidates, ct);
             candidateCount = candidates.Count;
 
+            account.LastTransactionSyncAt = DateTime.UtcNow;
+
+            // Kept for display/reaper purposes; no longer drives fetch windows.
             connection.LastSyncAt = DateTime.UtcNow;
             await _truelayerConnections.UpdateAsync(connection, ct);
         }

--- a/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Domain/BankAccount.cs
@@ -38,6 +38,14 @@ public class BankAccount : Entity
 
     public string? LastSyncError { get; set; }
 
+    /// <summary>
+    /// Per-account transaction-sync watermark. Null means the account has never completed a
+    /// transaction import and the next sync must run the provider's initial-history window.
+    /// Deliberately per-account: a credential/connection-level timestamp lets the first-synced
+    /// account starve its siblings' fetch windows (the "white card never syncs" bug).
+    /// </summary>
+    public DateTime? LastTransactionSyncAt { get; set; }
+
     public bool IsActive { get; set; } = true;
 
     public Guid? CreatedBy { get; set; }

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260812173123_M008_AccountSyncWatermark.Designer.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260812173123_M008_AccountSyncWatermark.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceSentry.Modules.BankSync.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceSentry.Modules.BankSync.Migrations
 {
     [DbContext(typeof(BankSyncDbContext))]
-    partial class BankSyncDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812173123_M008_AccountSyncWatermark")]
+    partial class M008_AccountSyncWatermark
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260812173123_M008_AccountSyncWatermark.cs
+++ b/backend/src/FinanceSentry.Modules.BankSync/Migrations/20260812173123_M008_AccountSyncWatermark.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceSentry.Modules.BankSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class M008_AccountSyncWatermark : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastTransactionSyncAt",
+                schema: "bank_sync",
+                table: "BankAccounts",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            // Backfill: accounts that already hold transactions resume from their latest row so
+            // they don't re-run the initial history import. The 2026-07-04 floor matters: the
+            // dedup HMAC key was rotated on 2026-07-01 (#220), so re-fetching a window that
+            // overlaps rows stored under the old key would re-ingest every one of them as a
+            // duplicate (their stored hashes can no longer match). Accounts with no rows keep
+            // NULL and run the initial import — nothing exists there to duplicate.
+            migrationBuilder.Sql("""
+                UPDATE bank_sync."BankAccounts" a
+                SET "LastTransactionSyncAt" = GREATEST(t.max_date, TIMESTAMPTZ '2026-07-04 00:00:00+00')
+                FROM (
+                    SELECT "AccountId", MAX(COALESCE("PostedDate", "TransactionDate")) AS max_date
+                    FROM bank_sync."Transactions"
+                    WHERE "IsActive" = true
+                    GROUP BY "AccountId"
+                ) t
+                WHERE t."AccountId" = a."Id";
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastTransactionSyncAt",
+                schema: "bank_sync",
+                table: "BankAccounts");
+        }
+    }
+}


### PR DESCRIPTION
Monobank used cred.LastSyncAt and TrueLayer used connection.LastSyncAt as
the 'since' for statement fetches — but both are shared by every account
on the credential/connection. Whichever account synced first advanced the
watermark, and every sibling then fetched a near-zero window. Cards added
after connect (e.g. the Monobank white card, created by the #366 backfill)
never received their initial history import and never would.

- BankAccount.LastTransactionSyncAt: per-account watermark; NULL = run the
  provider's initial-history import on next sync
- Monobank + TrueLayer sync branches read/advance the account watermark;
  the credential/connection timestamps remain for display/reaper use.
  TrueLayer's SCA-wall path still leaves the watermark unadvanced.
- Migration M008: adds the column and backfills existing accounts to
  max(tx date) clamped to >= 2026-07-04 — the floor avoids re-fetching
  windows that overlap rows hashed under the pre-#220 dedup key, which
  would re-ingest all of them as duplicates. Empty accounts stay NULL and
  import their history for the first time.

458 unit tests green, build clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
