### PR TITLE
docs: land draft specs 034 + 038 on main

### DIFF
--- a/specs/034-research-rag/checklists/requirements.md
+++ b/specs/034-research-rag/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: Research Corpus Semantic Search (RAG)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details in the spec body (the how lives in research.md, referenced not inlined)
+- [x] Focused on user value (reason over research with citations)
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements testable and unambiguous
+- [x] Success criteria measurable (recall@5 ≥ 80%, zero fabricated citations, no new datastore)
+- [x] Success criteria technology-agnostic (implementation choices deferred to research.md/plan)
+- [x] Acceptance scenarios defined
+- [x] Edge cases identified (stale data, ticker ambiguity, hallucinated citations, numbers-in-text)
+- [x] Scope bounded (prose only; numbers stay in 033 + tools)
+- [x] Dependencies + assumptions identified
+
+## Feature Readiness
+- [x] FRs have clear acceptance criteria
+- [x] User scenarios cover the primary flow
+- [x] Meets measurable outcomes
+- [x] No implementation detail leaks into the spec (the research report holds it deliberately)
+
+## Notes
+- Research is COMPLETE (research.md) — the plan can adopt its "recommended minimal architecture" directly. This is unusual: research precedes plan here by explicit request, so `/speckit.plan` mostly transcribes decisions rather than making them.
+- The hard boundary (numbers never from retrieval) is captured as FR-005 + SC-003 and is the defining constraint.
+- Ready for `/speckit.plan`.

--- a/specs/034-research-rag/research.md
+++ b/specs/034-research-rag/research.md
@@ -1,0 +1,112 @@
+# Research: Production RAG over a Personal Financial Text Corpus
+
+**Method**: deep-research pass (2026-07-22) — multi-source, cross-checked, cited. Conflicts flagged rather than smoothed. Scoped to *this* system (ASP.NET Core 9 / C# 13 monolith on PostgreSQL 14, single user, hundreds–low-thousands of docs; corpus = short news, long SEC filings, medium thesis notes; hard rule = numbers from SQL/tools, never fuzzy retrieval; preference = minimal infra, reuse Postgres, lean local/cheap).
+
+**Meta-finding (the through-line):** *configuration, not model choice, drives most of the accuracy.* On FinanceBench, naive shared-vector RAG scored ~19% vs an optimized RAG ~76% on the same questions, near the ~79% long-context ceiling. Biggest wins here are **table-aware ingestion, metadata + temporal filtering, and a golden-set eval loop** — not exotic models.
+
+---
+
+## 1. Chunking
+
+- **Baseline**: recursive/structure-aware split at **~400–512 tokens, 10–20% overlap** (~50–100 tokens). Optimal size is query-dependent (factoid 256–512; analytical 1024+), so no single size is best for both news and filings.
+- **Overlap — conflicting evidence**: a 2026 analysis found overlap gave no measurable benefit; most guides still say 10–20%. → start 512/~50 and treat overlap as tunable-toward-zero.
+- **Skip semantic chunking**: multiple studies (Vectara; arXiv cost study) found fixed-size *matches or beats* semantic on retrieval F1 at a fraction of the cost; on 10 SEC filings, structure-aware hit 0.877 context recall vs semantic 0.759 with ~10× more chunks.
+- **Table-to-text = the single highest-leverage fix**: converting HTML filing tables to pipe-delimited text lifted recall **52.6% → 73.8% (~40% relative)** before any other tuning. Keep tables **atomic — never split mid-table.**
+- **Two high-ROI techniques (defer to v2)**: parent-document / small-to-big retrieval (+15–30% on context-needing queries); Anthropic **Contextual Retrieval** (LLM-generated 50–100 token prefix per chunk) — cut top-20 failures 35% alone, 49% with contextual BM25, 67% adding a reranker (strongest single technique; costs an LLM call per chunk at ingest — affordable at this volume).
+
+**Recommendation**: route by doc type. News/notes → near-atomic (1 chunk if <512 tokens, else 512/50). Filings → section/structure-aware split with **dedicated table-to-text**, tables atomic. Add contextual-chunk prefixes in v2. Skip semantic chunking.
+
+## 2. Embedding models
+
+- Top of MTEB is compressed (~5 pts) → context length, finance-fit, cost, dims matter more than top-line score.
+- **Local**: **BGE-M3** — 1024-dim, **8192-token** context, emits dense+sparse+multi-vector from one model (drives hybrid by itself), ONNX-exportable → **best self-hosted default.** nomic-embed-text-v1.5 (768-dim, 8192, Matryoshka) is a strong alt. bge-large / E5 cap at 512 tokens — too short for filings. Qwen3-Embedding-7B tops open boards but is overkill to serve for one user.
+- **API**: OpenAI text-embedding-3-large (3072-dim Matryoshka, ~$0.13/1M) cheap strong fallback; **voyage-finance-2** — finance-specialized, 1024-dim, **32K context**, ~+7% over OpenAI-3-large and +12% over Cohere-v3 on 11 financial datasets, **free 50M-token tier**.
+- **Conflict flagged**: "Do we need domain-specific embeddings?" — gains are task-dependent; treat Voyage's +7–12% as vendor benchmarks, validate on your eval set. **FinBERT is sentiment, not a retrieval embedder — do not use for retrieval.** Matryoshka (truncatable dims) is now standard.
+- **Running a local model from .NET**: (1) ONNX Runtime in-process (lowest latency; must port the HF tokenizer to C#); (2) **Ollama embeddings API** (`POST /api/embed`, serves bge-m3/nomic — easiest wiring, plain HTTP, no tokenizer plumbing, extra process); (3) Python sidecar (widest support, extra service).
+
+**Recommendation**: **BGE-M3 via the existing local Ollama** (reuses infra you already run; gives sparse vectors for hybrid for free). Swap to **voyage-finance-2** (free tier, drop-in) if finance retrieval underperforms on the eval set. Keep 1024 dims (storage is a non-issue).
+
+## 3. pgvector on Postgres 14
+
+- **Over-provisioned at this scale.** pgvector HNSW matches/beats dedicated DBs at 1M vectors (Supabase: outperforms Qdrant on equal compute, accuracy@10=0.99); sub-10ms p99 to ~5M. You're 2–3 orders of magnitude below where it strains.
+- **PG14 supported**: current pgvector 0.8.x supports Postgres 13+ (HNSW since 0.5, quantization 0.7, iterative scans 0.8).
+- **Use HNSW, not IVFFlat** (3× faster, better accuracy; IVFFlat only for very large static sets). Defaults `m=16, ef_construction=64`; raise `ef_search`→~80–100 for recall.
+- **Metadata filtering**: pre-0.8 post-filtering "overfiltered"; enable pgvector 0.8 `hnsw.iterative_scan=relaxed_order` (or partial indexes for selective filters).
+- **Outgrow only** near low-millions of vectors; even then **pgvectorscale** (disk-backed StreamingDiskANN) keeps you in Postgres to tens of millions. A dedicated vector DB is a "1000× growth" concern, maybe never.
+
+**Recommendation**: pgvector on existing PG14, **HNSW defaults**, `ef_search≈80`, **0.8 iterative_scan=relaxed_order** for filtered queries. No vector DB. pgvectorscale as the future lever.
+
+## 4. Hybrid retrieval & reranking
+
+- **Hybrid (dense + BM25) for finance — mixed evidence, flag as unresolved.** Pro: Anthropic saw contextual embeddings + contextual BM25 cut failures 49%; hybrid's edge concentrates on exact-match (tickers, codes). Con: on LOFin, plain dense *beat* naive BM25+dense hybrid; another source has BM25 beating dense. → **Build hybrid but tune weights empirically; don't trust naive RRF blindly.**
+- **BM25 in Postgres**: native `ts_rank` **lacks IDF**; ParadeDB `pg_search` / Tiger `pg_textsearch` add real BM25 + fuzzy (~20× faster ranked top-K at 1M rows). But native FTS is "fine" at thousands–hundreds-of-thousands of docs, and staying in Postgres means the keyword index updates **transactionally** (no separate engine, no stale-index ETL gap).
+- **Fusion**: **RRF, k=60** (robust near-universal default; works on ranks, no score normalization). Reach for weighted fusion only with calibrated comparable scores.
+- **Reranking (high ROI, validate)**: retrieve 20–50 → rerank to 3–5. Reported +15–30% precision for ~100–300ms; on finance text+tables, hybrid + Cohere Rerank gave +17.4% Recall@5. **But** off-the-shelf cross-encoders can *hurt* specialized domains (−12% to −34% on patents) — validate. Models: **bge-reranker-v2-m3** (278M, Apache-2.0, ~matches Cohere, zero API cost) self-host default; **ms-marco MiniLM** lightest CPU. **License trap**: Jina Reranker v2 is CC-BY-NC (non-commercial); bge/mxbai are Apache-2.0.
+
+**Recommendation**: hybrid = **pgvector HNSW (dense) + Postgres full-text (BM25-ish)**, fused **RRF k=60**. Start **native tsvector** (adequate; zero new infra); upgrade to ParadeDB `pg_search` only if exact-term ranking disappoints. Reranker is a **fast follow, not v0** (bge-reranker-v2-m3 on GPU, MiniLM-ONNX on CPU; retrieve 30 → rerank 5) — validate it helps on the golden set first.
+
+## 5. Retrieval-quality tactics
+
+- **HyDE / query expansion — contested; risky for numbers.** Some evals show gains with reranking, others show HyDE *underperforming* vanilla dense; HyDE's fabricated hypothetical doc can inject false details and helps little on precise numeric queries. **Defer; prefer a reranker first.**
+- **Metadata filtering = highest-value tactic.** Store `ticker, published/filing_date, source, doc_type, thesis_id, as_of_date` and filter with the vector search. Also the ticker-disambiguation defense.
+- **Recency**: use **soft time-decay** (similarity × age-decay), not hard `WHERE date<X` (too aggressive). RAG is "blind to time" — retrieves stale + current at equal similarity; **as-of-date filtering** is the best mitigation.
+- **Citations**: capture provenance (doc, section, url, offset) *before* chunking so every chunk is traceable; citations can be hallucinated even when they look grounded → **atomic-claim verification** (decompose answer, check each claim vs its cited chunk) as a v2 guardrail.
+
+**Recommendation**: ship metadata filtering + **as-of-date + soft recency decay** + provenance-at-ingest from day one (cheap, hit finance failure modes). Atomic-claim citation verification as v2. **Skip HyDE** unless the eval proves it.
+
+## 6. Evaluation (solo-dev, lightweight)
+
+- **RAGAS** is the right fit — RAG-specific, LLM-judge, synthetic test-gen. Metrics: faithfulness, answer relevancy, context precision, context recall. **Only context recall needs labels**; the other three are reference-free → start with almost no labeling.
+- **Golden set ~100 Q/A pairs** (LLM-generate then human-review) is the practical target.
+- **LLM-as-judge biases** (position >10% swing, verbosity, self-preference) → randomize/swap order + average; **judge with a different model family than the answer generator** (if answers come from Qwen/Claude, judge with the other).
+- **Primary metric: recall@k** (how much answerable evidence reaches the generator); target **recall@5 ≥ 80%**. Rank metrics (MRR/nDCG) matter less once you rerank. Optional: Arize Phoenix for local traces + embedding-cluster inspection.
+
+**Recommendation**: ~100-pair golden set (LLM-gen, hand-reviewed, incl. hard numeric ones), run **RAGAS** (faithfulness + context precision reference-free; recall on labeled subset), track **recall@5 ≥ 80%**, judge with a different model family. A few hours of setup.
+
+## 7. Finance-specific pitfalls & mitigations
+
+| Pitfall | Mitigation |
+|---|---|
+| Stale/temporal data (old filing contradicts new) | as-of-date filtering + soft recency decay; optional supersession ledger |
+| Numbers in text/tables | table-aware chunking; **resolve actual figures via SQL/tools, RAG only locates + cites** |
+| Entity/ticker disambiguation | ticker metadata filter + name/co-reference resolution before retrieval |
+| Hallucinated citations | atomic-claim verification against the specific cited chunk |
+| Over-chunking loses context | structure-aware + parent-document retrieval; don't over-split |
+
+The "numbers never from fuzzy retrieval" rule is exactly right and corroborated by the numeric-retrieval failures above — keep the boundary hard.
+
+---
+
+## (a) Recommended minimal architecture (v0)
+
+**Storage (reuse Postgres, one new `rag` schema):**
+- `rag.documents` (id, doc_type {news|filing|thesis_note}, ticker, source, published_date, as_of_date, url, raw_text, provenance jsonb)
+- `rag.chunks` (id, document_id fk, chunk_text, section, ticker, published_date, embedding `vector(1024)`, `content_tsv` tsvector)
+- **HNSW** on `embedding` (cosine, defaults; pgvector 0.8 `iterative_scan=relaxed_order`; session `ef_search≈80`). **GIN** on `content_tsv`.
+
+**Ingest (C#):** route by doc_type (news/notes near-atomic; filings section-aware + **table-to-text**, tables atomic); capture provenance per chunk *before* embedding; embed with **BGE-M3 (1024-dim, 8192-token) via Ollama** (or ONNX in-process); populate `content_tsv`.
+
+**Query:** extract ticker/date filters → `WHERE`; dense (HNSW top-30) + keyword (`ts_rank` top-30) in parallel; **RRF k=60** → top-10; soft recency decay + as-of-date; feed top-5 to the LLM with a strict "cite the chunk id or say you don't know; numbers come from SQL/tools, not these passages" instruction; return answer with chunk-level citations.
+
+**Eval:** ~100-pair golden set + RAGAS (recall@5 target ≥80%), judged by a different model family.
+
+**Models locked**: embedder **BGE-M3** (fallback **voyage-finance-2**); index **pgvector HNSW**; fusion **RRF k=60**; keyword **native tsvector**. Zero new services beyond Postgres + local Ollama.
+
+## (b) Defer until later
+1. Cross-encoder reranker (bge-reranker-v2-m3 / MiniLM-ONNX) — validate on golden set first.
+2. Anthropic Contextual Retrieval (chunk prefixes) — strongest single technique, adds ingest cost.
+3. ParadeDB `pg_search` (real BM25+IDF+fuzzy) — only if native tsvector disappoints.
+4. voyage-finance-2 swap — only if BGE-M3 underperforms on the eval set.
+5. HyDE / query expansion — contested, risky for numeric queries.
+6. Atomic-claim citation verification loop — v2 guardrail.
+7. Semantic chunking — evidence says skip entirely.
+8. pgvectorscale / dedicated vector DB — irrelevant until ~millions of vectors.
+9. Parent-document retrieval — nice filings upgrade; can wait if section-aware chunking already returns whole sections.
+
+## Key conflicts / low-confidence flags
+- Chunk overlap helps vs no-benefit — tune toward zero.
+- Semantic chunking loses to fixed/structure-aware — skip.
+- Hybrid-on-finance: dense-vs-BM25 ordering is dataset-dependent — tune empirically.
+- HyDE — coin-flip in the literature, risky for numbers.
+- Rerankers can hurt specialized domains — validate.
+- Vendor benchmarks (Voyage/Cohere/Supabase/reranker deltas) are self-published — verify on your own corpus.

--- a/specs/034-research-rag/spec.md
+++ b/specs/034-research-rag/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Research Corpus Semantic Search (RAG)
+
+**Feature Branch**: `034-research-rag`
+**Created**: 2026-07-22
+**Status**: Draft (research done — see research.md)
+**Input**: User description: "Semantic search over my financial text corpus — news, SEC filings, my own thesis/decision notes — so Ledger can reason over research with citations. Numbers never come from fuzzy retrieval; RAG only locates and cites text."
+
+## Overview
+
+Finance Sentry's tools answer *numeric/structured* questions deterministically. What they can't do is let the agent **reason over the text** it has accumulated — "what have analysts and filings been saying about DRAM pricing," "what did *I* write when I entered MU," "summarize the bear case across everything I've read." Today Ledger can only keyword-search news; it can't semantically search the whole corpus, and it can't touch filings or its own notes as a searchable body.
+
+This feature adds **semantic (RAG) search over the unstructured text corpus** — market news, SEC filings, and the user's own thesis/decision notes — returning the most relevant **passages with citations** for the agent to reason over. The **hard boundary** (validated by the research pass): **numbers never come from retrieval.** RAG *locates and cites text*; authoritative figures still come from SQL/tools. This is the complement to the analytical query tool (033): prose vs. numbers.
+
+> The full research report (chunking, embedding-model choice, pgvector, hybrid retrieval, evaluation, finance pitfalls) is in [research.md](./research.md). The plan should follow its "recommended minimal architecture."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reason over news + my own notes (Priority: P1)
+
+The user's market news and personal thesis/decision notes are chunked, embedded, and indexed. Ledger can ask a natural-language question and get back the most relevant passages **with citations** (source, title/url, date), which it reasons over — never inventing figures, always attributing.
+
+**Why this priority**: This is the core new capability and the smallest corpus that proves the whole pipeline (ingest → embed → hybrid retrieve → cite). News + notes are already in Finance Sentry and are the highest-value, lowest-complexity slice.
+
+**Independent Test**: Ask "what have I written about MU, and what has the news said about memory pricing?" → receive relevant passages from *both* the user's notes and news, each with a citation; confirm no fabricated numbers and that an unanswerable query returns "nothing found," not a guess.
+
+**Acceptance Scenarios**:
+
+1. **Given** ingested news + notes, **When** Ledger runs a semantic search, **Then** it receives the top relevant passages, each with a source citation and date.
+2. **Given** a query with exact terms (a ticker), **When** searched, **Then** hybrid retrieval (semantic + keyword) surfaces exact-term matches that pure semantic search would miss.
+3. **Given** the retrieved passages, **When** Ledger answers, **Then** every claim is attributable to a returned passage and **no numeric figure is asserted from the passages** as authoritative.
+4. **Given** a query with no relevant content, **When** searched, **Then** it returns an explicit empty result — never a fabricated passage or citation.
+
+---
+
+### User Story 2 - Bring in SEC filings (Priority: P2)
+
+SEC filings (long, structured, table-heavy) are ingested with **structure-aware chunking and table-to-text extraction** so the agent can search across filings — the research's single highest-recall lever — with the same citation guarantees.
+
+**Why this priority**: Filings are the richest research source but the hardest to chunk well (the research shows table-to-text alone lifted recall ~40%). Deferred from US1 because it needs the specialized ingestion, but it's the biggest content unlock.
+
+**Independent Test**: Ingest a filing with tables; ask a question answerable from a filing table's surrounding text; confirm the relevant section is retrieved and cited, and the table's labels/shape are intact in the returned passage.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ingested filing, **When** searched, **Then** the relevant section is retrieved with its citation (filing, section, date).
+2. **Given** a filing with tables, **When** chunked, **Then** tables are kept intact (readable text) and not split mid-table.
+
+---
+
+### User Story 3 - Know it actually works (Priority: P3)
+
+A lightweight evaluation harness measures retrieval quality against a small golden set, so changes to chunking/embedding/retrieval can be judged instead of guessed.
+
+**Why this priority**: The research's clearest meta-finding is that *configuration, not model choice, drives accuracy* — which means you must be able to measure. Valuable, but the capability ships without it.
+
+**Independent Test**: Run the eval harness over a ~100-pair golden set; get a retrieval recall@k score and a faithfulness read; confirm a deliberate degradation (worse chunking) lowers the score.
+
+**Acceptance Scenarios**:
+
+1. **Given** a golden set, **When** the eval runs, **Then** it reports retrieval recall@5 and an answer-faithfulness measure.
+2. **Given** a config change, **When** re-evaluated, **Then** the score moves in the expected direction (regression is detectable).
+
+---
+
+### Edge Cases
+
+- **Stale vs current** (an old filing contradicts a new one): retrieval must not present stale text as current — use as-of-date / recency handling so the agent knows the passage's date.
+- **Ticker ambiguity** (same name, different entity): retrieval scoped/filtered by ticker so a passage about the wrong "Acme" isn't returned as relevant.
+- **Hallucinated citation**: a returned citation must point to a real ingested passage; the agent must not fabricate sources.
+- **Numbers in text**: a figure inside a retrieved passage is *context to cite*, not an authoritative value — the boundary holds.
+- **Empty / cold start**: before ingestion, search returns explicit emptiness.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST ingest the text corpus (news, thesis/decision notes; filings in US2) — chunk, embed, and index each document — with provenance (source, title/url, date, ticker where known) captured per chunk.
+- **FR-002**: System MUST provide a semantic search that, given a natural-language query, returns the most relevant passages **with citations** (source, date, and a link/reference back to the original).
+- **FR-003**: Retrieval MUST be **hybrid** — combining semantic similarity with keyword matching — so exact terms (tickers, named entities) are not missed.
+- **FR-004**: Results MUST be filterable by metadata (ticker, source, date range) and MUST account for **recency/as-of-date** so stale text is not presented as current.
+- **FR-005**: The system MUST **never present numeric figures from retrieved passages as authoritative** — retrieval locates and cites text; authoritative numbers come from the deterministic tools. The search tool's description MUST state this.
+- **FR-006**: An unanswerable query MUST return an explicit empty result; the system MUST NOT fabricate a passage or a citation.
+- **FR-007**: Filing ingestion (US2) MUST use structure-aware chunking and MUST keep tables intact (table-to-text), not split mid-table.
+- **FR-008**: The system MUST provide a lightweight way to evaluate retrieval quality (recall@k) and answer faithfulness against a golden set (US3).
+- **FR-009**: Ingestion MUST be incremental (new documents embedded as they arrive) and MUST reuse existing infrastructure (Postgres) rather than adding a separate datastore, per the research recommendation.
+
+### Key Entities *(include if feature involves data)*
+
+- **Corpus Document**: an ingested text item — type (news / filing / thesis-note), source, url, ticker(s), published/as-of date, raw text, provenance.
+- **Corpus Chunk**: a retrievable unit of a document — chunk text, embedding, keyword-index vector, and inherited metadata (ticker, date, source, section) for filtering + citation.
+- **Golden Eval Pair**: a question + expected-relevant source(s) used to measure retrieval quality.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Ledger can answer a research question by retrieving relevant passages from **both** news and the user's own notes in a single search, each with a citation.
+- **SC-002**: Hybrid retrieval surfaces exact-term (ticker) matches that pure semantic search misses — demonstrable on a query where the term is rare.
+- **SC-003**: **Zero** fabricated citations and **zero** authoritative numbers sourced from retrieved text across a review sample (the boundary holds).
+- **SC-004**: Filing tables are retrievable with their labels/shape intact (US2) — verified on a table-bearing filing.
+- **SC-005**: Retrieval recall@5 on the golden set is **≥ 80%** (the research's target), and a config regression is detectable by the eval (US3).
+- **SC-006**: No new datastore is introduced — the corpus + embeddings live in the existing Postgres.
+
+## Assumptions
+
+- **The research report governs the how.** Embedding model, chunking, pgvector index, hybrid fusion, and eval choices follow [research.md]'s recommended minimal architecture (BGE-M3 via the existing local Ollama with a voyage-finance-2 fallback; pgvector HNSW on the existing Postgres; RRF hybrid with native full-text; ~100-pair golden set + RAGAS). These are plan-level and may be revalidated against the eval set.
+- **Corpus already partly exists in FS**: news (030), filings (EDGAR), thesis/decision notes (020). This feature adds embedding + retrieval over them.
+- **Local, minimal infra**: reuse Postgres (pgvector) and the existing local Ollama; no dedicated vector DB, no paid SaaS in v1.
+- **Single primary user**; per-user scoping where the corpus is personal (notes), market-wide where it isn't (news, filings).
+
+## Notes
+
+- **[DECISION] RAG is for prose, not numbers**: the defining boundary. Retrieval locates + cites text; authoritative figures come from SQL/tools (033 + existing tools). Corroborated by the research (numeric-retrieval failure modes).
+- **[DECISION] Reuse Postgres/pgvector + local Ollama**: no new datastore or SaaS — the research shows pgvector is over-provisioned at this scale.
+- **[DECISION] Start with news + notes (US1), filings second (US2)**: smallest corpus that proves the pipeline first; filings need the specialized table-aware ingestion.
+- **[OUT OF SCOPE] Analytical/numeric querying**: that's feature 033 (structured data). 033 and 034 are complements (numbers vs. prose), not alternatives.
+- **[DEFERRED per research]**: cross-encoder reranker, Anthropic contextual-retrieval prefixes, ParadeDB `pg_search`, HyDE/query-expansion, a dedicated vector DB — all deferred until the measured baseline warrants them.

--- a/specs/038-earnings-stance-engine/checklists/requirements.md
+++ b/specs/038-earnings-stance-engine/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Ledger Earnings-Season Stance Engine
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec deliberately names existing FS subsystems by role (companion pipeline, earnings calendar, thesis-event track record, external data integration) as *dependencies to reuse* rather than implementation prescriptions — the "reuse, don't rebuild" constraint is a genuine business/architectural boundary, not a leaked design detail.
+- Concrete class/tool/source names from the seed prompt were intentionally kept out of spec.md and reserved for plan.md.
+- All items pass. Ready for `/speckit.plan` (or `/speckit.clarify` if deeper interrogation is wanted first).

--- a/specs/038-earnings-stance-engine/spec.md
+++ b/specs/038-earnings-stance-engine/spec.md
@@ -1,0 +1,167 @@
+# Feature Specification: Ledger Earnings-Season Stance Engine
+
+**Feature Branch**: `038-earnings-stance-engine`
+**Created**: 2026-08-07
+**Status**: Draft
+**Input**: Give the Ledger finance agent the Finance Sentry capabilities it needs to autonomously review every holding/watchlist name as it reports earnings, form a bullish/bearish stance, and have that stance logged and scored over time.
+
+## Context & North Star
+
+Ledger (the OpenClaw finance agent) should become an autonomous, opinionated analyst: it forms and voices a bullish/bearish stance on every name the user holds or watches, updates it as facts arrive, and helps the user — with **every call logged and scored so its autonomy earns trust over time**.
+
+This feature delivers only the **Finance Sentry (backend) side**: the facts, the mechanical trigger, the one-call review data, and the logging. The agent's judgment, narrative, and the Telegram scorecard itself are Ledger's job (OpenClaw agent-config) and are **out of scope for this repository**.
+
+Division of labour (established direction — "FS is core, agent is thin"): **FS answers "what / when / how much" and fires triggers; Ledger answers "so what / bull or bear."** Nothing in this feature makes a judgment call or moves capital.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Ledger is woken when a name reports (Priority: P1)
+
+Each day the system checks every name in the user's holdings and watchlist against the earnings calendar. When a name is about to report ("reports today") or has just reported ("reported since the last check"), the system raises a companion event that wakes Ledger to act — routed through the existing companion notification pipeline and gated by the existing materiality policy, so the user is not spammed.
+
+**Why this priority**: Without a trigger, autonomy is impossible — Ledger would only ever review a name if the user manually asked. This is the missing spark that turns "on request" into "the agent just does it during earnings season."
+
+**Independent Test**: Seed a holding whose earnings date is today (or was yesterday); run the daily check; confirm exactly one "reported"/"upcoming" companion event is raised for that user+name+quarter, that it flows to the agent-wake path, and that re-running the check the same day raises no duplicate.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user holds a name reporting today, **When** the daily check runs, **Then** an "earnings upcoming" event is raised for that name and routed to the agent-wake pipeline.
+2. **Given** a name reported since the last check, **When** the daily check runs, **Then** an "earnings reported" event is raised once for that name and fiscal quarter.
+3. **Given** an event was already raised for a name+quarter, **When** the check runs again that day (or the next), **Then** no duplicate event is raised for the same name+quarter/state.
+4. **Given** a name is neither in holdings nor watchlist, **When** it reports, **Then** no event is raised for that user.
+5. **Given** the materiality policy would suppress an event under the user's current notification mode, **When** the event is raised, **Then** it is filtered by the existing policy exactly as other companion events are.
+
+---
+
+### User Story 2 - Ledger reviews a name with a single call (Priority: P1)
+
+When Ledger goes to review a name, it can request one consolidated "earnings review" for that ticker and receive everything needed to judge the **state of the business**: the latest reported-quarter fundamentals, the most recent regulatory filing reference, recent analyst actions and the current recommendation trend, the latest valuation snapshot, and the user's existing thesis for that name (if any). Ledger makes one request instead of orchestrating five.
+
+**Why this priority**: This is the substance of the review. Forcing the agent to hand-assemble five separate lookups per name, for a dozen names, is slow, error-prone, and burns agent budget. One clean bundle is what makes a whole-portfolio sweep practical.
+
+**Independent Test**: Request the review bundle for a ticker that has fundamentals, a filing, analyst coverage, and a thesis on record; confirm the response contains each of those blocks; request it for a bare ticker with none of them and confirm the response returns cleanly with the missing blocks marked absent rather than erroring.
+
+**Acceptance Scenarios**:
+
+1. **Given** a ticker with fundamentals, a recent filing, analyst actions, a valuation snapshot, and a thesis, **When** Ledger requests the review, **Then** all five blocks are returned in one response.
+2. **Given** a ticker with no thesis on record, **When** Ledger requests the review, **Then** the response returns successfully with the thesis block marked absent.
+3. **Given** a ticker with no coverage at all, **When** Ledger requests the review, **Then** the response returns successfully with each block marked absent (no error).
+4. **Given** the review is requested, **When** the response is assembled, **Then** business-trajectory information (fundamentals, filing, valuation) is clearly distinguished from any market-reaction information.
+
+---
+
+### User Story 3 - The review carries an expectations axis (Priority: P2)
+
+The review bundle also carries, as a **separate and clearly labelled second axis**, how the just-reported quarter came in **versus consensus** — actual vs. estimate earnings (and revenue where available), plus the beat/miss direction and magnitude. This is never merged into the business-state view; it is the price/risk lens, kept beside the thesis lens.
+
+**Why this priority**: A great business that guides below consensus still gets repriced — ignoring expectations blinds the agent (and the user) to the market reaction they actually feel. But the business-state scorecard is valuable without it, so this is a fast follow, not a blocker. It also depends on an external data key that may not be present.
+
+**Independent Test**: For a ticker with a recently reported quarter, request the review and confirm the expectations block reports actual vs. estimate and a beat/miss magnitude, kept separate from the business-state blocks; with the data source disabled/keyless, confirm the review still returns and the expectations block is simply marked unavailable.
+
+**Acceptance Scenarios**:
+
+1. **Given** consensus data is available for a reported quarter, **When** Ledger requests the review, **Then** the expectations block shows actual vs. estimate and beat/miss magnitude, separate from business-state.
+2. **Given** the consensus data source is unavailable or unconfigured, **When** Ledger requests the review, **Then** the review still returns and the expectations block is marked unavailable (no error, no fabricated numbers).
+3. **Given** both axes are present, **When** the review is returned, **Then** they are never collapsed into a single combined rating by the system.
+
+---
+
+### User Story 4 - Every stance is logged and scored (Priority: P1)
+
+After Ledger reviews a name, it records its stance for that name — direction (bullish / bearish / neutral), a conviction level, and a short decision note — as an append-only, price-stamped event. Over time these recorded stances are scored against the market the same way existing thesis lifecycle events are, so the user can see how Ledger's past earnings calls actually aged.
+
+**Why this priority**: This is what makes autonomy trustworthy rather than a firehose of unaccountable opinions. It is a first-class requirement, not polish: a stance that is never recorded can never be graded, and an agent whose calls are never graded can never be shown to be an expert.
+
+**Independent Test**: Record a bullish stance for a ticker; confirm a new append-only, price-stamped event exists carrying the direction, conviction, and note; confirm the existing price-backfill/scoring mechanism picks it up like other tracked events; confirm the record is never mutated after insert (except the standard later price backfill).
+
+**Acceptance Scenarios**:
+
+1. **Given** Ledger has reviewed a name, **When** it records a stance, **Then** an append-only event is stored with direction, conviction, decision note, ticker, timestamp, and price-stamp fields.
+2. **Given** a stance event was recorded, **When** the existing track-record scoring runs, **Then** the stance is scored against the benchmark like other tracked events.
+3. **Given** a stance event exists, **When** anything other than the standard price backfill occurs, **Then** the recorded direction/conviction/note are never altered.
+4. **Given** the user asks how Ledger's earnings calls have performed, **When** the track record is read, **Then** recorded stances appear with their scored outcomes.
+
+### Edge Cases
+
+- A name reports outside market hours or the calendar date is an estimate (unconfirmed) — the "reported" state must only fire on a genuine transition, and estimated dates must not be treated as confirmed reports.
+- A name appears in both holdings and watchlist — it must not generate two events for the same report.
+- A name is held in a non-US/again-unsupported market with no earnings coverage — it is simply skipped, not errored.
+- The earnings calendar source is temporarily unavailable on a given day — the check degrades gracefully and re-attempts next run without emitting false "reported" events or losing a genuine one.
+- A ticker symbol is ambiguous or maps to no coverage — the review returns cleanly with empty blocks.
+- Ledger records two stances for the same name in one quarter (e.g., a correction) — both are retained (append-only); the latest is the current stance, history is preserved.
+- The consensus data key is absent — the expectations axis is silently unavailable everywhere it would appear, consistent with the existing keyless-source behaviour.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Trigger (US1)**
+
+- **FR-001**: The system MUST, on a daily schedule, evaluate every name in each user's current holdings and watchlist against upcoming and recent earnings-report dates.
+- **FR-002**: The system MUST raise an "earnings upcoming" signal when a watched name's confirmed report date is the current day, and an "earnings reported" signal when a watched name has transitioned to reported since the previous evaluation.
+- **FR-003**: The system MUST route these signals through the existing companion event/notification pipeline and MUST subject them to the existing materiality/notification-mode policy.
+- **FR-004**: The system MUST raise each distinct signal at most once per user + name + fiscal quarter + state, persisting enough state to guarantee idempotency across repeated runs.
+- **FR-005**: The system MUST only consider a report "confirmed" (not an estimated date) before emitting a "reported" signal, and MUST degrade gracefully (no false or lost signals) when the calendar source is unavailable.
+
+**Review bundle (US2)**
+
+- **FR-006**: The system MUST expose an agent-callable "earnings review" for a single ticker that returns, in one response: latest reported-quarter fundamentals, the most recent relevant regulatory filing reference, recent analyst actions and current recommendation trend, the latest valuation snapshot, and the user's thesis for that name if one exists.
+- **FR-007**: The review MUST return successfully when any or all of those blocks are absent, marking each missing block as absent rather than failing.
+- **FR-008**: The review MUST clearly separate business-trajectory information from market-reaction information within the response.
+
+**Expectations axis (US3)**
+
+- **FR-009**: The review MUST include a distinct expectations block reporting the just-reported quarter's actual vs. consensus earnings (and revenue where available) and the beat/miss direction and magnitude.
+- **FR-010**: The expectations block MUST be sourced from the existing external data integration, MUST be silently unavailable when that source is unconfigured, and MUST never fabricate figures.
+- **FR-011**: The system MUST NOT collapse the business-trajectory axis and the expectations axis into a single combined rating.
+
+**Logged stance (US4)**
+
+- **FR-012**: The system MUST let Ledger record an earnings stance for a name as an append-only event carrying direction (bullish/bearish/neutral), conviction, a decision note, ticker, and timestamp.
+- **FR-013**: Recorded stance events MUST be price-stamped and scored by the existing track-record mechanism, on the same footing as existing thesis lifecycle events.
+- **FR-014**: Recorded stance events MUST be immutable after insert except for the standard later price backfill; the direction/conviction/note MUST never be corrected in place.
+- **FR-015**: Recorded stances MUST be readable as part of the existing track record so their scored outcomes can be reviewed.
+
+**Cross-cutting**
+
+- **FR-016**: The feature MUST NOT execute trades or move capital; all output is advisory facts, triggers, and logs.
+- **FR-017**: Each piece MUST be independently shippable: the trigger and business-state review MUST function with existing data before the expectations axis is added.
+
+### Key Entities *(include if feature involves data)*
+
+- **Earnings-watch state**: Per user + ticker + fiscal quarter, records which signals have already been emitted, so the daily check is idempotent. The minimal memory that prevents duplicate wakes.
+- **Earnings review (composed, not stored)**: A read-time bundle for one ticker aggregating fundamentals, filing reference, analyst actions/recommendation trend, valuation snapshot, thesis, and the expectations axis. Assembled on request from existing data; not a new persisted record.
+- **Expectations datum**: Actual vs. consensus earnings/revenue and beat/miss magnitude for a reported quarter, sourced from the existing external integration; may be absent.
+- **Earnings stance event**: An append-only, price-stamped record of Ledger's call on a name — direction, conviction, decision note, ticker, timestamp — extending the existing thesis-event track record so it is scored over time.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: During an earnings season, for every name the user holds or watches that reports, Ledger is woken exactly once for that report (no misses, no duplicates) — verifiable by comparing the reported names against the events raised over the season.
+- **SC-002**: Ledger can assemble a full per-name review from a single request; a whole-portfolio sweep of a dozen names requires one request per name rather than five.
+- **SC-003**: The business-state review is usable and delivers value with no dependency on the external consensus data source (i.e., the scorecard works before the expectations axis exists).
+- **SC-004**: When the consensus source is configured, every reviewed just-reported name shows a beat/miss result kept visibly separate from its business-state read.
+- **SC-005**: 100% of stances Ledger records are retained immutably and appear in the track record with a scored outcome once prices are available — none are lost or silently overwritten.
+- **SC-006**: After one earnings season, the user can answer "how did Ledger's earnings calls do?" directly from the recorded, scored track record.
+- **SC-007**: No trade is ever placed and no capital is ever moved by this feature.
+
+## Assumptions
+
+- The existing earnings calendar (holdings + watchlist aware) is the source of report dates; no new calendar source is introduced.
+- The existing companion event → dispatch → agent-wake → Telegram pipeline and its materiality/notification-mode policy are reused unchanged; this feature only adds new event kinds and the daily producer.
+- The existing research data (fundamentals, filings, analyst actions, recommendation trend, valuation snapshot, thesis) is sufficient for the business-state axis with no new external source.
+- The expectations axis reuses the already-integrated external market-data provider and key; when the key is absent the axis is simply unavailable, matching existing keyless-source behaviour.
+- The existing thesis-event track record (append-only, price-stamped, benchmark-scored) is the logging and scoring substrate; this feature extends it with an earnings-stance event kind rather than building a parallel mechanism.
+- "Holdings" means the user's current brokerage/crypto positions already known to the system; watchlist means the existing research watchlist.
+- The agent-side cron, persona rules, and the visual scorecard are delivered as OpenClaw agent-config and are out of scope here.
+
+## Notes
+
+- [DECISION] Reuse over rebuild: the trigger rides the existing companion pipeline (new event kinds only), the review composes existing tools, the expectations axis extends the existing external integration, and stance logging extends the existing thesis-event track record. No new notification path, no new scoring engine, no new calendar source.
+- [DECISION] Two axes never merged: business trajectory (thesis lens) and expectations gap (price/risk lens) are always surfaced separately. Rationale: a good business with a bad reaction, and a weak business with a relief rally, are both real, actionable states that a single collapsed rating destroys.
+- [DECISION] Logging is first-class, not optional: FR-012–FR-015 ship with the feature, not later. Rationale: autonomy is only trustworthy if past calls are graded; an ungraded agent can never be shown to be an expert.
+- [DECISION] Incremental delivery: US1 (trigger) + US2 (business-state review) + US4 (logged stance) form the shippable MVP on existing data; US3 (expectations axis) is a fast follow gated on the external key. Rationale: don't block the whole scorecard on one optional data source.
+- [OUT OF SCOPE] Trade execution and capital movement: this feature is advisory only (FR-016). Position sizing remains governed by the (advisory) IPS.
+- [OUT OF SCOPE] Ledger's judgment, persona, cron, and the Telegram scorecard rendering: agent-config on OpenClaw, not this repository. FS delivers data + trigger + logging; Ledger decides bull/bear and speaks.
+- [OUT OF SCOPE] Any frontend/UI: this is a backend + agent-tool-surface feature only.


### PR DESCRIPTION
Every spec lives on main. 034 is historical — superseded by the
implemented 036-research-retrieval-rag (see ROADMAP); 038 is an open
draft. Neither has plan/tasks yet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
