### PR TITLE
feat(ci): weekly automated releases (Monday cron merges the Release Please PR)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,10 @@ name: Release Please
 on:
   push:
     branches: [main]
+  # Dispatched by weekly-release.yml after it merges the release PR: a merge done with
+  # GITHUB_TOKEN does not fire push workflows, so the tag/release step must be invoked
+  # explicitly (workflow_dispatch is exempt from that restriction).
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,43 @@
+name: Weekly Release
+
+# Cuts a release once a week by merging the Release Please PR that accumulates on main.
+# Release Please keeps that PR current on every merge; this job just lands it on a cadence.
+# No releasable commits since the last release → no PR → the job no-ops.
+#
+# GITHUB_TOKEN merges do not fire push-triggered workflows, so after merging this job
+# explicitly dispatches Release Please (tags + publishes the GitHub release) and the VPS
+# deploy (ships the bumped version manifest, e.g. the UI footer version).
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch: # manual "release now"
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: weekly-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Merge pending release PR, then dispatch tag + deploy
+        run: |
+          set -euo pipefail
+          pr=$(gh pr list --state open --label "autorelease: pending" --json number --jq '.[0].number // empty')
+          if [[ -z "$pr" ]]; then
+            echo "No pending release PR — nothing to release this week."
+            exit 0
+          fi
+          echo "Merging release PR #$pr"
+          gh pr merge "$pr" --squash --delete-branch
+          gh workflow run release-please.yml --ref main
+          gh workflow run deploy.yml --ref main


### PR DESCRIPTION
Weekly Release (Mon 08:00 UTC, also manually dispatchable) merges the
open 'autorelease: pending' PR, then dispatches Release Please (tag +
GitHub release — required because GITHUB_TOKEN merges don't fire push
workflows) and the VPS deploy (ships the version bump). No pending PR →
clean no-op.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
