### PR TITLE
chore(deps): webpack-dev-server 5.2.6 override — zero open Dependabot alerts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21397,9 +21397,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21421,7 +21421,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,6 +96,7 @@
   },
   "overrides": {
     "undici": "^7.28.1",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "webpack-dev-server": "^5.2.6"
   }
 }


### PR DESCRIPTION
Dependabot's own fix (#437) bumped build-angular to 22.x (incompatible
with Angular 21); a transitive override gets the patched dev-server
without touching the toolchain.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
