### PR TITLE
Cover thesis and risk data-quality regressions

### DIFF
--- a/backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs
+++ b/backend/tests/FinanceSentry.Mcp.Tests/IntegrationTests/ToolParityTests.cs
@@ -211,6 +211,7 @@ public sealed class ToolParityTests
         services.AddScoped<RunThesisMonitorTool>();
         services.AddScoped<ListThesisBreaksTool>();
         services.AddScoped<ListThesisEventsTool>();
+        services.AddScoped<SaveThesisTool>();
         services.AddScoped<GetThesisPerformanceTool>();
         services.AddScoped<GetTrackRecordTool>();
         services.AddScoped<GetPostmortemPacketTool>();
@@ -814,6 +815,31 @@ public sealed class ToolParityTests
     }
 
     [Fact]
+    public async Task SaveThesis_AcceptsLongNarrativeThesisText()
+    {
+        var userId = Guid.NewGuid();
+        await using var sp = BuildProvider(Guid.NewGuid().ToString("N"));
+        await using var scope = sp.CreateAsyncScope();
+        var svc = scope.ServiceProvider;
+        var thesisText = string.Join(
+            " ",
+            Enumerable.Repeat("Micron memory cycle recovery remains intact through pricing discipline.", 4));
+
+        var saveTool = svc.GetRequiredService<SaveThesisTool>();
+        var thesis = await saveTool.ExecuteAsync(
+            ticker: "MU",
+            thesisText: thesisText,
+            keyDataPoints: [],
+            catalysts: [],
+            invalidationTriggers: [],
+            userId: userId);
+
+        thesis.Should().NotBeNull();
+        thesis!.ThesisText.Should().Be(thesisText);
+        thesis.ThesisText.Length.Should().BeGreaterThan(200);
+    }
+
+    [Fact]
     public async Task GetThesisPerformance_ComputesExcessReturn_AgainstLiveQuote()
     {
         var userId = Guid.NewGuid();
@@ -1105,6 +1131,39 @@ public sealed class ToolParityTests
         verdict!.Decision.Should().Be(RiskDecision.Refused);
         verdict.RuleKey.Should().Be(RiskRuleKeys.MaxPositionWeight);
         verdict.MaxCompliantSizeUsd.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CheckRiskRules_Proposal_UsesCurrentValueBook_ForMinCashBuffer()
+    {
+        var userId = Guid.NewGuid();
+        await using var sp = BuildProvider(Guid.NewGuid().ToString("N"));
+        await using var scope = sp.CreateAsyncScope();
+        var svc = scope.ServiceProvider;
+
+        var bankDb = svc.GetRequiredService<BankSyncDbContext>();
+        var account = new BankAccount(userId, "ext-risk-cash", "Chase", "checking", "1234", "Test", "USD", userId);
+        account.BeginSync();
+        account.MarkActive(2_446m);
+        bankDb.BankAccounts.Add(account);
+
+        var cryptoHolding = CryptoHolding.Create(userId, "SOL", 10m, 0m, 12_054m);
+        cryptoHolding.SetCostBasis(100_000m, 10_000m, null, DateTime.UtcNow, 1, 1);
+        var cryptoDb = svc.GetRequiredService<CryptoSyncDbContext>();
+        cryptoDb.CryptoHoldings.Add(cryptoHolding);
+
+        await bankDb.SaveChangesAsync();
+        await cryptoDb.SaveChangesAsync();
+
+        var saveTool = svc.GetRequiredService<SaveRiskRulesTool>();
+        await saveTool.ExecuteAsync(minCashBufferPct: 0.10m, userId: userId);
+
+        var checkTool = svc.GetRequiredService<CheckRiskRulesTool>();
+        var verdict = await checkTool.ExecuteAsync(ticker: "MHPC", proposedUsd: 800m, userId: userId);
+
+        verdict.Should().NotBeNull();
+        verdict!.Decision.Should().Be(RiskDecision.Allowed);
+        verdict.RuleKey.Should().NotBe(RiskRuleKeys.MinCashBuffer);
     }
 
     // ── Opportunity scanner (019) parity ──────────────────────────────────────

--- a/backend/tests/FinanceSentry.Modules.Agent.Tests/McpToolBridgeTests.cs
+++ b/backend/tests/FinanceSentry.Modules.Agent.Tests/McpToolBridgeTests.cs
@@ -104,6 +104,18 @@ public sealed class McpToolBridgeTests
         }
     }
 
+    [Fact]
+    public void RealBridge_SaveThesis_AllowsNarrativeLengthThesisText()
+    {
+        var bridge = new McpToolBridge(Options.Create(new AgentOptions()), NullLogger<McpToolBridge>.Instance);
+
+        var saveThesis = bridge.GetTools().Single(t => t.Name == "save_thesis");
+        var properties = saveThesis.InputSchema.AsObject()["properties"]!.AsObject();
+        var thesisText = properties["thesisText"]!.AsObject();
+
+        thesisText.Should().NotContainKey("maxLength", "thesisText is persisted as varchar(4000), not a tool-call-sized label");
+    }
+
     private static ServiceProvider BuildScope(Guid callerId) =>
         new ServiceCollection()
             .AddScoped<IFakeIdentity>(_ => new FakeIdentity(callerId))


### PR DESCRIPTION
## Summary
- add MCP bridge coverage proving save_thesis does not cap thesisText like a short label
- add real save_thesis parity coverage for 200+ character thesis narratives
- add check_risk_rules parity coverage proving MinCashBuffer uses current-value book math despite phantom SOL cost basis

## Verification
- /home/node/.openclaw/tools/dotnet/dotnet test backend/tests/FinanceSentry.Modules.Agent.Tests/FinanceSentry.Modules.Agent.Tests.csproj --filter "McpToolBridgeTests"
- /home/node/.openclaw/tools/dotnet/dotnet test backend/tests/FinanceSentry.Mcp.Tests/FinanceSentry.Mcp.Tests.csproj --filter "SaveThesis_AcceptsLongNarrativeThesisText|CheckRiskRules_Proposal_UsesCurrentValueBook_ForMinCashBuffer"
- /home/node/.openclaw/tools/dotnet/dotnet restore backend/FinanceSentry.sln
- /home/node/.openclaw/tools/dotnet/dotnet build backend/FinanceSentry.sln --no-restore -c Release (passes with pre-existing NU1903 SSH.NET advisory)
- /home/node/.openclaw/tools/dotnet/dotnet test backend/FinanceSentry.sln --no-restore -c Release (passes with pre-existing NU1903 SSH.NET advisory)

Closes #443